### PR TITLE
feat: Add heartbeat notification.

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -11,6 +11,7 @@ import {
   DownloadUrlResponse,
   GetDownloadUrlPayload,
   GetUploadUrlPayload,
+  HeartbeatResponsePayload,
   RegisterResponse,
   RegisterOffboardingResponse,
   RegisterPushToken,
@@ -157,6 +158,12 @@ export const reportJobStatus = (payload: ReportJobStatusPayload & { k1?: string 
 export const submitInvoice = (payload: SubmitInvoicePayload & { k1?: string }) =>
   post<SubmitInvoicePayload & { k1?: string }, DefaultSuccessPayload>(
     "/lnurlp/submit_invoice",
+    payload,
+  );
+
+export const heartbeatResponse = (payload: HeartbeatResponsePayload & { k1?: string }) =>
+  post<HeartbeatResponsePayload & { k1?: string }, DefaultSuccessPayload>(
+    "/heartbeat_response",
     payload,
   );
 

--- a/client/src/types/serverTypes.ts
+++ b/client/src/types/serverTypes.ts
@@ -28,9 +28,11 @@ export type GetDownloadUrlPayload = { backup_version: number | null, };
 
 export type GetUploadUrlPayload = { backup_version: number, };
 
-export type NotificationTypes = "background_sync" | "maintenance" | "lightning_invoice_request" | "backup_trigger" | "offboarding";
+export type HeartbeatResponsePayload = { notification_id: string, };
 
-export type NotificationsData = { notification_type: NotificationTypes, k1: string | null, transaction_id: string | null, amount: number | null, offboarding_request_id: string | null, };
+export type NotificationTypes = "background_sync" | "maintenance" | "lightning_invoice_request" | "backup_trigger" | "offboarding" | "heartbeat";
+
+export type NotificationsData = { notification_type: NotificationTypes, k1: string | null, transaction_id: string | null, amount: number | null, offboarding_request_id: string | null, notification_id: string | null, };
 
 export type RegisterOffboardingResponse = { success: boolean, request_id: string, };
 

--- a/server/src/ark_client.rs
+++ b/server/src/ark_client.rs
@@ -138,6 +138,7 @@ pub async fn maintenance(app_state: AppState) -> anyhow::Result<()> {
         transaction_id: None,
         amount: None,
         offboarding_request_id: None,
+        notification_id: None,
     };
 
     if let Err(e) = send_push_notification_with_unique_k1(app_state, notification_data, None).await
@@ -174,6 +175,7 @@ pub async fn handle_offboarding_requests(app_state: AppState) -> anyhow::Result<
             transaction_id: None,
             amount: None,
             offboarding_request_id: Some(request.request_id.clone()),
+            notification_id: None,
         };
 
         if let Err(e) = send_push_notification_with_unique_k1(

--- a/server/src/constants.rs
+++ b/server/src/constants.rs
@@ -36,4 +36,6 @@ pub const DEFAULT_PRIVATE_PORT: &str = "3099";
 pub const DEFAULT_LNURL_DOMAIN: &str = "localhost";
 pub const DEFAULT_SERVER_NETWORK: &str = "regtest";
 pub const DEFAULT_BACKUP_CRON: &str = "every 2 hours";
-pub const DEFAULT_BACKGROUND_SYNC_CRON: &str = "every 2 hours";
+pub const DEFAULT_BACKGROUND_SYNC_CRON: &str = "every 48 hours";
+pub const DEFAULT_HEARTBEAT_CRON: &str = "every 48 hours";
+pub const DEFAULT_DEREGISTER_CRON: &str = "every 12 hours";

--- a/server/src/cron.rs
+++ b/server/src/cron.rs
@@ -143,6 +143,16 @@ pub async fn check_and_deregister_inactive_users(app_state: AppState) -> anyhow:
             continue;
         }
 
+        let heartbeat_repo = HeartbeatRepository::new(&tx);
+        if let Err(e) = heartbeat_repo.delete_by_pubkey(&pubkey).await {
+            tracing::error!(
+                "Failed to delete heartbeat notifications for {}: {}",
+                pubkey,
+                e
+            );
+            continue;
+        }
+
         if let Err(e) = tx.commit().await {
             tracing::error!(
                 "Failed to commit deregistration transaction for {}: {}",

--- a/server/src/cron.rs
+++ b/server/src/cron.rs
@@ -1,7 +1,10 @@
 use crate::{
     AppState,
     constants::{self, EnvVariables},
-    db::backup_repo::BackupRepository,
+    db::{
+        backup_repo::BackupRepository, heartbeat_repo::HeartbeatRepository,
+        offboarding_repo::OffboardingRepository, push_token_repo::PushTokenRepository,
+    },
     push::{send_push_notification, send_push_notification_with_unique_k1},
     types::{NotificationTypes, NotificationsData},
 };
@@ -17,6 +20,7 @@ async fn background_sync(app_state: AppState) {
             transaction_id: None,
             amount: None,
             offboarding_request_id: None,
+            notification_id: None,
         })
         .unwrap(),
         priority: "high".to_string(),
@@ -44,6 +48,7 @@ pub async fn send_backup_notifications(app_state: AppState) -> anyhow::Result<()
             transaction_id: None,
             amount: None,
             offboarding_request_id: None,
+            notification_id: None,
         };
         if let Err(e) = send_push_notification_with_unique_k1(
             app_state.clone(),
@@ -53,6 +58,91 @@ pub async fn send_backup_notifications(app_state: AppState) -> anyhow::Result<()
         .await
         {
             tracing::error!("Failed to send backup notification: {}", e);
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn send_heartbeat_notifications(app_state: AppState) -> anyhow::Result<()> {
+    let conn = app_state.db.connect()?;
+    let heartbeat_repo = HeartbeatRepository::new(&conn);
+
+    let active_users = heartbeat_repo.get_active_users().await?;
+    tracing::info!(
+        "Sending heartbeat notifications to {} active users",
+        active_users.len()
+    );
+
+    for pubkey in active_users {
+        let notification_id = heartbeat_repo.create_notification(&pubkey).await?;
+
+        let notification_data = NotificationsData {
+            notification_type: NotificationTypes::Heartbeat,
+            k1: None,
+            transaction_id: None,
+            amount: None,
+            offboarding_request_id: None,
+            notification_id: Some(notification_id),
+        };
+
+        if let Err(e) = send_push_notification_with_unique_k1(
+            app_state.clone(),
+            notification_data,
+            Some(pubkey.clone()),
+        )
+        .await
+        {
+            tracing::error!("Failed to send heartbeat notification to {}: {}", pubkey, e);
+        }
+    }
+
+    // Cleanup old notifications
+    heartbeat_repo.cleanup_old_notifications().await?;
+
+    Ok(())
+}
+
+pub async fn check_and_deregister_inactive_users(app_state: AppState) -> anyhow::Result<()> {
+    let conn = app_state.db.connect()?;
+    let heartbeat_repo = HeartbeatRepository::new(&conn);
+
+    let users_to_deregister = heartbeat_repo.get_users_to_deregister().await?;
+
+    if users_to_deregister.is_empty() {
+        return Ok(());
+    }
+
+    tracing::info!("Deregistering {} inactive users", users_to_deregister.len());
+
+    for pubkey in users_to_deregister {
+        tracing::info!("Deregistering inactive user: {}", pubkey);
+
+        // Use a transaction to ensure all or nothing is deleted
+        let tx = conn.transaction().await?;
+
+        if let Err(e) = PushTokenRepository::delete_by_pubkey(&tx, &pubkey).await {
+            tracing::error!("Failed to delete push token for {}: {}", pubkey, e);
+            continue;
+        }
+
+        if let Err(e) = OffboardingRepository::delete_by_pubkey(&tx, &pubkey).await {
+            tracing::error!(
+                "Failed to delete offboarding requests for {}: {}",
+                pubkey,
+                e
+            );
+            continue;
+        }
+
+        if let Err(e) = tx.commit().await {
+            tracing::error!(
+                "Failed to commit deregistration transaction for {}: {}",
+                pubkey,
+                e
+            );
+        } else {
+            tracing::info!("Successfully deregistered inactive user: {}", pubkey);
         }
     }
 
@@ -85,6 +175,30 @@ pub async fn cron_scheduler(app_state: AppState) -> anyhow::Result<JobScheduler>
         })
     })?;
     sched.add(backup_job).await?;
+
+    // Heartbeat notifications - every 48 hours
+    let heartbeat_app_state = app_state.clone();
+    let heartbeat_job = Job::new_async(constants::DEFAULT_HEARTBEAT_CRON, move |_, _| {
+        let app_state = heartbeat_app_state.clone();
+        Box::pin(async move {
+            if let Err(e) = send_heartbeat_notifications(app_state).await {
+                tracing::error!("Failed to send heartbeat notifications: {}", e);
+            }
+        })
+    })?;
+    sched.add(heartbeat_job).await?;
+
+    // Check for inactive users - every 12 hours
+    let inactive_check_app_state = app_state.clone();
+    let inactive_check_job = Job::new_async(constants::DEFAULT_DEREGISTER_CRON, move |_, _| {
+        let app_state = inactive_check_app_state.clone();
+        Box::pin(async move {
+            if let Err(e) = check_and_deregister_inactive_users(app_state).await {
+                tracing::error!("Failed to check and deregister inactive users: {}", e);
+            }
+        })
+    })?;
+    sched.add(inactive_check_job).await?;
 
     Ok(sched)
 }

--- a/server/src/db/heartbeat_repo.rs
+++ b/server/src/db/heartbeat_repo.rs
@@ -1,0 +1,127 @@
+use anyhow::Result;
+use uuid::Uuid;
+
+pub struct HeartbeatRepository<'a> {
+    conn: &'a libsql::Connection,
+}
+
+impl<'a> HeartbeatRepository<'a> {
+    pub fn new(conn: &'a libsql::Connection) -> Self {
+        Self { conn }
+    }
+
+    /// Creates a new heartbeat notification record
+    pub async fn create_notification(&self, pubkey: &str) -> Result<String> {
+        let notification_id = Uuid::new_v4().to_string();
+
+        self.conn
+            .execute(
+                "INSERT INTO heartbeat_notifications (pubkey, notification_id, status) VALUES (?, ?, 'pending')",
+                libsql::params![pubkey, notification_id.clone()],
+            )
+            .await?;
+
+        Ok(notification_id)
+    }
+
+    /// Marks a heartbeat notification as responded
+    pub async fn mark_as_responded(&self, notification_id: &str) -> Result<bool> {
+        let result = self.conn
+            .execute(
+                "UPDATE heartbeat_notifications SET responded_at = CURRENT_TIMESTAMP, status = 'responded' WHERE notification_id = ? AND status = 'pending'",
+                libsql::params![notification_id],
+            )
+            .await?;
+
+        Ok(result > 0)
+    }
+
+    /// Counts consecutive missed heartbeats for a user (most recent first)
+    pub async fn count_consecutive_missed(&self, pubkey: &str) -> Result<i32> {
+        let mut rows = self.conn
+            .query(
+                "SELECT status FROM heartbeat_notifications WHERE pubkey = ? ORDER BY sent_at DESC LIMIT 10",
+                libsql::params![pubkey],
+            )
+            .await?;
+
+        let mut consecutive_missed = 0;
+        while let Some(row) = rows.next().await? {
+            let status: String = row.get(0)?;
+            if status == "pending" {
+                consecutive_missed += 1;
+            } else {
+                break;
+            }
+        }
+
+        Ok(consecutive_missed)
+    }
+
+    /// Gets all users who have push tokens (active users)
+    pub async fn get_active_users(&self) -> Result<Vec<String>> {
+        let mut rows = self.conn
+            .query(
+                "SELECT DISTINCT pt.pubkey FROM push_tokens pt INNER JOIN users u ON pt.pubkey = u.pubkey",
+                (),
+            )
+            .await?;
+
+        let mut pubkeys = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let pubkey: String = row.get(0)?;
+            pubkeys.push(pubkey);
+        }
+
+        Ok(pubkeys)
+    }
+
+    /// Cleans up old heartbeat notifications (keeps only last 15 per user)
+    pub async fn cleanup_old_notifications(&self) -> Result<()> {
+        self.conn
+            .execute(
+                "DELETE FROM heartbeat_notifications WHERE id NOT IN (
+                    SELECT id FROM (
+                        SELECT id, ROW_NUMBER() OVER (PARTITION BY pubkey ORDER BY sent_at DESC) as rn
+                        FROM heartbeat_notifications
+                    ) ranked WHERE rn <= 15
+                )",
+                (),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// Gets users who have missed 10 or more consecutive heartbeats
+    pub async fn get_users_to_deregister(&self) -> Result<Vec<String>> {
+        let mut rows = self
+            .conn
+            .query(
+                "WITH recent_heartbeats AS (
+                    SELECT pubkey, status, sent_at,
+                           ROW_NUMBER() OVER (PARTITION BY pubkey ORDER BY sent_at DESC) as rn
+                    FROM heartbeat_notifications
+                ),
+                consecutive_missed AS (
+                    SELECT pubkey,
+                           COUNT(*) as missed_count
+                    FROM recent_heartbeats
+                    WHERE rn <= 10 AND status = 'pending'
+                    GROUP BY pubkey
+                    HAVING COUNT(*) = 10
+                )
+                SELECT pubkey FROM consecutive_missed",
+                (),
+            )
+            .await?;
+
+        let mut pubkeys = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let pubkey: String = row.get(0)?;
+            pubkeys.push(pubkey);
+        }
+
+        Ok(pubkeys)
+    }
+}

--- a/server/src/db/heartbeat_repo.rs
+++ b/server/src/db/heartbeat_repo.rs
@@ -47,6 +47,17 @@ impl<'a> HeartbeatRepository<'a> {
         Ok(())
     }
 
+    /// Deletes all heartbeat notifications for a user by pubkey
+    pub async fn delete_by_pubkey(&self, pubkey: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "DELETE FROM heartbeat_notifications WHERE pubkey = ?",
+                libsql::params![pubkey],
+            )
+            .await?;
+        Ok(())
+    }
+
     /// Counts consecutive missed heartbeats for a user (most recent first)
     #[cfg(test)]
     pub async fn count_consecutive_missed(&self, pubkey: &str) -> Result<i32> {

--- a/server/src/db/heartbeat_repo.rs
+++ b/server/src/db/heartbeat_repo.rs
@@ -36,7 +36,19 @@ impl<'a> HeartbeatRepository<'a> {
         Ok(result > 0)
     }
 
+    /// Deletes a heartbeat notification by its ID
+    pub async fn delete_notification(&self, notification_id: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "DELETE FROM heartbeat_notifications WHERE notification_id = ?",
+                libsql::params![notification_id],
+            )
+            .await?;
+        Ok(())
+    }
+
     /// Counts consecutive missed heartbeats for a user (most recent first)
+    #[cfg(test)]
     pub async fn count_consecutive_missed(&self, pubkey: &str) -> Result<i32> {
         let mut rows = self.conn
             .query(

--- a/server/src/db/migrations.rs
+++ b/server/src/db/migrations.rs
@@ -112,6 +112,21 @@ const MIGRATIONS: &[&str] = &[
         UPDATE devices SET updated_at = CURRENT_TIMESTAMP WHERE pubkey = OLD.pubkey;
     END;
     "#,
+    r#"
+    CREATE TABLE heartbeat_notifications (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        pubkey TEXT NOT NULL,
+        notification_id TEXT NOT NULL UNIQUE,
+        sent_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        responded_at TIMESTAMP,
+        status TEXT NOT NULL DEFAULT 'pending',
+        FOREIGN KEY (pubkey) REFERENCES users(pubkey)
+    );
+
+    CREATE INDEX idx_heartbeat_notifications_pubkey ON heartbeat_notifications(pubkey);
+    CREATE INDEX idx_heartbeat_notifications_status ON heartbeat_notifications(status);
+    CREATE INDEX idx_heartbeat_notifications_sent_at ON heartbeat_notifications(sent_at);
+    "#,
 ];
 
 /// Applies all pending migrations to the database.

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -1,5 +1,6 @@
 pub mod backup_repo;
 pub mod device_repo;
+pub mod heartbeat_repo;
 pub mod job_status_repo;
 pub mod migrations;
 pub mod offboarding_repo;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -26,8 +26,9 @@ use crate::{
         app_middleware,
         gated_api_v0::{
             complete_upload, delete_backup, deregister, get_download_url, get_upload_url,
-            get_user_info, list_backups, register_offboarding_request, register_push_token,
-            report_job_status, submit_invoice, update_backup_settings, update_ln_address,
+            get_user_info, heartbeat_response, list_backups, register_offboarding_request,
+            register_push_token, report_job_status, submit_invoice, update_backup_settings,
+            update_ln_address,
         },
         private_api_v0::health_check,
         public_api_v0::{get_k1, lnurlp_request, register},
@@ -266,6 +267,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         .route("/backup/delete", post(delete_backup))
         .route("/backup/settings", post(update_backup_settings))
         .route("/report_job_status", post(report_job_status))
+        .route("/heartbeat_response", post(heartbeat_response))
         .layer(user_exists_layer);
 
     // Routes that need auth but user may not exist (like registration)

--- a/server/src/routes/gated_api_v0.rs
+++ b/server/src/routes/gated_api_v0.rs
@@ -307,6 +307,9 @@ pub async fn deregister(
     PushTokenRepository::delete_by_pubkey(&tx, &pubkey).await?;
     OffboardingRepository::delete_by_pubkey(&tx, &pubkey).await?;
 
+    let heartbeat_repo = HeartbeatRepository::new(&tx);
+    heartbeat_repo.delete_by_pubkey(&pubkey).await?;
+
     tx.commit().await?;
 
     Ok(Json(DefaultSuccessPayload { success: true }))

--- a/server/src/routes/public_api_v0.rs
+++ b/server/src/routes/public_api_v0.rs
@@ -195,6 +195,7 @@ pub async fn lnurlp_request(
                 transaction_id: Some(transaction_id_clone),
                 amount: Some(amount),
                 offboarding_request_id: None,
+                notification_id: None,
             })
             .unwrap(),
             priority: "high".to_string(),

--- a/server/src/tests/gated_heartbeat_tests.rs
+++ b/server/src/tests/gated_heartbeat_tests.rs
@@ -1,0 +1,369 @@
+use axum::body::Body;
+use axum::http::{self, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use crate::db::heartbeat_repo::HeartbeatRepository;
+use crate::tests::common::{TestUser, create_test_user, setup_test_app};
+use crate::types::DefaultSuccessPayload;
+use crate::utils::make_k1;
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_heartbeat_response_success() {
+    let (app, app_state) = setup_test_app().await;
+
+    let user = TestUser::new();
+    create_test_user(&app_state, &user).await;
+
+    // Create a heartbeat notification first
+    let conn = app_state.db.connect().unwrap();
+    let heartbeat_repo = HeartbeatRepository::new(&conn);
+    let notification_id = heartbeat_repo
+        .create_notification(&user.pubkey().to_string())
+        .await
+        .unwrap();
+
+    let k1 = make_k1(app_state.k1_values.clone());
+    let auth_payload = user.auth_payload(&k1);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/heartbeat_response")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header("x-auth-key", auth_payload.key)
+                .header("x-auth-sig", auth_payload.sig)
+                .header("x-auth-k1", auth_payload.k1)
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "notification_id": notification_id
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let res: DefaultSuccessPayload = serde_json::from_slice(&body).unwrap();
+    assert_eq!(res.success, true);
+
+    // Verify the heartbeat was marked as responded in the database
+    let mut rows = conn
+        .query(
+            "SELECT status, responded_at FROM heartbeat_notifications WHERE notification_id = ?",
+            libsql::params![notification_id],
+        )
+        .await
+        .unwrap();
+
+    let row = rows.next().await.unwrap().unwrap();
+    let status: String = row.get(0).unwrap();
+    let responded_at: Option<String> = row.get(1).unwrap();
+
+    assert_eq!(status, "responded");
+    assert!(responded_at.is_some());
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_heartbeat_response_invalid_notification_id() {
+    let (app, app_state) = setup_test_app().await;
+
+    let user = TestUser::new();
+    create_test_user(&app_state, &user).await;
+
+    let k1 = make_k1(app_state.k1_values.clone());
+    let auth_payload = user.auth_payload(&k1);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/heartbeat_response")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header("x-auth-key", auth_payload.key)
+                .header("x-auth-sig", auth_payload.sig)
+                .header("x-auth-k1", auth_payload.k1)
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "notification_id": "non-existent-notification-id"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_heartbeat_response_already_responded() {
+    let (app, app_state) = setup_test_app().await;
+
+    let user = TestUser::new();
+    create_test_user(&app_state, &user).await;
+
+    // Create a heartbeat notification and mark it as already responded
+    let conn = app_state.db.connect().unwrap();
+    let heartbeat_repo = HeartbeatRepository::new(&conn);
+    let notification_id = heartbeat_repo
+        .create_notification(&user.pubkey().to_string())
+        .await
+        .unwrap();
+
+    // Mark it as responded first
+    heartbeat_repo
+        .mark_as_responded(&notification_id)
+        .await
+        .unwrap();
+
+    let k1 = make_k1(app_state.k1_values.clone());
+    let auth_payload = user.auth_payload(&k1);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/heartbeat_response")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header("x-auth-key", auth_payload.key)
+                .header("x-auth-sig", auth_payload.sig)
+                .header("x-auth-k1", auth_payload.k1)
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "notification_id": notification_id
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_heartbeat_response_unauthenticated() {
+    let (app, app_state) = setup_test_app().await;
+
+    let user = TestUser::new();
+    create_test_user(&app_state, &user).await;
+
+    // Create a heartbeat notification
+    let conn = app_state.db.connect().unwrap();
+    let heartbeat_repo = HeartbeatRepository::new(&conn);
+    let notification_id = heartbeat_repo
+        .create_notification(&user.pubkey().to_string())
+        .await
+        .unwrap();
+
+    let k1 = make_k1(app_state.k1_values.clone());
+    let mut auth_payload = user.auth_payload(&k1);
+    auth_payload.sig = "invalid_signature".to_string();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/heartbeat_response")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header("x-auth-key", auth_payload.key)
+                .header("x-auth-sig", auth_payload.sig)
+                .header("x-auth-k1", auth_payload.k1)
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "notification_id": notification_id
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_heartbeat_repo_create_notification() {
+    let (_, app_state) = setup_test_app().await;
+
+    let user = TestUser::new();
+    create_test_user(&app_state, &user).await;
+
+    let conn = app_state.db.connect().unwrap();
+    let heartbeat_repo = HeartbeatRepository::new(&conn);
+
+    let notification_id = heartbeat_repo
+        .create_notification(&user.pubkey().to_string())
+        .await
+        .unwrap();
+
+    assert!(!notification_id.is_empty());
+
+    // Verify the notification was created in the database
+    let mut rows = conn
+        .query(
+            "SELECT pubkey, status FROM heartbeat_notifications WHERE notification_id = ?",
+            libsql::params![notification_id],
+        )
+        .await
+        .unwrap();
+
+    let row = rows.next().await.unwrap().unwrap();
+    let pubkey: String = row.get(0).unwrap();
+    let status: String = row.get(1).unwrap();
+
+    assert_eq!(pubkey, user.pubkey().to_string());
+    assert_eq!(status, "pending");
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_heartbeat_repo_count_consecutive_missed() {
+    let (_, app_state) = setup_test_app().await;
+
+    let user = TestUser::new();
+    create_test_user(&app_state, &user).await;
+
+    let conn = app_state.db.connect().unwrap();
+    let heartbeat_repo = HeartbeatRepository::new(&conn);
+
+    // Create 5 old missed notifications (pending status)
+    for i in 0..5 {
+        conn.execute(
+            "INSERT INTO heartbeat_notifications (pubkey, notification_id, status, sent_at) VALUES (?, ?, 'pending', datetime('now', '-' || ? || ' seconds'))",
+            libsql::params![user.pubkey().to_string(), format!("old-{}", i), 100 + i],
+        )
+        .await
+        .unwrap();
+    }
+
+    // Create 1 responded notification (more recent than the old ones)
+    conn.execute(
+        "INSERT INTO heartbeat_notifications (pubkey, notification_id, status, sent_at, responded_at) VALUES (?, 'responded', 'responded', datetime('now', '-50 seconds'), datetime('now', '-49 seconds'))",
+        libsql::params![user.pubkey().to_string()],
+    )
+    .await
+    .unwrap();
+
+    // Create 3 most recent missed notifications
+    for i in 0..3 {
+        conn.execute(
+            "INSERT INTO heartbeat_notifications (pubkey, notification_id, status, sent_at) VALUES (?, ?, 'pending', datetime('now', '-' || ? || ' seconds'))",
+            libsql::params![user.pubkey().to_string(), format!("recent-{}", i), 10 + i],
+        )
+        .await
+        .unwrap();
+    }
+
+    // Should count only the 3 most recent missed notifications
+    let consecutive_missed = heartbeat_repo
+        .count_consecutive_missed(&user.pubkey().to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(consecutive_missed, 3);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_heartbeat_repo_get_users_to_deregister() {
+    let (_, app_state) = setup_test_app().await;
+
+    // Create users with different secret keys
+    let user1 = TestUser::new_with_key(&[0xcd; 32]);
+    let user2 = TestUser::new_with_key(&[0xab; 32]);
+
+    // Create users with unique lightning addresses
+    let conn = app_state.db.connect().unwrap();
+    conn.execute(
+        "INSERT INTO users (pubkey, lightning_address) VALUES (?, ?)",
+        libsql::params![user1.pubkey().to_string(), "user1@localhost"],
+    )
+    .await
+    .unwrap();
+
+    conn.execute(
+        "INSERT INTO users (pubkey, lightning_address) VALUES (?, ?)",
+        libsql::params![user2.pubkey().to_string(), "user2@localhost"],
+    )
+    .await
+    .unwrap();
+
+    let heartbeat_repo = HeartbeatRepository::new(&conn);
+
+    // User1: Create 10 missed notifications (should be deregistered)
+    for _ in 0..10 {
+        heartbeat_repo
+            .create_notification(&user1.pubkey().to_string())
+            .await
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+
+    // User2: Create 5 missed notifications (should NOT be deregistered)
+    for _ in 0..5 {
+        heartbeat_repo
+            .create_notification(&user2.pubkey().to_string())
+            .await
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+
+    let users_to_deregister = heartbeat_repo.get_users_to_deregister().await.unwrap();
+
+    assert_eq!(users_to_deregister.len(), 1);
+    assert_eq!(users_to_deregister[0], user1.pubkey().to_string());
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_heartbeat_repo_cleanup_old_notifications() {
+    let (_, app_state) = setup_test_app().await;
+
+    let user = TestUser::new();
+    create_test_user(&app_state, &user).await;
+
+    let conn = app_state.db.connect().unwrap();
+    let heartbeat_repo = HeartbeatRepository::new(&conn);
+
+    // Create 20 notifications (more than the 15 limit)
+    for _ in 0..20 {
+        heartbeat_repo
+            .create_notification(&user.pubkey().to_string())
+            .await
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+
+    // Cleanup old notifications
+    heartbeat_repo.cleanup_old_notifications().await.unwrap();
+
+    // Verify only 15 notifications remain
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM heartbeat_notifications WHERE pubkey = ?",
+            libsql::params![user.pubkey().to_string()],
+        )
+        .await
+        .unwrap();
+
+    let row = rows.next().await.unwrap().unwrap();
+    let count: i32 = row.get(0).unwrap();
+
+    assert_eq!(count, 15);
+}

--- a/server/src/tests/mod.rs
+++ b/server/src/tests/mod.rs
@@ -2,5 +2,6 @@ pub mod common;
 pub mod gated_auth_tests;
 pub mod gated_backup_tests;
 pub mod gated_error_tests;
+pub mod gated_heartbeat_tests;
 pub mod gated_user_tests;
 pub mod public_api_v0;

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -172,6 +172,7 @@ pub enum NotificationTypes {
     LightningInvoiceRequest,
     BackupTrigger,
     Offboarding,
+    Heartbeat,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]
@@ -183,6 +184,13 @@ pub struct NotificationsData {
     #[ts(type = "number | null")]
     pub amount: Option<u64>,
     pub offboarding_request_id: Option<String>,
+    pub notification_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Validate, TS)]
+#[ts(export, export_to = "../../client/src/types/serverTypes.ts")]
+pub struct HeartbeatResponsePayload {
+    pub notification_id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]


### PR DESCRIPTION
feat: Add heartbeat notification. Right now we do not know if a user has stopped using our app and we will indefinitely send them notifications.
A new heartbeat endpoint has been added where we send a push to a user
every 2 days and if they fail to respond back 10 consecutive times, we
stop serving them.