### PR TITLE
Add APK signing to Android CI workflow

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         run: |
           nix develop .# --command bash -c "\$ANDROID_HOME/build-tools/35.0.0/apksigner sign --ks keystore.jks \
             --ks-pass pass:\$KEYSTORE_PASSWORD \


### PR DESCRIPTION
Add steps to decode, sign, and clean up Android release keystore during CI build

Temp: use nitesh key, Hampus will swap the key later coz he's eepy due to personal reasons.