### PR TITLE
Fix Bun hoisting behavior on Windows for NitroArk in download script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "android:clean": "bun client android:clean",
     "ios:clean": "bun client ios:clean",
     "postinstall": "bun scripts/download_ark_binaries.js",
+    "prepare": "husky",
     "check": "bun client check"
   },
   "patchedDependencies": {


### PR DESCRIPTION
Bun's node_modules hoisting on Windows is weird.
For some reason the download script cannot find NitroArk when it's in `<root>\node_modules\.bin\react-native-nitro-ark@<ver>`.

This PR changes it the download script so that it tries to go through a symlink that Bun on windows creates in `<root>\client\node_modules\react-native-nitro-ark` -> `<root>\node_modules\.bin\react-native-nitro-ark@<ver>`.