### PR TITLE
Allow duplicate emails when verifying users

### DIFF
--- a/server/migrations/0007_drop_email_unique_index.sql
+++ b/server/migrations/0007_drop_email_unique_index.sql
@@ -1,0 +1,7 @@
+-- Allow multiple users to share the same email address.
+--
+-- Pubkey is the canonical user identity in Noah; email is optional metadata
+-- used for verification and (future) notifications.
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_email_key;
+DROP INDEX IF EXISTS idx_users_email_unique;
+


### PR DESCRIPTION
Summary
- drop the unique constraint on `users.email` so multiple wallets can reuse the same address
- simplify email verification/email update flow by removing uniqueness checks and errors
- adjust verification tests to cover the new behavior and assert success for duplicate emails

Testing
- Not run (not requested)