### PR TITLE
Update AGENTS docs and add agent start guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,11 +74,11 @@ It is intentionally operational: where code lives, how the runtime behaves, and 
 - Install deps: `just install` (or `bun install`).
 - Enter Nix shell (recommended): `direnv allow` or `nix develop`.
 
-### Client run commands
+### Mobile app execution policy for autonomous agents
 
-- Android regtest debug: `just android` or `just android-regtest`.
-- iOS regtest debug: `just ios` or `just ios-regtest`.
-- Signet/Mainnet variants: use `just android-signet`, `just ios-signet`, `just android-mainnet`, `just ios-mainnet`.
+- Do not start Android/iOS apps locally as part of autonomous workflow.
+- Do not run simulator/emulator commands like `just android`, `just ios`, or variant-specific equivalents.
+- Rely on GitHub Actions client pipelines for platform builds (Android and iOS).
 
 ### Server run commands
 
@@ -112,6 +112,9 @@ It is intentionally operational: where code lives, how the runtime behaves, and 
 - Husky pre-commit runs:
   - `bun client check`
   - `cargo fmt --check`
+- After opening a PR, monitor CI status checks:
+  - `gh pr checks --watch`
+  - or `gh pr view --json statusCheckRollup`
 
 ## Client architecture details
 

--- a/start.md
+++ b/start.md
@@ -16,16 +16,15 @@ Use this file as the first-step runbook for autonomous work in this repository.
 2. Optional Nix shell (recommended):
    - `nix develop`
 
-## 3) Pick the correct runtime path
+## 3) Pick the correct validation path
 
 - Client task:
-  - Start app: `just android` or `just ios`
-  - Validate: `just check`
+  - Do not start Android/iOS simulators or emulators locally.
+  - Validate with static checks: `just check`
 - Server task:
-  - Start backend: `just server`
-  - Validate: `cargo test` and `cargo fmt --check`
-- Full regtest/integration task:
-  - `just setup-everything`
+  - Validate with local checks: `cargo fmt --check` and `cargo test`
+- Integration/regtest task:
+  - Only run `just setup-everything` if explicitly requested by the user.
 
 ## 4) Safe implementation protocol
 
@@ -62,6 +61,8 @@ If server payload types changed, verify generated TS contract changes in:
    - why
    - validation commands run
    - any risks/follow-ups
+4. After opening PR, monitor status checks:
+   - `gh pr checks --watch`
 
 ## 7) Stop conditions
 


### PR DESCRIPTION
## Summary
- replace outdated AGENTS.md with a code-backed autonomous agent guide
- add start.md with a first-run operational checklist for agents
- document current client/server architecture, runtime flows, commands, testing, and safety constraints

## Validation
- bun --cwd client check (triggered by pre-commit hook)

## Notes
- No production code changes; documentation-only update.