### PR TITLE
Fix required status checks for path-filtered CI

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -2,13 +2,6 @@ name: CI
 
 on:
   pull_request:
-    paths:
-      - "client/**"
-      - "scripts/**"
-      - "package.json"
-      - "bun.lock"
-      - "!**/*.md"
-      - "!**/.github/workflows/*"
   workflow_call:
     inputs:
       build_aab:
@@ -31,8 +24,44 @@ on:
         value: ${{ jobs.android_build.outputs.run_id }}
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      client_changed: ${{ steps.set_changed.outputs.client_changed }}
+    steps:
+      - name: 🏗 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🔎 Detect client-related changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            client:
+              - 'client/**'
+              - 'scripts/**'
+              - 'package.json'
+              - 'bun.lock'
+              - '.github/workflows/client.yml'
+
+      - name: 🧭 Set client change output
+        id: set_changed
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FILTER_CLIENT: ${{ steps.filter.outputs.client }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            echo "client_changed=${FILTER_CLIENT}" >> "$GITHUB_OUTPUT"
+          else
+            # For workflow_call, always run client checks/build.
+            echo "client_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     runs-on: self-hosted
+    needs: changes
+    if: needs.changes.outputs.client_changed == 'true'
     steps:
       - name: 🏗 Checkout code
         uses: actions/checkout@v4
@@ -48,7 +77,8 @@ jobs:
 
   android_build:
     runs-on: self-hosted
-    needs: lint
+    needs: [changes, lint]
+    if: needs.changes.outputs.client_changed == 'true'
     outputs:
       artifact_name: ${{ steps.rename_apk.outputs.artifact_name }}
       apk_filename: ${{ steps.rename_apk.outputs.apk_filename }}
@@ -148,14 +178,24 @@ jobs:
 
   client_gate:
     runs-on: ubuntu-latest
-    needs: [lint, android_build]
+    needs: [changes, lint, android_build]
     if: always()
     steps:
       - name: ✅ Gate
         run: |
-          if [[ "${{ needs.lint.result }}" == "success" || "${{ needs.lint.result }}" == "skipped" ]] && \
-             [[ "${{ needs.android_build.result }}" == "success" || "${{ needs.android_build.result }}" == "skipped" ]]; then
-            echo "Client checks passed or skipped"
+          if [[ "${{ needs.changes.result }}" != "success" ]]; then
+            echo "Client change detection failed"
+            exit 1
+          fi
+
+          if [[ "${{ needs.changes.outputs.client_changed }}" != "true" ]]; then
+            echo "No client-related changes; client checks not required"
+            exit 0
+          fi
+
+          if [[ "${{ needs.lint.result }}" == "success" ]] && \
+             [[ "${{ needs.android_build.result }}" == "success" ]]; then
+            echo "Client checks passed"
             exit 0
           else
             echo "Client checks failed"

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -2,14 +2,6 @@ name: Server CI
 
 on:
   pull_request:
-    paths:
-      - "server/**"
-      - "scripts/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "!**/*.md"
-      - "!**/.github/workflows/*"
-
   push:
     branches:
       - master
@@ -21,7 +13,41 @@ on:
       - "!**/*.md"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      server_changed: ${{ steps.set_changed.outputs.server_changed }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 🔎 Detect server-related changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            server:
+              - 'server/**'
+              - 'scripts/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/server.yml'
+
+      - name: 🧭 Set server change output
+        id: set_changed
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FILTER_SERVER: ${{ steps.filter.outputs.server }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            echo "server_changed=${FILTER_SERVER}" >> "$GITHUB_OUTPUT"
+          else
+            echo "server_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   server_build_and_test:
+    needs: changes
+    if: needs.changes.outputs.server_changed == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -61,13 +87,23 @@ jobs:
 
   server_gate:
     runs-on: ubuntu-latest
-    needs: server_build_and_test
+    needs: [changes, server_build_and_test]
     if: always()
     steps:
       - name: ✅ Gate
         run: |
-          if [[ "${{ needs.server_build_and_test.result }}" == "success" || "${{ needs.server_build_and_test.result }}" == "skipped" ]]; then
-            echo "Server checks passed or skipped"
+          if [[ "${{ needs.changes.result }}" != "success" ]]; then
+            echo "Server change detection failed"
+            exit 1
+          fi
+
+          if [[ "${{ needs.changes.outputs.server_changed }}" != "true" ]]; then
+            echo "No server-related changes; server checks not required"
+            exit 0
+          fi
+
+          if [[ "${{ needs.server_build_and_test.result }}" == "success" ]]; then
+            echo "Server checks passed"
             exit 0
           else
             echo "Server checks failed"


### PR DESCRIPTION
## Summary
- remove `pull_request.paths` filters from client/server workflows so required checks always start
- add lightweight `changes` jobs using `dorny/paths-filter` to detect client/server-relevant diffs
- run heavy jobs only when relevant files changed
- keep `client_gate` and `server_gate` as stable required checks that pass when area is untouched

## Why
Required checks can stay pending forever when a workflow is skipped at trigger-level by path filters. This moves filtering to the job level so branch protection works consistently.

## Branch protection
Set required checks to:
- `client_gate`
- `server_gate`
