### PR TITLE
Trigger iOS/Android/server CI on workflow-file changes

### DIFF
--- a/.github/workflows/client-telegram.yml
+++ b/.github/workflows/client-telegram.yml
@@ -9,8 +9,8 @@ on:
       - "scripts/**"
       - "package.json"
       - "bun.lock"
+      - ".github/workflows/**"
       - "!**/*.md"
-      - "!**/.github/workflows/*"
 
 jobs:
   build:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -43,7 +43,7 @@ jobs:
               - 'scripts/**'
               - 'package.json'
               - 'bun.lock'
-              - '.github/workflows/client.yml'
+              - '.github/workflows/**'
 
       - name: 🧭 Set client change output
         id: set_changed

--- a/.github/workflows/ios-telegram.yml
+++ b/.github/workflows/ios-telegram.yml
@@ -9,8 +9,8 @@ on:
       - "scripts/**"
       - "package.json"
       - "bun.lock"
+      - ".github/workflows/**"
       - "!**/*.md"
-      - "!**/.github/workflows/*"
 
 jobs:
   build:

--- a/.github/workflows/noah-maestro-test-ios.yml
+++ b/.github/workflows/noah-maestro-test-ios.yml
@@ -7,8 +7,8 @@ on:
       - "scripts/**"
       - "package.json"
       - "bun.lock"
+      - ".github/workflows/**"
       - "!**/*.md"
-      - "!**/.github/workflows/*"
 
 jobs:
   build-release-ios:

--- a/.github/workflows/server-push.yml
+++ b/.github/workflows/server-push.yml
@@ -9,8 +9,8 @@ on:
       - "fly/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - ".github/workflows/**"
       - "!**/*.md"
-      - "!**/.github/workflows/*"
 
 jobs:
   server-build-and-push:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -10,6 +10,7 @@ on:
       - "scripts/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - ".github/workflows/**"
       - "!**/*.md"
 
 jobs:
@@ -31,7 +32,7 @@ jobs:
               - 'scripts/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
-              - '.github/workflows/server.yml'
+              - '.github/workflows/**'
 
       - name: 🧭 Set server change output
         id: set_changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,9 @@ It is intentionally operational: where code lives, how the runtime behaves, and 
 - After opening a PR, monitor CI status checks:
   - `gh pr checks --watch`
   - or `gh pr view --json statusCheckRollup`
+- After PR is merged, sync local `master` before continuing work:
+  - `git checkout master`
+  - `git pull --ff-only origin master`
 
 ## Client architecture details
 

--- a/start.md
+++ b/start.md
@@ -63,6 +63,9 @@ If server payload types changed, verify generated TS contract changes in:
    - any risks/follow-ups
 4. After opening PR, monitor status checks:
    - `gh pr checks --watch`
+5. Once checks pass and PR is merged, sync local `master` immediately:
+   - `git checkout master`
+   - `git pull --ff-only origin master`
 
 ## 7) Stop conditions
 


### PR DESCRIPTION
## Summary
- trigger iOS PR CI when `.github/workflows/**` files change
- trigger Android and server push workflows on `master` when workflow files change
- update client/server PR change detection to treat workflow-file edits as relevant changes
- document agent post-merge requirement to sync local `master` in `AGENTS.md` and `start.md`

## Why
Workflow-only PRs and merges can silently skip CI with path filters, which makes it hard to validate workflow updates. This ensures CI runs when workflows themselves are modified.

## Files changed
- `.github/workflows/client.yml`
- `.github/workflows/server.yml`
- `.github/workflows/noah-maestro-test-ios.yml`
- `.github/workflows/client-telegram.yml`
- `.github/workflows/ios-telegram.yml`
- `.github/workflows/server-push.yml`
- `AGENTS.md`
- `start.md`

## Validation
- Parsed all workflow YAML files successfully.
- Pre-commit hook passed: `bun --cwd client check`.
