### PR TITLE
Fix lightning receive lag on the receive screen

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "react-native-gesture-handler": "~2.30.0",
         "react-native-keychain": "^10.0.0",
         "react-native-mmkv": "^4.1.2",
-        "react-native-nitro-ark": "^0.0.97",
+        "react-native-nitro-ark": "^0.0.99",
         "react-native-nitro-modules": "0.33.7",
         "react-native-qrcode-svg": "^6.3.21",
         "react-native-quick-base64": "^2.2.2",
@@ -1679,7 +1679,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@4.1.2", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-6LHb2DQBXuo96Aues13EugmlWw/HAYuh3KoJoQNrC4JsBwn3J3KiRYAg2mCm5Je0VYq2YsmbgZG7XJwX/WFYZA=="],
 
-    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.97", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.33.7" } }, "sha512-9HBuKG17fT9RmejEOX179bjlvg2r3PIlU7puOXcZW3engNSEBfsOEb217l0IjjV1R1EZbRW3YYrO/7ECdYgvqQ=="],
+    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.99", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.33.7" } }, "sha512-HkT9fKmkC53DNPEuT1imYQPlTlWPOdkhwphR5WWc8+oFMlgxqlwnJjYpOxWnWe9vlkMws5IKpCfmhMNhX9npog=="],
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.33.7", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-WepMobWe4j1Ae5GQ5RxYGBdBpJBwzP6zaOxJ7r6nhbY5iyl01DL3Gsh4gk8edzNFRuAh1rvXDAHIipq8SahxeQ=="],
 

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -247,7 +247,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.14.1)
   - hermes-engine/Pre-built (0.14.1)
   - MMKVCore (2.2.4)
-  - NitroArk (0.0.97):
+  - NitroArk (0.0.99):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -3109,133 +3109,133 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EXApplication: 44f202420678bba77f603c373bd3fd033e6c21e9
-  EXConstants: b3c63be5f8648e4ab8e6ff5099b62f629247f969
+  EXApplication: 838dd0a6dc467b7a4267cdf5c997d9ee91a562a7
+  EXConstants: a16ad8db13865e97aaecf64bb92e8ad8e8ce1ae8
   EXJSONUtils: 0080c14b673cfa9a6be5e3fe429768ffe3d42dfb
-  EXManifests: 2b53302deb6d7275ae26005b8014f5a1aee42a0e
-  Expo: ed1258b36d29c6b5021951ab7933754e765587cb
-  expo-dev-client: d8a4157de0889a8b429788323520a9873973ddb3
-  expo-dev-launcher: 681b320210301de9be0d625f3c399841570e1d3c
-  expo-dev-menu: 6eb76803513cd6c6231d680d331861de816fb1db
+  EXManifests: 22ec6b0abf4e9b54ea22624aa955cf68d6c90590
+  Expo: 2332b1dbde7e998db81028b9e342853745f59e0e
+  expo-dev-client: b2e44ea014f85225c42cd5831cc71f0cf2596e0b
+  expo-dev-launcher: b9d91b173e8a2acdbbce5085963682fc3d6ca49c
+  expo-dev-menu: d1a363588c35dad9c27b257794a3f255800b8677
   expo-dev-menu-interface: bf6f816d29b45bec038080790963c635e8d588c2
-  ExpoAsset: bdc7bc21fe25d197c3aa7547e14c12c42087d9c9
-  ExpoClipboard: 6bb321d2991652e6736d400f1d7c073aa02c41a0
-  ExpoDevice: 8fb20656b96e38f8928cd069210a1aad0c759ac3
-  ExpoDomWebView: f101fb3db4b6eec4163fca51f7507189b7e48661
-  ExpoFileSystem: e1a42d7f69f7faae33f4d7d01708f7861f7bd757
-  ExpoFont: 1aa465cf9f8ac6b670405becba8b15473581b2dd
-  ExpoHaptics: 8952528daeafbb20d147c33f8cc6ab648cd34c58
-  ExpoImagePicker: afea73184bf1cd0c1c42f09b74513d31e4004453
-  ExpoKeepAwake: 7f3b28c361c37389b18841bb52a58003b39fcb33
-  ExpoLocalAuthentication: cc44c1a568250326491ec92886c6ef588f569251
-  ExpoLogBox: 89b634d5a8a64c4a6a7caad8f9985a28463c7002
-  ExpoModulesCore: a57a0a1e39caa9ad5f76c8477b831ee32fbeddfc
-  ExpoModulesJSI: a554588f3260ee3c44a3e7f4a8151c2b9ffdb024
-  ExpoNotifications: 35c1549deb8fb2cba86e6fda778d46d08c11ea25
-  ExpoSQLite: 77506d3d056c57118280d1e2a2d76cc06e4926b3
-  ExpoSystemUI: ae936ff8f78ca3d6c13884704beb7705fe26d136
-  ExpoTaskManager: 6038b80fbe63915383dcf57fa0156b23e2615fab
-  EXUpdatesInterface: d48f288b92900bd95a27c6cf92a7b9aff826d49a
+  ExpoAsset: 4fc5f72f8a74135c522fa61df0bfb869e5b3c3e6
+  ExpoClipboard: ea1c19f29543c3f84abcbc500c6f1a62d954fd5c
+  ExpoDevice: a39e12fa0c62816a81d3c1c2c8d7da0cc951069c
+  ExpoDomWebView: d4f2ed3c3fa31d0ce89e79501a0c041c2f233189
+  ExpoFileSystem: 0d267067930a744555ff6ab842fd79d3eeb2c33b
+  ExpoFont: 4d2a6dedce012c4793532cb38d561d3da95eaafd
+  ExpoHaptics: 8bce973169ae09427d0a10886d222601ada8c128
+  ExpoImagePicker: 9005f90c3a2959b77655093488ab56650f69f93a
+  ExpoKeepAwake: 55711a70fe88a41e793bbe28543c93cb47ff265d
+  ExpoLocalAuthentication: ccc92a75fd11b83b1e321074a803ba7dd90bead1
+  ExpoLogBox: 35febda08748ff213ea133f51acf976ba8c44b2c
+  ExpoModulesCore: 9f7715884df4159d9a8862dc322c5d834aebe921
+  ExpoModulesJSI: bd2650f43a2c0d3fb753f33b70fa0972602f51d5
+  ExpoNotifications: f38ce09b263075e560f3e5d99c31523d892ba7fe
+  ExpoSQLite: c01882b3ce0d20ad2351213dbd081a6e0e1f8837
+  ExpoSystemUI: c4c5b9ba9a5a4713c70f3d68c3bcf3221f2198f2
+  ExpoTaskManager: 1a197d3c489d5ed7ae824f7d6b98404e3a662ff2
+  EXUpdatesInterface: 26412751a0f7a7130614655929e316f684552aab
   FBLazyVector: 32e9ed0301d0fcbc1b2b341dd7fcbf291f51eb83
-  hermes-engine: d94c2de3afca348d2c52b31010a9ab2042b26ff2
+  hermes-engine: 9288d96d73c49b8a0e1a8af173848fff3c6852e6
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
-  NitroArk: eb9abfbead3b461ee8d963ed54125a7bae3d0ac4
-  NitroMmkv: c9fd61d98afd00a6e4e1656a415c28f7be0fd74e
-  NitroModules: a5ca899bb0c1326c937f11de6b050a467c5a12de
-  NoahTools: 75801cbc713b18283ac0754049e47c64bf0bdc1d
+  NitroArk: fb1afd98e3c942ce4c9fedf3665f974cdab04fbb
+  NitroMmkv: 8a41b343ffcd651bfb1ec9d50a8c15f488b37aae
+  NitroModules: 241bcd942565edae90e699f1d2a610adc79ffb6f
+  NoahTools: efea1336628719c3ab4a565f3c03d2deeadd3d14
   RCTDeprecation: a522c536d2c7be8f518dd834883cf6dce1d4f545
   RCTRequired: 44337def23abb244c025e9e7ab58f9cd3d63ec7d
   RCTSwiftUI: b2f0c2f2761631b8cd605767536cbb1cbf8d020f
-  RCTSwiftUIWrapper: 02581172ec5db9b67bce917579130c0f1b564b6f
+  RCTSwiftUIWrapper: 82b4944db8c3e99e68ff1122e5d39d6c0f4e54de
   RCTTypeSafety: 8e2d7c3de09142686e773aabf98733ac733ae36b
   React: f4edc7518ccb0b54a6f580d89dd91471844b4990
   React-callinvoker: 79ef4e3f1c021571f6d2dafbe45ca432b2f3a146
-  React-Core: c19ad4660fd48bc8abc060d979f8ee37f1fc4a5a
-  React-Core-prebuilt: aee9af9ca32817fac4d82a667d92d40a5eb7ec23
-  React-CoreModules: f94ec3ee2bac588d033ad15a2377af746284f8c8
-  React-cxxreact: de66364f2d5fb77d3da3cfa927b2fd960892c711
+  React-Core: 469995a2b6ef0ffff38ed123ccd202287703939e
+  React-Core-prebuilt: ad2037ced03638feb44b8619c9591d85bd9691f6
+  React-CoreModules: db3b65cb984dfc7e0b00db517712cff8d938fc3f
+  React-cxxreact: 8551bebcc6bc624ce774dccae20c383844aa9d06
   React-debug: 4f6739c820d7da9c20f48caa985573b6a847e5f5
-  React-defaultsnativemodule: 331ff498331cf9bd93f6add195c6864873bd3c82
-  React-domnativemodule: 8860ef957adc0f0637bbb7d51f76b3ab368720a0
-  React-Fabric: 052e38e1dc92bd60815e5f07b05abb2ab2d52ee0
-  React-FabricComponents: 48aa1d267c9d704fdea41094450c144a867f31cb
-  React-FabricImage: e3e6a5d1ac5edf1c33b06fffa5573f1748169374
-  React-featureflags: 4db447994c36121c013d670d4eb1c6b4d739b1a5
-  React-featureflagsnativemodule: 866a38b3e49c54452ac34176bf614835b846af3a
-  React-graphics: deb070e5745d7913aad56c7d9d790ed6046f2344
-  React-hermes: 10ce149307c1825aa4dde7981afb9fdfbd88c21d
-  React-idlecallbacksnativemodule: 4cc78f47dd6488b71138313fb62d15b06974addf
-  React-ImageManager: 703963a49915a0893631dc9fe10ca707d6a6b8b0
-  React-intersectionobservernativemodule: 2788446004e3a779deb0ff78c812d0ffef481725
-  React-jserrorhandler: 23046be59c7678567db719d4890e67cc9a7cd05b
-  React-jsi: 2b0fce5e788c3cbfddf10bfc70084aca2a82bd79
-  React-jsiexecutor: 2810824cd65560e47d751560836ef1c5a5e45e4b
-  React-jsinspector: b2c3e00c0e122a33d3a90ec9f8e530e1e0f51848
-  React-jsinspectorcdp: 29e34bcca5b2ed2e43b64eb5d1e848ea5b171b1f
-  React-jsinspectornetwork: 2ad8784d751c1e983282975f6da1c75d45c41527
-  React-jsinspectortracing: 585195329c9fac9b777cb71badaa6d53b986a414
-  React-jsitooling: f605384b63ccf2816c90885c57e14c1d07161118
-  React-jsitracing: 491e85cd6a47d5d6494bf670136f96a730e8de4a
-  React-logger: 69811317123fe08dc34ed5837dc1d269c468cc8d
-  React-Mapbuffer: 8f8cbeb5bedb521cce0897a71274e3a72b5236a1
-  React-microtasksnativemodule: bef4a47c7efd42421de52201e6d76a73cf6c816e
-  react-native-bottom-tabs: bcb70e4fae95fc9da0da875f7414acda26dfc551
-  react-native-quick-base64: 6568199bb2ac8e72ecdfdc73a230fbc5c1d3aac4
-  react-native-safe-area-context: 37e680fc4cace3c0030ee46e8987d24f5d3bdab2
-  react-native-slider: 8b9a218d1a3e526146a170cb6133be9cda23e70e
-  react-native-vector-icons: 8215b0e62bf79d3be628cf658ec23777f9bec53c
+  React-defaultsnativemodule: 43e75f4d675332132e6a5c82476c23518f8ce493
+  React-domnativemodule: 58a89a184f31f64b465b1ab67a4dfd5f43e29257
+  React-Fabric: 9473ecf5fc7003ffcc4703b5d1c0a50c2d45c2cf
+  React-FabricComponents: c05596a1c540824a9b1267820b1bf0a4e770c3d9
+  React-FabricImage: b4b4a67a7bc779c6e56b465e03807db92e7404c2
+  React-featureflags: 3cdba2c6183501105c6ff7f1f036e5320a9e3a4a
+  React-featureflagsnativemodule: 9633fd79ba0d59e7aaedb5934ded4cf2547f4f91
+  React-graphics: d291cb7b78be5030d22aec3e4b213d24168b58fb
+  React-hermes: 47a87f485a75346352aebe04f87185fbfde1eff3
+  React-idlecallbacksnativemodule: 6c8ed5733c1cb8b728f6da2a3df2a28c477d45a5
+  React-ImageManager: a6058734c28ab7d31436b8960fdde048e678510b
+  React-intersectionobservernativemodule: 2b2ebf2dd99f428ff83f174f533edf5b8a9cd9a6
+  React-jserrorhandler: 8c2b9301bae169a7dc24506af26c819ab0a22da6
+  React-jsi: 99fe9c6178e49c32bc43813f0cc0b3e1843ef09e
+  React-jsiexecutor: eb2154f6b0f6e25d5e4783d61f524b182105cd18
+  React-jsinspector: ad9cd4bef601f67f0fad2e491af6f7757f283187
+  React-jsinspectorcdp: 9b839d621199d318252bba32ee0c752d47a08d41
+  React-jsinspectornetwork: a57565df6fe761e08b0e2f298ff229c6579b8413
+  React-jsinspectortracing: 4c010e1e5ef174624b17bdbf3fc3a61f4fcdc363
+  React-jsitooling: 6c6ae31b25ca1957dd43d5c1517b958f9a694cb7
+  React-jsitracing: b913589e2066dea7e6b340222ad669f857354181
+  React-logger: 492d6067ffeb8f5dab6493de30035f22cffe3323
+  React-Mapbuffer: 8c4d41ddf7b9bfb06e944e3805f1d7eace7f4aff
+  React-microtasksnativemodule: 3b0be17d494b6d101a3efbbc7b18c7d42ef9fe76
+  react-native-bottom-tabs: 484fe90c49d4d7d547d15ae78f4de75492a395fa
+  react-native-quick-base64: d87272898345e0fc3c3afb8e5dff335d51214f3e
+  react-native-safe-area-context: 53f796cb6c814661bbe99fbdfd0585d07b996cdd
+  react-native-slider: a4bbed2fba298dbcd09225b5f4a1e9baf2d04268
+  react-native-vector-icons: f068b165e45f94b4e643b01512c363453fbd3b34
   react-native-vector-icons-ionicons: ad07e944a092a5cf71b8b569d8f5ce2bf674c415
-  react-native-worklets-core: f4ac400fe6a0df6cd303a7d2fa3b595f7ac2beac
-  React-NativeModulesApple: f9fa097fc24cec967b77bfc05f72d2ea7db05b87
-  React-networking: 29a9ae1a2e6ce8bb19174cc47110b36ae7ffcbcd
+  react-native-worklets-core: 5357708fd3915bf1c870a03ff969578c69bd3909
+  React-NativeModulesApple: 2a7118e5e104229a901412173db166cb51983797
+  React-networking: dc151abf285c4a8e72a5a38e5212ece0a1051776
   React-oscompat: 856e980339052dc5a35980a498e24dd8480acf29
-  React-perflogger: 9bc8be0a575776c09af1731de3aa469c3aab322b
-  React-performancecdpmetrics: d8cf7557eb80d594a268f3215df925d3a5ddedf6
-  React-performancetimeline: ab28b8575ef5dd94da9ac3db9b7693c0a2265f11
+  React-perflogger: 89f11a86ed524b414dc682053e149d880a920402
+  React-performancecdpmetrics: dd30de51c54122f3346ad4619f9962ae4bb4d5bc
+  React-performancetimeline: d60cca3cbab36b44aefa08c9eaba90d49251efff
   React-RCTActionSheet: 832a3c674944347d5bb431ff1af831460579485b
-  React-RCTAnimation: f2246e91d358d0159b3e9796a3ec3605d7cf905a
-  React-RCTAppDelegate: 09f4de36c104fba77036c8adfe2ce2da98f34f35
-  React-RCTBlob: 72bc0e5ab91340fc68f65f487d4b15fb0c78f103
-  React-RCTFabric: 9c3b1e37689acf750c2609ba758019e29053e80b
-  React-RCTFBReactNativeSpec: f9e94240428b1f28c24774e7e830a9bedaddef26
-  React-RCTImage: b42bcb8251cf5f4dbd38bb06dbbb7573b317fff1
-  React-RCTLinking: 43bcb5c9260bf87587c3556a156e7842d5ecdbb7
-  React-RCTNetwork: 8bb137f12690823bcb85e9decb183cb1557f2dfc
-  React-RCTRuntime: aa0bc6737e7e5faa51971c95ddc8d301b341f9bc
-  React-RCTSettings: 7e86e7749698f8fba012d513d7a8ed6353110029
-  React-RCTText: 496485c3f117b7aea97875df5eccedca9afd2754
-  React-RCTVibration: 7bd136f9caffdf59e806bc6a7b78c6dccc07d2f6
+  React-RCTAnimation: 9765749249fdec146b6101899443b468bb5340c8
+  React-RCTAppDelegate: 0ade51e2380a85868123b76777d387f0778ddaef
+  React-RCTBlob: d3b08b18353f45d8fc36f7ce855199736119f995
+  React-RCTFabric: 0a76c4550c4899b976697142011f8f494265eae5
+  React-RCTFBReactNativeSpec: 84efdcfb6354616221a0104af33761edc3922be7
+  React-RCTImage: c0b26ca589bbea54944f0524cbd28098a6e0b6b0
+  React-RCTLinking: 193a0d6000aacca029d9a776375d595163ff9c4b
+  React-RCTNetwork: 02633893aaea780b44c20519889f775763b3076b
+  React-RCTRuntime: af90c854d272b850b1db85f22f2ea91136cae242
+  React-RCTSettings: 21dfbfae23f1e3681493bd9077bfbbf20130056b
+  React-RCTText: a51533c9479ed1e2e108bd0d34a06663a57354b2
+  React-RCTVibration: 2a518ffd91d4a501e8dc767ebc47903e2c2b060c
   React-rendererconsistency: c57e8f7982ff098a504f59dde1f2cd02d5e89fa5
-  React-renderercss: 750b83dbb38d2dea3472b757d5cfe1925f43501a
-  React-rendererdebug: 5b945c9984752ea71f9f260a5f9c10d63c1a9204
-  React-RuntimeApple: 106c9626d28de6ee322f55f0982325a1262d7f96
-  React-RuntimeCore: 277d6e8b468e72b682ae06f5ccadd8722a63efac
-  React-runtimeexecutor: c8dc369b1413a0cf7a1ce9704fb94c0434856354
-  React-RuntimeHermes: 748241078a52013839337873cc5aa1588f90983c
-  React-runtimescheduler: c1b5d850135067e6bff5307d34d31433f6eefb1c
-  React-timing: d331f1b7d8f206911c6d06d668c850b7065409ba
-  React-utils: d1e321807f43b6f69695842e3731d099e58e89de
-  React-webperformancenativemodule: 52be7b8ca3f0d6ba3f7314f526442554f37d5cb9
-  ReactAppDependencyProvider: d69159b417e8c9d82b8fe4d0a27def4c3e8f767f
-  ReactCodegen: 4b7c14cdd5ba185e9c796b2a21daee55f76313ee
-  ReactCommon: 8868269b67561136a7970be188b40738135af077
-  ReactNativeDependencies: 8e5bf5ddbdba341f2e919cdcce37d18859e00db2
-  RNCClipboard: 88d7eeb555d1183915f0885bdbc5c97eb6f7f3ba
-  RNFSTurbo: c7b0404cf75174839c944bcfd12eaf12d8b2d73f
-  RNGestureHandler: 5494787ce29288a8941fa825663f2b1fa0a5aaf1
-  RNKeychain: 667b7bd224f14055ae4cb52b41a82ad0ad70574f
-  RNReanimated: 66999baa9236e70537f4fbaa55ef9b7b153a1ebb
-  RNScreens: 14243fa0d9842ffa7f8bb2d00b6c3cfd3ca817e8
-  RNSentry: fbdf0705a341b40f9c78cce0cb3adf7fdcc895cf
-  RNShare: 900932239a5316b6f9324c5549a69d51aeb962f4
-  RNSVG: 0bd149b873018bc6e0e3321e2f6435bdba294460
-  RNWorklets: 3717433a29c10a2983a48cdbc60baf51c680ae82
+  React-renderercss: 2120a8fa3138aa8611882470f9b3d975dee8a29f
+  React-rendererdebug: 59033ed3ffc885313dc4ad2184948d31f05580fa
+  React-RuntimeApple: 8a46695772330c0fa7be9144049594ad00df44b6
+  React-RuntimeCore: a92455a8dc590297b892a15ed818c63bc47f3892
+  React-runtimeexecutor: d2bd1ff2b741db5a9d1d65284d7f8c95e8a9d26e
+  React-RuntimeHermes: d0f024ea6b79f8c5ba28c5bf2423bc5c0c56d18c
+  React-runtimescheduler: 1fac8d4a62f5065eddce44e61ae3a8880a9bd7e7
+  React-timing: ac48a67e3bfe891e42105a26fabceb28ee80c7b9
+  React-utils: b4b240f1b75b1ccc2cfc386407667b81cc82187a
+  React-webperformancenativemodule: 0d626aa48eecbb4f9ce22ce559a0c1a83cfc9bd0
+  ReactAppDependencyProvider: 1976cdf5076a7e34718a56ead2f2069c7f54ebe9
+  ReactCodegen: 72b5b7e34c02aedcf8032a519b63e97a78e74981
+  ReactCommon: 696163beb1630cf1f7590dbc8bfc542e40bdbe76
+  ReactNativeDependencies: 4b413a7eff20fec07fbd9bfae68b9ed6cefab8c0
+  RNCClipboard: 398455e1ad6a44a94d679452b951ffb788e8599b
+  RNFSTurbo: 48c7fabc69584f5befe95fb37edf6b33a07df568
+  RNGestureHandler: 8e4a9372425d4caa9e3da5072a8dda7a54ed1097
+  RNKeychain: 91be81cd32b30c7d4c2569dcad29b472d9b93982
+  RNReanimated: bf781fa0ddb2c4321f5f4102d91defb9968f49de
+  RNScreens: fb11b7412bcbdc0ffafcaf9174938d998d4e2bc4
+  RNSentry: ece9e903539dbad0e1671ac5639850f9db1c9a06
+  RNShare: a7c655ac541bdee567832880e187eb4a974234a2
+  RNSVG: b5bd4454de003a99d3130a3c6a1b1c949c89d37d
+  RNWorklets: 339959ef7522bca12b4dcbd4997619370cfe5cd5
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageSVGCoder: 8e10c8f6cc879c7dfb317b284e13dd589379f01c
   Sentry: d587a8fe91ca13503ecd69a1905f3e8a0fcf61be
   SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
   UMAppLoader: 71b50bcc31d86495e52c0b4cd17e2708bf297be3
-  VisionCamera: 0044a94f7489f19e19d5938e97dfc36f4784af3c
+  VisionCamera: 47f10351a1b6a8d251b90986ae72ca5f52331954
   Yoga: dd994d8c85dca5cc9b10f5df8c01f9ef1d0da191
   ZIPFoundation: dfd3d681c4053ff7e2f7350bc4e53b5dba3f5351
 

--- a/client/package.json
+++ b/client/package.json
@@ -105,7 +105,7 @@
     "react-native-gesture-handler": "~2.30.0",
     "react-native-keychain": "^10.0.0",
     "react-native-mmkv": "^4.1.2",
-    "react-native-nitro-ark": "^0.0.97",
+    "react-native-nitro-ark": "^0.0.99",
     "react-native-nitro-modules": "0.33.7",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-quick-base64": "^2.2.2",

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -16,7 +16,6 @@ import {
   type OnchainPaymentResult,
   boardAllArk,
   offboardAllArk,
-  tryClaimLightningReceive,
 } from "../lib/paymentsApi";
 import { queryClient } from "~/queryClient";
 import { DestinationTypes } from "~/lib/sendUtils";
@@ -253,46 +252,6 @@ export function useSend(destinationType: DestinationTypes) {
     },
     onError: (error: Error) => {
       showAlert({ title: "Send Failed", description: error.message });
-    },
-  });
-}
-
-export function useCheckAndClaimLnReceive() {
-  return useMutation({
-    mutationFn: async ({
-      paymentHash,
-      amountSat,
-      sessionId,
-    }: {
-      paymentHash: string;
-      amountSat: number;
-      sessionId: number;
-    }) => {
-      const maxAttempts = 20;
-      const intervalMs = 1000;
-
-      for (let i = 0; i < maxAttempts; i++) {
-        const result = await tryClaimLightningReceive(paymentHash, false);
-
-        if (result.isOk() && result.value && result.value.finished_at) {
-          return { amountSat, paymentHash, sessionId };
-        }
-
-        log.d(`Attempt ${i + 1}/${maxAttempts} failed`);
-
-        if (i < maxAttempts - 1) {
-          await new Promise((resolve) => setTimeout(resolve, intervalMs));
-        }
-      }
-
-      throw new Error(`Failed to claim lightning receive after ${maxAttempts} attempts`);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["balance"] });
-      queryClient.invalidateQueries({ queryKey: ["transactions"] });
-    },
-    onError: (error: Error) => {
-      log.w("Failed to claim lightning receive:", [error.message]);
     },
   });
 }

--- a/client/src/lib/barkMovement.ts
+++ b/client/src/lib/barkMovement.ts
@@ -40,15 +40,18 @@ export type BarkSubsystemName = BarkSubsystem["name"];
 export type BarkSubsystemKind = BarkSubsystem["kind"];
 export type BarkSubsystemId = `${BarkSubsystemName}:${BarkSubsystemKind}`;
 
-type BarkMovementWithTypedSubsystem<Name extends BarkSubsystemName, Kind extends BarkSubsystemKind> =
-  BarkMovement & {
-    subsystem: BarkMovement["subsystem"] & {
-      name: Name;
-      kind: Kind;
-    };
+type BarkMovementWithTypedSubsystem<
+  Name extends BarkSubsystemName,
+  Kind extends BarkSubsystemKind,
+> = BarkMovement & {
+  subsystem: BarkMovement["subsystem"] & {
+    name: Name;
+    kind: Kind;
   };
+};
 
-const toSubsystemId = (subsystem: BarkSubsystem): BarkSubsystemId => `${subsystem.name}:${subsystem.kind}`;
+const toSubsystemId = (subsystem: BarkSubsystem): BarkSubsystemId =>
+  `${subsystem.name}:${subsystem.kind}`;
 
 const KNOWN_BARK_SUBSYSTEM_IDS = new Set<BarkSubsystemId>(
   Object.values(BARK_SUBSYSTEM).map(toSubsystemId),
@@ -99,4 +102,17 @@ export const isArkReceiveMovement = (
   }
 
   return getMovementSubsystemId(movement) === toSubsystemId(BARK_SUBSYSTEM.ARKOOR_RECEIVE);
+};
+
+export const isLightningReceiveMovement = (
+  movement: BarkMovement | undefined,
+): movement is BarkMovementWithTypedSubsystem<
+  typeof BARK_SUBSYSTEM.LIGHTNING_RECEIVE.name,
+  typeof BARK_SUBSYSTEM.LIGHTNING_RECEIVE.kind
+> => {
+  if (!movement) {
+    return false;
+  }
+
+  return getMovementSubsystemId(movement) === toSubsystemId(BARK_SUBSYSTEM.LIGHTNING_RECEIVE);
 };

--- a/client/src/lib/paymentsApi.ts
+++ b/client/src/lib/paymentsApi.ts
@@ -4,6 +4,7 @@ import {
   syncPendingBoards as syncPendingBoardsNitro,
   offboardAll as offboardAllNitro,
   subscribeArkoorAddressMovements as subscribeArkoorAddressMovementsNitro,
+  subscribeLightningPaymentMovements as subscribeLightningPaymentMovementsNitro,
   sendArkoorPayment as sendArkoorPaymentNitro,
   payLightningAddress as payLightningAddressNitro,
   payLightningOffer as payLightningOfferNitro,
@@ -219,6 +220,23 @@ export const subscribeArkoorAddressMovements = (
     return err(
       new Error(
         `Failed to subscribe to Ark address movements: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ),
+    );
+  }
+};
+
+export const subscribeLightningPaymentMovements = (
+  paymentHash: string,
+  onEvent: (event: BarkNotificationEvent) => void,
+): Result<BarkNotificationSubscription, Error> => {
+  try {
+    return ok(subscribeLightningPaymentMovementsNitro(paymentHash, onEvent));
+  } catch (error) {
+    return err(
+      new Error(
+        `Failed to subscribe to lightning payment movements: ${
           error instanceof Error ? error.message : String(error)
         }`,
       ),

--- a/client/src/screens/ReceiveScreen.tsx
+++ b/client/src/screens/ReceiveScreen.tsx
@@ -6,7 +6,6 @@ import {
   Keyboard,
   TextInput,
   ScrollView,
-  InteractionManager,
 } from "react-native";
 import { Text } from "../components/ui/text";
 import { useAlert } from "~/contexts/AlertProvider";
@@ -44,6 +43,7 @@ import { queryClient } from "~/queryClient";
 import { BlinkingCaret } from "~/components/BlinkingCaret";
 
 const minAmount = 1;
+const SUBSCRIPTION_RETRY_DELAY_MS = 1000;
 const log = logger("ReceiveScreen");
 
 type ActiveReceiveSession = {
@@ -61,6 +61,39 @@ type ReceiveRailGeneration = {
 
 type GeneratedReceiveRequest = ReceiveRailGeneration & {
   amountSat: number;
+};
+
+type IdleDeadlineLike = {
+  readonly didTimeout: boolean;
+  timeRemaining: () => number;
+};
+
+type IdleCallbackLike = (deadline: IdleDeadlineLike) => void;
+
+type IdleTaskHandle =
+  | { kind: "idle"; id: number }
+  | { kind: "timeout"; id: ReturnType<typeof setTimeout> };
+
+const scheduleIdleTask = (callback: IdleCallbackLike): IdleTaskHandle => {
+  const requestIdleCallback = (
+    globalThis as typeof globalThis & {
+      requestIdleCallback?: (cb: IdleCallbackLike) => number;
+    }
+  ).requestIdleCallback;
+
+  if (requestIdleCallback) {
+    return { kind: "idle", id: requestIdleCallback(callback) };
+  }
+
+  return {
+    kind: "timeout",
+    id: setTimeout(() => {
+      callback({
+        didTimeout: false,
+        timeRemaining: () => 0,
+      });
+    }, 0),
+  };
 };
 
 const truncateAddress = (addr: string) => {
@@ -161,8 +194,12 @@ const ReceiveScreen = () => {
   const activeReceiveSessionRef = useRef<ActiveReceiveSession | null>(null);
   const arkSubscriptionRef = useRef<BarkNotificationSubscription | null>(null);
   const lightningSubscriptionRef = useRef<BarkNotificationSubscription | null>(null);
+  const arkSubscriptionRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lightningSubscriptionRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isCompletingReceiveRef = useRef(false);
   const amountInputRef = useRef<TextInput>(null);
+  const [arkSubscriptionRetryTick, setArkSubscriptionRetryTick] = useState(0);
+  const [lightningSubscriptionRetryTick, setLightningSubscriptionRetryTick] = useState(0);
 
   const {
     mutateAsync: generateOffchainAddress,
@@ -225,7 +262,7 @@ const ReceiveScreen = () => {
       return;
     }
 
-    InteractionManager.runAfterInteractions(() => {
+    scheduleIdleTask(() => {
       stopSubscription(subscription, "Ark");
     });
   }, [stopSubscription]);
@@ -238,10 +275,66 @@ const ReceiveScreen = () => {
       return;
     }
 
-    InteractionManager.runAfterInteractions(() => {
+    scheduleIdleTask(() => {
       stopSubscription(subscription, "Lightning");
     });
   }, [stopSubscription]);
+
+  const clearArkSubscriptionRetry = useCallback(() => {
+    if (!arkSubscriptionRetryTimeoutRef.current) {
+      return;
+    }
+
+    clearTimeout(arkSubscriptionRetryTimeoutRef.current);
+    arkSubscriptionRetryTimeoutRef.current = null;
+  }, []);
+
+  const clearLightningSubscriptionRetry = useCallback(() => {
+    if (!lightningSubscriptionRetryTimeoutRef.current) {
+      return;
+    }
+
+    clearTimeout(lightningSubscriptionRetryTimeoutRef.current);
+    lightningSubscriptionRetryTimeoutRef.current = null;
+  }, []);
+
+  const scheduleArkSubscriptionRetry = useCallback(
+    (sessionId: number) => {
+      if (arkSubscriptionRetryTimeoutRef.current) {
+        return;
+      }
+
+      arkSubscriptionRetryTimeoutRef.current = setTimeout(() => {
+        arkSubscriptionRetryTimeoutRef.current = null;
+
+        if (activeReceiveSessionRef.current?.sessionId !== sessionId) {
+          return;
+        }
+
+        setArkSubscriptionRetryTick((tick) => tick + 1);
+      }, SUBSCRIPTION_RETRY_DELAY_MS);
+    },
+    [],
+  );
+
+  const scheduleLightningSubscriptionRetry = useCallback(
+    (sessionId: number) => {
+      if (lightningSubscriptionRetryTimeoutRef.current) {
+        return;
+      }
+
+      lightningSubscriptionRetryTimeoutRef.current = setTimeout(() => {
+        lightningSubscriptionRetryTimeoutRef.current = null;
+
+        if (activeReceiveSessionRef.current?.sessionId !== sessionId) {
+          return;
+        }
+
+        setLightningSubscriptionRetryTick((tick) => tick + 1);
+      }, SUBSCRIPTION_RETRY_DELAY_MS);
+    },
+    [],
+  );
 
   const clearGeneratedReceiveData = useCallback(
     ({ resetAmount }: { resetAmount: boolean }) => {
@@ -258,11 +351,19 @@ const ReceiveScreen = () => {
       receiveSessionIdRef.current += 1;
       activeReceiveSessionRef.current = null;
       isCompletingReceiveRef.current = false;
+      clearArkSubscriptionRetry();
+      clearLightningSubscriptionRetry();
       clearGeneratedReceiveData({ resetAmount });
       releaseArkSubscription();
       releaseLightningSubscription();
     },
-    [clearGeneratedReceiveData, releaseArkSubscription, releaseLightningSubscription],
+    [
+      clearArkSubscriptionRetry,
+      clearGeneratedReceiveData,
+      clearLightningSubscriptionRetry,
+      releaseArkSubscription,
+      releaseLightningSubscription,
+    ],
   );
 
   const handleReceiveComplete = useCallback(
@@ -350,7 +451,6 @@ const ReceiveScreen = () => {
       return;
     }
 
-    activeSession.paymentHash = lightningInvoice.payment_hash;
     releaseLightningSubscription();
 
     const subscriptionResult = subscribeLightningPaymentMovements(
@@ -362,14 +462,20 @@ const ReceiveScreen = () => {
 
     if (subscriptionResult.isErr()) {
       log.w("Failed to subscribe to Lightning receive updates", [subscriptionResult.error.message]);
+      scheduleLightningSubscriptionRetry(activeSession.sessionId);
       return;
     }
 
+    clearLightningSubscriptionRetry();
+    activeSession.paymentHash = lightningInvoice.payment_hash;
     lightningSubscriptionRef.current = subscriptionResult.value;
   }, [
+    clearLightningSubscriptionRetry,
     handleLightningReceiveEvent,
     lightningInvoice?.payment_hash,
     releaseLightningSubscription,
+    lightningSubscriptionRetryTick,
+    scheduleLightningSubscriptionRetry,
   ]);
 
   useEffect(() => {
@@ -382,7 +488,6 @@ const ReceiveScreen = () => {
       return;
     }
 
-    activeSession.arkAddress = arkAddress;
     releaseArkSubscription();
 
     const subscriptionResult = subscribeArkoorAddressMovements(arkAddress, (event) => {
@@ -391,11 +496,21 @@ const ReceiveScreen = () => {
 
     if (subscriptionResult.isErr()) {
       log.w("Failed to subscribe to Ark receive updates", [subscriptionResult.error.message]);
+      scheduleArkSubscriptionRetry(activeSession.sessionId);
       return;
     }
 
+    clearArkSubscriptionRetry();
+    activeSession.arkAddress = arkAddress;
     arkSubscriptionRef.current = subscriptionResult.value;
-  }, [arkAddress, handleArkoorReceiveEvent, releaseArkSubscription]);
+  }, [
+    arkAddress,
+    arkSubscriptionRetryTick,
+    clearArkSubscriptionRetry,
+    handleArkoorReceiveEvent,
+    releaseArkSubscription,
+    scheduleArkSubscriptionRetry,
+  ]);
 
   useFocusEffect(
     useCallback(() => {

--- a/client/src/screens/ReceiveScreen.tsx
+++ b/client/src/screens/ReceiveScreen.tsx
@@ -16,7 +16,6 @@ import {
   useGenerateLightningInvoice,
   useGenerateOnchainAddress,
   useGenerateOffchainAddress,
-  useCheckAndClaimLnReceive,
 } from "../hooks/usePayments";
 import { useCopyToClipboard } from "../lib/clipboardUtils";
 import QRCode from "react-native-qrcode-svg";
@@ -33,10 +32,11 @@ import { COLORS } from "~/lib/styleConstants";
 import { CurrencyToggle } from "~/components/CurrencyToggle";
 import {
   subscribeArkoorAddressMovements,
+  subscribeLightningPaymentMovements,
   type BarkNotificationEvent,
   type BarkNotificationSubscription,
 } from "~/lib/paymentsApi";
-import { isArkReceiveMovement } from "~/lib/barkMovement";
+import { isArkReceiveMovement, isLightningReceiveMovement } from "~/lib/barkMovement";
 import logger from "~/lib/log";
 import type { Bolt11Invoice } from "react-native-nitro-ark";
 import { queryClient } from "~/queryClient";
@@ -117,10 +117,7 @@ const PaymentRail = ({
 }) => {
   const iconColor = useIconColor();
   return (
-    <Pressable
-      onPress={onCopy}
-      className="flex-row items-center gap-4 py-4"
-    >
+    <Pressable onPress={onCopy} className="flex-row items-center gap-4 py-4">
       <View
         className="h-11 w-11 items-center justify-center rounded-full border border-border"
         style={{ backgroundColor: "rgba(201, 138, 60, 0.10)" }}
@@ -164,6 +161,7 @@ const ReceiveScreen = () => {
   const receiveSessionIdRef = useRef(0);
   const activeReceiveSessionRef = useRef<ActiveReceiveSession | null>(null);
   const arkSubscriptionRef = useRef<BarkNotificationSubscription | null>(null);
+  const lightningSubscriptionRef = useRef<BarkNotificationSubscription | null>(null);
   const isCompletingReceiveRef = useRef(false);
   const amountInputRef = useRef<TextInput>(null);
 
@@ -184,11 +182,6 @@ const ReceiveScreen = () => {
     isPending: isGeneratingLightning,
     reset: resetLightningInvoice,
   } = useGenerateLightningInvoice();
-
-  const {
-    mutateAsync: checkAndClaimLnReceive,
-    reset: resetLnReceiveCheck,
-  } = useCheckAndClaimLnReceive();
 
   const isLoading = isGeneratingVtxo || isGeneratingOnchain || isGeneratingLightning;
   const isGenerated = Boolean(bip321Uri);
@@ -211,6 +204,26 @@ const ReceiveScreen = () => {
       }
     } catch (error) {
       log.w("Failed to stop Ark receive subscription", [
+        error instanceof Error ? error.message : String(error),
+      ]);
+    }
+  }, []);
+
+  const stopLightningSubscription = useCallback(() => {
+    const subscription = lightningSubscriptionRef.current;
+
+    if (!subscription) {
+      return;
+    }
+
+    lightningSubscriptionRef.current = null;
+
+    try {
+      if (subscription.isActive()) {
+        subscription.stop();
+      }
+    } catch (error) {
+      log.w("Failed to stop Lightning receive subscription", [
         error instanceof Error ? error.message : String(error),
       ]);
     }
@@ -239,10 +252,10 @@ const ReceiveScreen = () => {
       activeReceiveSessionRef.current = null;
       isCompletingReceiveRef.current = false;
       stopArkSubscription();
-      resetLnReceiveCheck();
+      stopLightningSubscription();
       clearGeneratedReceiveData({ resetAmount });
     },
-    [clearGeneratedReceiveData, resetLnReceiveCheck, stopArkSubscription],
+    [clearGeneratedReceiveData, stopArkSubscription, stopLightningSubscription],
   );
 
   const handleReceiveComplete = useCallback(
@@ -299,6 +312,27 @@ const ReceiveScreen = () => {
     [handleReceiveComplete],
   );
 
+  const handleLightningReceiveEvent = useCallback(
+    (event: BarkNotificationEvent, sessionId: number) => {
+      if (event.kind === "channelLagging") {
+        return;
+      }
+
+      const activeSession = activeReceiveSessionRef.current;
+      if (!activeSession || activeSession.sessionId !== sessionId) {
+        return;
+      }
+
+      const movement = event.movement;
+      if (!movement || movement.status !== "successful" || !isLightningReceiveMovement(movement)) {
+        return;
+      }
+
+      handleReceiveComplete(activeSession.amountSat);
+    },
+    [handleReceiveComplete],
+  );
+
   useEffect(() => {
     setBip321Uri(
       buildReceiveRequestUri({
@@ -321,23 +355,22 @@ const ReceiveScreen = () => {
     }
 
     activeSession.paymentHash = lightningInvoice.payment_hash;
+    stopLightningSubscription();
 
-    void checkAndClaimLnReceive({
-      paymentHash: lightningInvoice.payment_hash,
-      amountSat: activeSession.amountSat,
-      sessionId: activeSession.sessionId,
-    })
-      .then((receiveData) => {
-        if (activeReceiveSessionRef.current?.sessionId !== receiveData.sessionId) {
-          return;
-        }
+    const subscriptionResult = subscribeLightningPaymentMovements(
+      lightningInvoice.payment_hash,
+      (event) => {
+        handleLightningReceiveEvent(event, activeSession.sessionId);
+      },
+    );
 
-        handleReceiveComplete(receiveData.amountSat);
-      })
-      .catch(() => {
-        // The mutation already logs failures; stale sessions are ignored here.
-      });
-  }, [checkAndClaimLnReceive, handleReceiveComplete, lightningInvoice?.payment_hash]);
+    if (subscriptionResult.isErr()) {
+      log.w("Failed to subscribe to Lightning receive updates", [subscriptionResult.error.message]);
+      return;
+    }
+
+    lightningSubscriptionRef.current = subscriptionResult.value;
+  }, [handleLightningReceiveEvent, lightningInvoice?.payment_hash, stopLightningSubscription]);
 
   useEffect(() => {
     if (!arkAddress) {
@@ -404,47 +437,43 @@ const ReceiveScreen = () => {
       generateOnchainAddress(),
       generateOffchainAddress(),
       generateLightningInvoice(amountSat),
-    ])
-      .then(([nextOnchainAddressResult, nextArkAddressResult, nextLightningInvoiceResult]) => {
-        if (activeReceiveSessionRef.current?.sessionId !== sessionId) {
-          return;
-        }
+    ]).then(([nextOnchainAddressResult, nextArkAddressResult, nextLightningInvoiceResult]) => {
+      if (activeReceiveSessionRef.current?.sessionId !== sessionId) {
+        return;
+      }
 
-        if (nextOnchainAddressResult.status === "rejected") {
-          log.w("Receive rail generation failed", ["onchain", nextOnchainAddressResult.reason]);
-        }
+      if (nextOnchainAddressResult.status === "rejected") {
+        log.w("Receive rail generation failed", ["onchain", nextOnchainAddressResult.reason]);
+      }
 
-        if (nextArkAddressResult.status === "rejected") {
-          log.w("Receive rail generation failed", ["ark", nextArkAddressResult.reason]);
-        }
+      if (nextArkAddressResult.status === "rejected") {
+        log.w("Receive rail generation failed", ["ark", nextArkAddressResult.reason]);
+      }
 
-        if (nextLightningInvoiceResult.status === "rejected") {
-          log.w("Receive rail generation failed", [
-            "lightning",
-            nextLightningInvoiceResult.reason,
-          ]);
-        }
+      if (nextLightningInvoiceResult.status === "rejected") {
+        log.w("Receive rail generation failed", ["lightning", nextLightningInvoiceResult.reason]);
+      }
 
-        const nextOnchainAddress =
-          nextOnchainAddressResult.status === "fulfilled"
-            ? nextOnchainAddressResult.value
-            : undefined;
-        const nextArkAddress =
-          nextArkAddressResult.status === "fulfilled" ? nextArkAddressResult.value : undefined;
-        const nextLightningInvoice =
-          nextLightningInvoiceResult.status === "fulfilled"
-            ? nextLightningInvoiceResult.value
-            : undefined;
+      const nextOnchainAddress =
+        nextOnchainAddressResult.status === "fulfilled"
+          ? nextOnchainAddressResult.value
+          : undefined;
+      const nextArkAddress =
+        nextArkAddressResult.status === "fulfilled" ? nextArkAddressResult.value : undefined;
+      const nextLightningInvoice =
+        nextLightningInvoiceResult.status === "fulfilled"
+          ? nextLightningInvoiceResult.value
+          : undefined;
 
-        if (!nextOnchainAddress && !nextArkAddress && !nextLightningInvoice) {
-          cancelReceiveSession({ resetAmount: false });
-          return;
-        }
+      if (!nextOnchainAddress && !nextArkAddress && !nextLightningInvoice) {
+        cancelReceiveSession({ resetAmount: false });
+        return;
+      }
 
-        setGeneratedOnchainAddress(nextOnchainAddress);
-        setArkAddress(nextArkAddress);
-        setLightningInvoice(nextLightningInvoice);
-      });
+      setGeneratedOnchainAddress(nextOnchainAddress);
+      setArkAddress(nextArkAddress);
+      setLightningInvoice(nextLightningInvoice);
+    });
   };
 
   const handleClear = () => {

--- a/client/src/screens/ReceiveScreen.tsx
+++ b/client/src/screens/ReceiveScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   View,
   Pressable,
@@ -6,6 +6,7 @@ import {
   Keyboard,
   TextInput,
   ScrollView,
+  InteractionManager,
 } from "react-native";
 import { Text } from "../components/ui/text";
 import { useAlert } from "~/contexts/AlertProvider";
@@ -24,7 +25,7 @@ import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { TabParamList } from "~/Navigators";
 import Icon from "@react-native-vector-icons/ionicons";
-import Animated, { FadeInDown, FadeInUp, LinearTransition, ZoomIn } from "react-native-reanimated";
+import Animated, { FadeInDown, FadeInUp, ZoomIn } from "react-native-reanimated";
 import { useIconColor, useThemeColors } from "../hooks/useTheme";
 import { satsToBtc, formatNumber, formatBip177 } from "~/lib/utils";
 import { useReceiveScreen } from "../hooks/useReceiveScreen";
@@ -56,6 +57,10 @@ type ReceiveRailGeneration = {
   arkAddress?: string;
   lightningInvoice?: Bolt11Invoice;
   onchainAddress?: string;
+};
+
+type GeneratedReceiveRequest = ReceiveRailGeneration & {
+  amountSat: number;
 };
 
 const truncateAddress = (addr: string) => {
@@ -150,13 +155,7 @@ const ReceiveScreen = () => {
   const colors = useThemeColors();
   const { amount, setAmount, currency, toggleCurrency, amountSat, btcPrice } = useReceiveScreen();
   const { copyWithState, isCopied } = useCopyToClipboard();
-  const [bip321Uri, setBip321Uri] = useState<string | undefined>(undefined);
-  const [generatedAmountSat, setGeneratedAmountSat] = useState<number | null>(null);
-  const [arkAddress, setArkAddress] = useState<string | undefined>(undefined);
-  const [generatedOnchainAddress, setGeneratedOnchainAddress] = useState<string | undefined>(
-    undefined,
-  );
-  const [lightningInvoice, setLightningInvoice] = useState<Bolt11Invoice | undefined>(undefined);
+  const [generatedRequest, setGeneratedRequest] = useState<GeneratedReceiveRequest | null>(null);
   const { showAlert } = useAlert();
   const receiveSessionIdRef = useRef(0);
   const activeReceiveSessionRef = useRef<ActiveReceiveSession | null>(null);
@@ -168,82 +167,90 @@ const ReceiveScreen = () => {
   const {
     mutateAsync: generateOffchainAddress,
     isPending: isGeneratingVtxo,
-    reset: resetOffchainAddress,
   } = useGenerateOffchainAddress();
 
   const {
     mutateAsync: generateOnchainAddress,
     isPending: isGeneratingOnchain,
-    reset: resetOnchainAddress,
   } = useGenerateOnchainAddress();
 
   const {
     mutateAsync: generateLightningInvoice,
     isPending: isGeneratingLightning,
-    reset: resetLightningInvoice,
   } = useGenerateLightningInvoice();
 
   const isLoading = isGeneratingVtxo || isGeneratingOnchain || isGeneratingLightning;
+  const generatedAmountSat = generatedRequest?.amountSat ?? null;
+  const arkAddress = generatedRequest?.arkAddress;
+  const generatedOnchainAddress = generatedRequest?.onchainAddress;
+  const lightningInvoice = generatedRequest?.lightningInvoice;
+  const bip321Uri = useMemo(
+    () =>
+      buildReceiveRequestUri({
+        amountSat: generatedAmountSat,
+        arkAddress,
+        lightningInvoice,
+        onchainAddress: generatedOnchainAddress,
+      }),
+    [arkAddress, generatedAmountSat, generatedOnchainAddress, lightningInvoice],
+  );
   const isGenerated = Boolean(bip321Uri);
+  const isClearDisabled = isLoading || (!isGenerated && amount === "");
   const isAmountLocked = isLoading || isGenerated;
   const displayAmount = amount === "" ? (currency === "USD" ? "0.00" : "0") : amount;
   const [isAmountFocused, setIsAmountFocused] = useState(false);
 
-  const stopArkSubscription = useCallback(() => {
+  const stopSubscription = useCallback(
+    (subscription: BarkNotificationSubscription | null, label: string) => {
+      if (!subscription) {
+        return;
+      }
+
+      try {
+        subscription.stop();
+      } catch (error) {
+        log.w(`Failed to stop ${label} receive subscription`, [
+          error instanceof Error ? error.message : String(error),
+        ]);
+      }
+    },
+    [],
+  );
+
+  const releaseArkSubscription = useCallback(() => {
     const subscription = arkSubscriptionRef.current;
-
-    if (!subscription) {
-      return;
-    }
-
     arkSubscriptionRef.current = null;
 
-    try {
-      if (subscription.isActive()) {
-        subscription.stop();
-      }
-    } catch (error) {
-      log.w("Failed to stop Ark receive subscription", [
-        error instanceof Error ? error.message : String(error),
-      ]);
+    if (!subscription) {
+      return;
     }
-  }, []);
 
-  const stopLightningSubscription = useCallback(() => {
+    InteractionManager.runAfterInteractions(() => {
+      stopSubscription(subscription, "Ark");
+    });
+  }, [stopSubscription]);
+
+  const releaseLightningSubscription = useCallback(() => {
     const subscription = lightningSubscriptionRef.current;
+    lightningSubscriptionRef.current = null;
 
     if (!subscription) {
       return;
     }
 
-    lightningSubscriptionRef.current = null;
-
-    try {
-      if (subscription.isActive()) {
-        subscription.stop();
-      }
-    } catch (error) {
-      log.w("Failed to stop Lightning receive subscription", [
-        error instanceof Error ? error.message : String(error),
-      ]);
-    }
-  }, []);
+    InteractionManager.runAfterInteractions(() => {
+      stopSubscription(subscription, "Lightning");
+    });
+  }, [stopSubscription]);
 
   const clearGeneratedReceiveData = useCallback(
     ({ resetAmount }: { resetAmount: boolean }) => {
-      setBip321Uri(undefined);
-      setGeneratedAmountSat(null);
-      setArkAddress(undefined);
-      setGeneratedOnchainAddress(undefined);
-      setLightningInvoice(undefined);
+      setGeneratedRequest(null);
       if (resetAmount) {
         setAmount("");
       }
-      resetOffchainAddress();
-      resetOnchainAddress();
-      resetLightningInvoice();
     },
-    [resetLightningInvoice, resetOffchainAddress, resetOnchainAddress, setAmount],
+    [setAmount],
   );
 
   const cancelReceiveSession = useCallback(
@@ -251,11 +258,11 @@ const ReceiveScreen = () => {
       receiveSessionIdRef.current += 1;
       activeReceiveSessionRef.current = null;
       isCompletingReceiveRef.current = false;
-      stopArkSubscription();
-      stopLightningSubscription();
       clearGeneratedReceiveData({ resetAmount });
+      releaseArkSubscription();
+      releaseLightningSubscription();
     },
-    [clearGeneratedReceiveData, stopArkSubscription, stopLightningSubscription],
+    [clearGeneratedReceiveData, releaseArkSubscription, releaseLightningSubscription],
   );
 
   const handleReceiveComplete = useCallback(
@@ -334,17 +341,6 @@ const ReceiveScreen = () => {
   );
 
   useEffect(() => {
-    setBip321Uri(
-      buildReceiveRequestUri({
-        amountSat: generatedAmountSat,
-        arkAddress,
-        lightningInvoice,
-        onchainAddress: generatedOnchainAddress,
-      }),
-    );
-  }, [arkAddress, generatedAmountSat, generatedOnchainAddress, lightningInvoice]);
-
-  useEffect(() => {
     if (!lightningInvoice?.payment_hash) {
       return;
     }
@@ -355,7 +351,7 @@ const ReceiveScreen = () => {
     }
 
     activeSession.paymentHash = lightningInvoice.payment_hash;
-    stopLightningSubscription();
+    releaseLightningSubscription();
 
     const subscriptionResult = subscribeLightningPaymentMovements(
       lightningInvoice.payment_hash,
@@ -370,7 +366,11 @@ const ReceiveScreen = () => {
     }
 
     lightningSubscriptionRef.current = subscriptionResult.value;
-  }, [handleLightningReceiveEvent, lightningInvoice?.payment_hash, stopLightningSubscription]);
+  }, [
+    handleLightningReceiveEvent,
+    lightningInvoice?.payment_hash,
+    releaseLightningSubscription,
+  ]);
 
   useEffect(() => {
     if (!arkAddress) {
@@ -383,7 +383,7 @@ const ReceiveScreen = () => {
     }
 
     activeSession.arkAddress = arkAddress;
-    stopArkSubscription();
+    releaseArkSubscription();
 
     const subscriptionResult = subscribeArkoorAddressMovements(arkAddress, (event) => {
       handleArkoorReceiveEvent(event, activeSession.sessionId);
@@ -395,7 +395,7 @@ const ReceiveScreen = () => {
     }
 
     arkSubscriptionRef.current = subscriptionResult.value;
-  }, [arkAddress, handleArkoorReceiveEvent, stopArkSubscription]);
+  }, [arkAddress, handleArkoorReceiveEvent, releaseArkSubscription]);
 
   useFocusEffect(
     useCallback(() => {
@@ -425,7 +425,7 @@ const ReceiveScreen = () => {
     }
 
     cancelReceiveSession({ resetAmount: false });
-    setGeneratedAmountSat(amountSat);
+    setGeneratedRequest({ amountSat });
     activeReceiveSessionRef.current = {
       sessionId: receiveSessionIdRef.current,
       amountSat,
@@ -470,9 +470,12 @@ const ReceiveScreen = () => {
         return;
       }
 
-      setGeneratedOnchainAddress(nextOnchainAddress);
-      setArkAddress(nextArkAddress);
-      setLightningInvoice(nextLightningInvoice);
+      setGeneratedRequest({
+        amountSat,
+        onchainAddress: nextOnchainAddress,
+        arkAddress: nextArkAddress,
+        lightningInvoice: nextLightningInvoice,
+      });
     });
   };
 
@@ -528,10 +531,7 @@ const ReceiveScreen = () => {
               </Text>
             </Animated.View>
 
-            <Animated.View
-              layout={LinearTransition.springify().damping(18).stiffness(180)}
-              className="mt-4"
-            >
+            <Animated.View className="mt-4">
               <View className="flex-row items-start justify-end gap-4">
                 <View className="flex-1">
                   {isGenerated ? (
@@ -687,20 +687,20 @@ const ReceiveScreen = () => {
               </Animated.View>
             )}
 
-            <Animated.View
-              layout={LinearTransition.springify().damping(18).stiffness(180)}
-              className="mt-5 flex-row items-center gap-3"
-            >
-              {isGenerated ? (
-                <Button onPress={handleClear} variant="outline" className="flex-1 rounded-2xl">
-                  <Text className="font-semibold">Clear</Text>
-                </Button>
-              ) : null}
+            <Animated.View className="mt-5 flex-row items-center gap-3">
+              <Button
+                onPress={handleClear}
+                disabled={isClearDisabled}
+                variant="outline"
+                className="h-14 w-[120px] rounded-2xl"
+              >
+                <Text className="font-semibold">Clear</Text>
+              </Button>
               <NoahButton
                 onPress={handleGenerate}
                 isLoading={isLoading}
                 disabled={isLoading || amount === "" || amountSat < minAmount}
-                className="flex-1 rounded-2xl py-4"
+                className="h-14 flex-1 rounded-2xl"
               >
                 {isGenerated ? "New request" : "Generate request"}
               </NoahButton>

--- a/scripts/captaind.toml
+++ b/scripts/captaind.toml
@@ -1,4 +1,3 @@
-
 data_dir = "/data/captaind"
 network = "regtest"
 vtxo_lifetime = 480
@@ -93,6 +92,9 @@ cln_reconnect_interval = "10s"
 # Interval to double check on pending invoices
 invoice_check_interval = "3s"
 
+# The time we give xpay to try finish a payment
+cln_xpay_timeout = "60s"
+
 # Minimum interval to keep between two consecutive checks of an invoice
 invoice_recheck_delay = "2s"
 
@@ -115,6 +117,12 @@ track_all_base_delay = "1s"
 track_all_max_delay = "60s"
 
 ln_receive_anti_dos_required = false
+
+# The fraction of the fee we charge that we allow CLN to claim at most
+#
+# E.g. if a user wants to pay 1000 sat, we charge him 0.4%, so 4 sats,
+# and the ln_max_fee_ppm is set to 750000, we set CLN's maxfee to 3 sats.
+ln_max_fee_ppm = 900000
 
 #############
 # LIGHTNING #

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -73,7 +73,7 @@ services:
         condition: service_healthy
 
   captaind:
-    image: niteshbalusu/captaind:nightly-2026-04-05
+    image: niteshbalusu/captaind:nightly-2026-04-09
     volumes:
       - captaind:/data/captaind
       - ./captaind.toml:/data/captaind/captaind.toml
@@ -90,7 +90,7 @@ services:
         condition: service_healthy
 
   bark:
-    image: niteshbalusu/bark:nightly-2026-04-05
+    image: niteshbalusu/bark:nightly-2026-04-09
     volumes:
       - bark:/root
     depends_on:


### PR DESCRIPTION
Switch receive completion to subscribe to lightning payment movements instead of polling, so Lightning receives can complete as soon as the movement is confirmed. Also updates the NitroArk dependency and matching local dev images for the new receive flow.