### PR TITLE
Claim Lightning payments from mailbox notifications

### DIFF
--- a/client/src/lib/lightningReceiveAmounts.ts
+++ b/client/src/lib/lightningReceiveAmounts.ts
@@ -1,0 +1,78 @@
+import { mmkv } from "./mmkv";
+
+const KEY_PREFIX = "lightning_receive_amount:";
+const ENTRY_TTL_MS = 24 * 60 * 60 * 1000;
+
+type LightningReceiveAmountEntry = {
+  amountSat: number;
+  createdAt: number;
+};
+
+function keyForPaymentHash(paymentHash: string) {
+  return `${KEY_PREFIX}${paymentHash}`;
+}
+
+function parseEntry(value: string | undefined): LightningReceiveAmountEntry | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as Partial<LightningReceiveAmountEntry>;
+    if (typeof parsed.amountSat !== "number" || typeof parsed.createdAt !== "number") {
+      return null;
+    }
+
+    return {
+      amountSat: parsed.amountSat,
+      createdAt: parsed.createdAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isExpired(entry: LightningReceiveAmountEntry, now = Date.now()) {
+  return now - entry.createdAt > ENTRY_TTL_MS;
+}
+
+export function pruneStoredLightningReceiveAmounts() {
+  const now = Date.now();
+  for (const key of mmkv.getAllKeys()) {
+    if (!key.startsWith(KEY_PREFIX)) {
+      continue;
+    }
+
+    const entry = parseEntry(mmkv.getString(key));
+    if (!entry || isExpired(entry, now)) {
+      mmkv.remove(key);
+    }
+  }
+}
+
+export function storeLightningReceiveAmount(paymentHash: string, amountSat: number) {
+  pruneStoredLightningReceiveAmounts();
+  mmkv.set(
+    keyForPaymentHash(paymentHash),
+    JSON.stringify({
+      amountSat,
+      createdAt: Date.now(),
+    } satisfies LightningReceiveAmountEntry),
+  );
+}
+
+export function getStoredLightningReceiveAmount(paymentHash: string): number | null {
+  const key = keyForPaymentHash(paymentHash);
+  const entry = parseEntry(mmkv.getString(key));
+
+  if (!entry || isExpired(entry)) {
+    mmkv.remove(key);
+    return null;
+  }
+
+  return entry.amountSat;
+}
+
+export function removeStoredLightningReceiveAmount(paymentHash: string) {
+  mmkv.remove(keyForPaymentHash(paymentHash));
+}

--- a/client/src/lib/pushNotifications.ts
+++ b/client/src/lib/pushNotifications.ts
@@ -9,7 +9,7 @@ import { submitInvoiceTask, triggerBackupTask, maintenanceTask } from "./tasks";
 import { registerPushToken, reportJobStatus, heartbeatResponse } from "~/lib/api";
 import { err, ok, Result, ResultAsync } from "neverthrow";
 import { NotificationData, ReportType } from "~/types/serverTypes";
-import { tryClaimLightningReceive } from "./paymentsApi";
+import { tryClaimAllLightningReceives } from "./paymentsApi";
 import { useWalletStore } from "~/store/walletStore";
 import { formatBip177 } from "./utils";
 import { updateWidget } from "~/hooks/useWidget";
@@ -28,6 +28,211 @@ export type RegisterForPushResult =
   | { kind: "device_not_supported" };
 
 const BACKGROUND_NOTIFICATION_TASK = "BACKGROUND-NOTIFICATION-TASK";
+const DEFAULT_NOTIFICATION_CHANNEL_ID = "default";
+const KNOWN_NOTIFICATION_TYPES = new Set<string>([
+  "maintenance",
+  "lightning_invoice_request",
+  "lightning_claim_request",
+  "backup_trigger",
+  "heartbeat",
+]);
+
+async function ensureDefaultNotificationChannel() {
+  if (Platform.OS !== "android") {
+    return;
+  }
+
+  await Notifications.setNotificationChannelAsync(DEFAULT_NOTIFICATION_CHANNEL_ID, {
+    name: "default",
+    importance: Notifications.AndroidImportance.MAX,
+    vibrationPattern: [0, 250, 250, 250],
+    lightColor: "#FF231F7C",
+  });
+}
+
+async function scheduleLightningPaymentNotification(amountSat: number | null): Promise<string> {
+  await ensureDefaultNotificationChannel();
+
+  return Notifications.scheduleNotificationAsync({
+    content: {
+      title: "Lightning Payment Received! ⚡",
+      body:
+        amountSat === null
+          ? "Your Lightning payment was claimed."
+          : `You received ${formatBip177(amountSat)}`,
+      sound: "default",
+      priority: Notifications.AndroidNotificationPriority.MAX,
+      data: {
+        notification_type: "lightning_payment_received",
+      },
+    },
+    trigger: Platform.OS === "android" ? { channelId: DEFAULT_NOTIFICATION_CHANNEL_ID } : null,
+  });
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function isKnownNotificationType(value: string): boolean {
+  return KNOWN_NOTIFICATION_TYPES.has(value);
+}
+
+function extractNotificationPayload(payload: unknown): unknown {
+  const record = asRecord(payload);
+  if (!record) {
+    return null;
+  }
+
+  if (
+    typeof record.notification_type === "string" &&
+    isKnownNotificationType(record.notification_type)
+  ) {
+    return record;
+  }
+
+  if ("body" in record) {
+    return record.body;
+  }
+
+  if (typeof record.dataString === "string") {
+    return record.dataString;
+  }
+
+  const nestedData = asRecord(record.data);
+  if (nestedData) {
+    if (
+      typeof nestedData.notification_type === "string" &&
+      isKnownNotificationType(nestedData.notification_type)
+    ) {
+      return nestedData;
+    }
+
+    if ("body" in nestedData) {
+      return nestedData.body;
+    }
+
+    if (typeof nestedData.dataString === "string") {
+      return nestedData.dataString;
+    }
+
+    const launchPayload = asRecord(nestedData.UIApplicationLaunchOptionsRemoteNotificationKey);
+    if (launchPayload && "body" in launchPayload) {
+      return launchPayload.body;
+    }
+  }
+
+  const launchPayload = asRecord(record.UIApplicationLaunchOptionsRemoteNotificationKey);
+  if (launchPayload && "body" in launchPayload) {
+    return launchPayload.body;
+  }
+
+  return null;
+}
+
+function parseNotificationData(payload: unknown): Result<NotificationData | null, Error> {
+  return Result.fromThrowable(
+    () => {
+      const rawPayload = extractNotificationPayload(payload);
+      if (!rawPayload) {
+        return null;
+      }
+
+      const parsed =
+        typeof rawPayload === "string" ? (JSON.parse(rawPayload) as unknown) : rawPayload;
+      const parsedRecord = asRecord(parsed);
+
+      if (
+        !parsedRecord ||
+        typeof parsedRecord.notification_type !== "string" ||
+        !KNOWN_NOTIFICATION_TYPES.has(parsedRecord.notification_type)
+      ) {
+        return null;
+      }
+
+      return parsedRecord as NotificationData;
+    },
+    (e) => new Error(`Failed to parse notification data: ${e}`),
+  )();
+}
+
+async function handleNotificationData(notificationData: NotificationData) {
+  switch (notificationData.notification_type) {
+    case "maintenance": {
+      const result = await maintenanceTask();
+      // Also perform a sync after maintenance
+      await handleTaskCompletion("maintenance", result, notificationData.notification_k1);
+
+      // Refresh widget after maintenance
+      await updateWidget();
+      break;
+    }
+
+    case "lightning_invoice_request": {
+      log.i("Received lightning invoice request", [notificationData]);
+      const invoiceResult = await submitInvoiceTask(
+        notificationData.transaction_id,
+        notificationData.amount,
+      );
+      if (invoiceResult.isErr()) {
+        throw invoiceResult.error;
+      }
+      break;
+    }
+
+    case "lightning_claim_request": {
+      log.i("Received lightning claim request", [notificationData]);
+      log.i("Claiming pending lightning receives", [notificationData.payment_hash]);
+      const claimResult = await tryClaimAllLightningReceives(false);
+      if (claimResult.isErr()) {
+        throw claimResult.error;
+      }
+      log.i("Successfully claimed pending lightning receives", [notificationData.payment_hash]);
+
+      const notificationId = await scheduleLightningPaymentNotification(
+        notificationData.amount_sat,
+      );
+      log.i("Local notification scheduled for lightning payment", [
+        notificationId,
+        notificationData.payment_hash,
+        notificationData.amount_sat,
+      ]);
+
+      await updateWidget();
+      break;
+    }
+
+    case "backup_trigger": {
+      const result = await triggerBackupTask();
+      await handleTaskCompletion("backup", result, notificationData.notification_k1);
+      log.d("Backup task completed");
+      break;
+    }
+
+    case "heartbeat": {
+      log.i("Received heartbeat notification", [notificationData]);
+      const heartbeatResult = await heartbeatResponse({
+        notification_id: notificationData.notification_id,
+      });
+
+      if (heartbeatResult.isErr()) {
+        log.w("Failed to respond to heartbeat", [heartbeatResult.error]);
+      } else {
+        log.d("Successfully responded to heartbeat", [notificationData.notification_id]);
+      }
+      break;
+    }
+
+    default: {
+      const _exhaustiveCheck: never = notificationData;
+      log.w("Unknown notification type received", [_exhaustiveCheck]);
+    }
+  }
+}
 
 /**
  * Reports job completion status to the server.
@@ -95,28 +300,7 @@ TaskManager.defineTask<Notifications.NotificationTaskPayload>(
         return;
       }
 
-      const notificationDataResult = Result.fromThrowable(
-        () => {
-          const typedData = data as {
-            data?: {
-              body?: unknown;
-              // iOS cold-launch wraps the notification payload under this key
-              // due to a bug in expo-task-manager's EXTaskService.m which passes
-              // the entire launchOptions dictionary instead of extracting the
-              // notification userInfo.
-              UIApplicationLaunchOptionsRemoteNotificationKey?: { body?: unknown };
-            };
-          };
-          const rawBody =
-            typedData?.data?.body ??
-            typedData?.data?.UIApplicationLaunchOptionsRemoteNotificationKey?.body;
-          if (typeof rawBody === "string") {
-            return JSON.parse(rawBody) as NotificationData;
-          }
-          return rawBody as NotificationData;
-        },
-        (e) => new Error(`Failed to parse notification data: ${e}`),
-      )();
+      const notificationDataResult = parseNotificationData(data);
 
       if (notificationDataResult.isErr()) {
         captureException(notificationDataResult.error);
@@ -126,88 +310,13 @@ TaskManager.defineTask<Notifications.NotificationTaskPayload>(
 
       const notificationData = notificationDataResult.value;
 
-      if (!notificationData || !notificationData.notification_type) {
+      if (!notificationData) {
         log.w("[Background Job] No data or type received", [notificationData]);
         return;
       }
 
       const taskResult = await ResultAsync.fromPromise(
-        (async () => {
-          switch (notificationData.notification_type) {
-            case "maintenance": {
-              const result = await maintenanceTask();
-              // Also perform a sync after maintenance
-              await handleTaskCompletion(
-                "maintenance",
-                result,
-                notificationData.notification_k1,
-              );
-
-              // Refresh widget after maintenance
-              await updateWidget();
-              break;
-            }
-
-            case "lightning_invoice_request": {
-              log.i("Received lightning invoice request", [notificationData]);
-              const invoiceResult = await submitInvoiceTask(
-                notificationData.transaction_id,
-                notificationData.amount,
-              );
-
-              // Wait for the invoice to be paid
-              // This is a terrible solution, but it is what it is for now
-              if (invoiceResult.isOk()) {
-                const claimResult = await tryClaimLightningReceive(
-                  invoiceResult.value.payment_hash,
-                  true,
-                );
-
-                if (claimResult.isOk() && claimResult.value && claimResult.value.finished_at) {
-                  const sats = notificationData.amount / 1000;
-                  await Notifications.scheduleNotificationAsync({
-                    content: {
-                      title: "Lightning Payment Received! ⚡",
-                      body: `You received ${formatBip177(sats)}`,
-                    },
-                    trigger: null,
-                  });
-                  log.d("Local notification triggered for payment", [sats]);
-
-                  // Refresh widget after lightning payment
-                  await updateWidget();
-                }
-              }
-              break;
-            }
-
-            case "backup_trigger": {
-              const result = await triggerBackupTask();
-              await handleTaskCompletion("backup", result, notificationData.notification_k1);
-              log.d("Backup task completed");
-              break;
-            }
-
-            case "heartbeat": {
-              log.i("Received heartbeat notification", [notificationData]);
-              const heartbeatResult = await heartbeatResponse({
-                notification_id: notificationData.notification_id,
-              });
-
-              if (heartbeatResult.isErr()) {
-                log.w("Failed to respond to heartbeat", [heartbeatResult.error]);
-              } else {
-                log.d("Successfully responded to heartbeat", [notificationData.notification_id]);
-              }
-              break;
-            }
-
-            default: {
-              const _exhaustiveCheck: never = notificationData;
-              log.w("Unknown notification type received", [_exhaustiveCheck]);
-            }
-          }
-        })(),
+        handleNotificationData(notificationData),
         (e) =>
           new Error(
             `Failed to handle background notification: ${e instanceof Error ? e.message : String(e)}`,
@@ -239,8 +348,40 @@ TaskManager.defineTask<Notifications.NotificationTaskPayload>(
 
 Notifications.registerTaskAsync(BACKGROUND_NOTIFICATION_TASK);
 
+Notifications.addNotificationReceivedListener((notification) => {
+  const notificationDataResult = parseNotificationData(notification.request.content.data);
+  if (notificationDataResult.isErr()) {
+    captureException(notificationDataResult.error);
+    log.e("[Foreground Notification] error", [notificationDataResult.error]);
+    return;
+  }
+
+  const notificationData = notificationDataResult.value;
+  if (!notificationData) {
+    return;
+  }
+
+  void (async () => {
+    useWalletStore.getState().setBackgroundJobRunning(true);
+
+    try {
+      await handleNotificationData(notificationData);
+    } catch (e) {
+      const error =
+        e instanceof Error
+          ? e
+          : new Error(`Failed to handle foreground notification: ${String(e)}`);
+      captureException(error);
+      log.e("[Foreground Notification] error", [error]);
+    } finally {
+      useWalletStore.getState().setBackgroundJobRunning(false);
+    }
+  })();
+});
+
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
+    shouldShowAlert: true,
     shouldPlaySound: true,
     shouldSetBadge: true,
     shouldShowBanner: true,
@@ -269,14 +410,7 @@ export async function getPushPermissionStatus(): Promise<Result<PushPermissionSt
 export async function registerForPushNotificationsAsync(): Promise<
   Result<RegisterForPushResult, Error>
 > {
-  if (Platform.OS === "android") {
-    Notifications.setNotificationChannelAsync("default", {
-      name: "default",
-      importance: Notifications.AndroidImportance.MAX,
-      vibrationPattern: [0, 250, 250, 250],
-      lightColor: "#FF231F7C",
-    });
-  }
+  await ensureDefaultNotificationChannel();
 
   // If the device is not a physical device, return a non-supported status
   if (!Device.isDevice) {

--- a/client/src/lib/pushNotifications.ts
+++ b/client/src/lib/pushNotifications.ts
@@ -5,15 +5,23 @@ import * as TaskManager from "expo-task-manager";
 import Constants from "expo-constants";
 import logger from "~/lib/log";
 import { captureException } from "@sentry/react-native";
-import { submitInvoiceTask, triggerBackupTask, maintenanceTask } from "./tasks";
+import {
+  claimLightningReceivesTask,
+  maintenanceTask,
+  submitInvoiceTask,
+  triggerBackupTask,
+} from "./tasks";
 import { registerPushToken, reportJobStatus, heartbeatResponse } from "~/lib/api";
 import { err, ok, Result, ResultAsync } from "neverthrow";
 import { NotificationData, ReportType } from "~/types/serverTypes";
-import { tryClaimAllLightningReceives } from "./paymentsApi";
 import { useWalletStore } from "~/store/walletStore";
 import { formatBip177 } from "./utils";
 import { updateWidget } from "~/hooks/useWidget";
 import { hasGooglePlayServices } from "~/constants";
+import {
+  getStoredLightningReceiveAmount,
+  removeStoredLightningReceiveAmount,
+} from "./lightningReceiveAmounts";
 
 const log = logger("pushNotifications");
 
@@ -187,21 +195,27 @@ async function handleNotificationData(notificationData: NotificationData) {
     case "lightning_claim_request": {
       log.i("Received lightning claim request", [notificationData]);
       log.i("Claiming pending lightning receives", [notificationData.payment_hash]);
-      const claimResult = await tryClaimAllLightningReceives(false);
+      const claimResult = await claimLightningReceivesTask();
       if (claimResult.isErr()) {
         throw claimResult.error;
       }
       log.i("Successfully claimed pending lightning receives", [notificationData.payment_hash]);
 
-      const notificationId = await scheduleLightningPaymentNotification(
-        notificationData.amount_sat,
-      );
+      const amountSat =
+        notificationData.amount_sat ??
+        (notificationData.payment_hash
+          ? getStoredLightningReceiveAmount(notificationData.payment_hash)
+          : null);
+      const notificationId = await scheduleLightningPaymentNotification(amountSat);
       log.i("Local notification scheduled for lightning payment", [
         notificationId,
         notificationData.payment_hash,
-        notificationData.amount_sat,
+        amountSat,
       ]);
 
+      if (notificationData.payment_hash) {
+        removeStoredLightningReceiveAmount(notificationData.payment_hash);
+      }
       await updateWidget();
       break;
     }

--- a/client/src/lib/tasks.ts
+++ b/client/src/lib/tasks.ts
@@ -1,10 +1,11 @@
 import { loadWalletIfNeeded, maintenanceWithOnchainDelegated } from "./walletApi";
 import logger from "~/lib/log";
-import { bolt11Invoice } from "./paymentsApi";
+import { bolt11Invoice, tryClaimAllLightningReceives } from "./paymentsApi";
 import { err, ok, Result } from "neverthrow";
 import { BackupService } from "~/lib/backupService";
 import { submitInvoice as submitInvoiceApi } from "./api";
 import { Bolt11Invoice } from "react-native-nitro-ark";
+import { storeLightningReceiveAmount } from "./lightningReceiveAmounts";
 
 const log = logger("tasks");
 
@@ -55,9 +56,27 @@ export async function submitInvoiceTask(
     return err(responseResult.error);
   }
 
+  storeLightningReceiveAmount(invoiceResult.value.payment_hash, sats);
   log.d("[Submit Invoice Job] completed");
 
   return ok(invoiceResult.value);
+}
+
+export async function claimLightningReceivesTask(): Promise<Result<void, Error>> {
+  const loadResult = await loadWalletIfNeeded();
+  if (loadResult.isErr()) {
+    log.e("Failed to load wallet for claiming lightning receives", [loadResult.error]);
+    return err(loadResult.error);
+  }
+
+  const claimResult = await tryClaimAllLightningReceives(false);
+  if (claimResult.isErr()) {
+    log.e("Failed to claim lightning receives", [claimResult.error]);
+    return err(claimResult.error);
+  }
+
+  log.d("[Claim Lightning Receives Job] completed");
+  return ok(undefined);
 }
 
 // Shared backup function that can be used by both hooks and background tasks

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -555,8 +555,8 @@ const SettingsScreen = () => {
               <View className="flex-1">
                 <Label className="text-foreground text-lg">Mailbox Notifications</Label>
                 <Text className="text-base mt-1 text-muted-foreground">
-                  Allow the Noah server to monitor your Ark mailbox so it can send push
-                  notifications for wallet activity.
+                  Allow Noah to monitor your Ark mailbox so it can wake this app to claim
+                  Lightning payments in the background.
                 </Text>
               </View>
               <Switch

--- a/client/src/types/serverTypes.ts
+++ b/client/src/types/serverTypes.ts
@@ -101,11 +101,13 @@ export type LightningAddressSuggestionsResponse = {
  */
 suggestions: Array<string>, };
 
+export type LightningClaimRequestNotification = { payment_hash: string | null, amount_sat: number | null, };
+
 export type LightningInvoiceRequestNotification = { transaction_id: string, amount: number, };
 
 export type MaintenanceNotification = { notification_k1: string, };
 
-export type NotificationData = { "notification_type": "maintenance" } & MaintenanceNotification | { "notification_type": "lightning_invoice_request" } & LightningInvoiceRequestNotification | { "notification_type": "backup_trigger" } & BackupTriggerNotification | { "notification_type": "heartbeat" } & HeartbeatNotification;
+export type NotificationData = { "notification_type": "maintenance" } & MaintenanceNotification | { "notification_type": "lightning_invoice_request" } & LightningInvoiceRequestNotification | { "notification_type": "lightning_claim_request" } & LightningClaimRequestNotification | { "notification_type": "backup_trigger" } & BackupTriggerNotification | { "notification_type": "heartbeat" } & HeartbeatNotification;
 
 /**
  * Defines the payload for a user registration request.

--- a/server/src/db/mailbox_authorization_repo.rs
+++ b/server/src/db/mailbox_authorization_repo.rs
@@ -102,6 +102,26 @@ impl<'a> MailboxAuthorizationRepository<'a> {
         Ok(record)
     }
 
+    pub async fn has_active_authorization(&self, pubkey: &str, now: i64) -> Result<bool> {
+        let exists = sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM mailbox_authorizations
+                WHERE pubkey = $1
+                  AND enabled = TRUE
+                  AND authorization_hex IS NOT NULL
+                  AND authorization_expires_at IS NOT NULL
+                  AND authorization_expires_at > $2
+            )",
+        )
+        .bind(pubkey)
+        .bind(now)
+        .fetch_one(self.pool)
+        .await?;
+
+        Ok(exists)
+    }
+
     pub async fn find_all_enabled(&self) -> Result<Vec<ActiveMailboxAuthorization>> {
         let records = sqlx::query_as::<_, ActiveMailboxAuthorization>(
             "SELECT

--- a/server/src/db/notification_tracking_repo.rs
+++ b/server/src/db/notification_tracking_repo.rs
@@ -123,7 +123,8 @@ impl<'a> NotificationTrackingRepository<'a> {
                 .fetch_one(self.pool)
                 .await?
             }
-            NotificationData::LightningInvoiceRequest(_) => None,
+            NotificationData::LightningInvoiceRequest(_)
+            | NotificationData::LightningClaimRequest(_) => None,
         };
 
         Ok(last_sent)

--- a/server/src/mailbox_worker.rs
+++ b/server/src/mailbox_worker.rs
@@ -26,6 +26,7 @@ use crate::{
     db::mailbox_authorization_repo::{ActiveMailboxAuthorization, MailboxAuthorizationRepository},
     errors::ApiError,
     push::{PushNotificationData, send_push_notification},
+    types::{LightningClaimRequestNotification, NotificationData},
 };
 
 #[derive(Debug, Clone)]
@@ -470,11 +471,58 @@ async fn process_mailbox_message(
     }
 
     match &message.message {
+        Some(Message::IncomingLightningPayment(lightning_payment)) if send_notifications => {
+            let payment_hash = hex::encode(&lightning_payment.payment_hash);
+            let notification = build_lightning_claim_notification(payment_hash)?;
+
+            tracing::info!(
+                service = "mailbox_worker",
+                pubkey = %mailbox.pubkey,
+                checkpoint = message.checkpoint,
+                notification_kind = "lightning_claim_request",
+                silent = true,
+                content_available = true,
+                "mailbox incoming lightning payment received; sending claim push notification"
+            );
+
+            send_push_notification(
+                app_state.clone(),
+                notification,
+                Some(mailbox.pubkey.to_string()),
+            )
+            .await?;
+        }
         Some(Message::Arkoor(arkoor)) if send_notifications && !arkoor.vtxos.is_empty() => {
+            tracing::info!(
+                service = "mailbox_worker",
+                pubkey = %mailbox.pubkey,
+                checkpoint = message.checkpoint,
+                vtxo_count = arkoor.vtxos.len(),
+                "mailbox arkoor message received"
+            );
+
             for raw_vtxo in &arkoor.vtxos {
                 let Some(notification) = build_receive_notification(raw_vtxo)? else {
                     continue;
                 };
+                let notification_kind = if notification.content_available
+                    && notification.title.is_none()
+                    && notification.body.is_none()
+                {
+                    "lightning_claim_request"
+                } else {
+                    "visible_receive"
+                };
+
+                tracing::info!(
+                    service = "mailbox_worker",
+                    pubkey = %mailbox.pubkey,
+                    checkpoint = message.checkpoint,
+                    notification_kind,
+                    silent = notification.title.is_none() && notification.body.is_none(),
+                    content_available = notification.content_available,
+                    "sending mailbox push notification"
+                );
 
                 send_push_notification(
                     app_state.clone(),
@@ -502,6 +550,26 @@ fn should_suppress_catchup_notifications(last_checkpoint: i64) -> bool {
     last_checkpoint == 0
 }
 
+fn build_lightning_claim_notification(
+    payment_hash: String,
+) -> Result<PushNotificationData, ApiError> {
+    let data = serde_json::to_string(&NotificationData::LightningClaimRequest(
+        LightningClaimRequestNotification {
+            payment_hash: Some(payment_hash),
+            amount_sat: None,
+        },
+    ))
+    .map_err(|e| ApiError::SerializeErr(e.to_string()))?;
+
+    Ok(PushNotificationData {
+        title: None,
+        body: None,
+        data,
+        priority: Priority::High,
+        content_available: true,
+    })
+}
+
 fn build_receive_notification(raw_vtxo: &[u8]) -> Result<Option<PushNotificationData>, ApiError> {
     let mut cursor = std::io::Cursor::new(raw_vtxo);
     let vtxo: Vtxo<Full> = Vtxo::decode(&mut cursor)
@@ -509,22 +577,17 @@ fn build_receive_notification(raw_vtxo: &[u8]) -> Result<Option<PushNotification
 
     let amount_sats = vtxo.amount().to_sat();
 
-    let body = match vtxo.policy_type() {
-        VtxoPolicyKind::Pubkey => Some(format!("You received {} sats via Ark.", amount_sats)),
-        VtxoPolicyKind::ServerHtlcRecv => {
-            Some(format!("You received {} sats via Lightning.", amount_sats))
-        }
-        VtxoPolicyKind::ServerHtlcSend => None,
-        _ => None,
-    };
-
-    Ok(body.map(|body| PushNotificationData {
-        title: Some("Payment received".to_string()),
-        body: Some(body),
-        data: "{}".to_string(),
-        priority: Priority::High,
-        content_available: false,
-    }))
+    match vtxo.policy_type() {
+        VtxoPolicyKind::Pubkey => Ok(Some(PushNotificationData {
+            title: Some("Payment received".to_string()),
+            body: Some(format!("You received {} sats via Ark.", amount_sats)),
+            data: "{}".to_string(),
+            priority: Priority::High,
+            content_available: false,
+        })),
+        VtxoPolicyKind::ServerHtlcRecv | VtxoPolicyKind::ServerHtlcSend => Ok(None),
+        _ => Ok(None),
+    }
 }
 
 async fn renew_mailbox_claim(
@@ -623,17 +686,38 @@ mod tests {
     }
 
     #[test]
-    fn build_receive_notification_for_lightning_receive_vtxo() {
+    fn build_lightning_claim_notification_for_incoming_lightning_payment() {
+        let payment_hash = "00".repeat(32);
+
+        let notification = build_lightning_claim_notification(payment_hash.clone())
+            .expect("lightning claim notification should build");
+
+        assert_eq!(notification.title, None);
+        assert_eq!(notification.body, None);
+        assert_eq!(notification.priority, Priority::High);
+        assert!(notification.content_available);
+
+        let data: NotificationData =
+            serde_json::from_str(&notification.data).expect("notification data should decode");
+        assert!(matches!(
+            data,
+            NotificationData::LightningClaimRequest(LightningClaimRequestNotification {
+                payment_hash: Some(hash),
+                amount_sat: None,
+            }) if hash == payment_hash
+        ));
+    }
+
+    #[test]
+    fn build_receive_notification_skips_lightning_receive_vtxo() {
         let raw = VTXO_VECTORS.round2_vtxo.serialize();
 
-        let notification = build_receive_notification(&raw)
-            .expect("lightning receive vtxo should decode")
-            .expect("lightning receive vtxo should notify");
+        let notification =
+            build_receive_notification(&raw).expect("lightning receive vtxo should decode");
 
-        assert_eq!(notification.title.as_deref(), Some("Payment received"));
-        assert_eq!(
-            notification.body.as_deref(),
-            Some("You received 10000 sats via Lightning.")
+        assert!(
+            notification.is_none(),
+            "lightning receive should use its mailbox event"
         );
     }
 

--- a/server/src/mailbox_worker.rs
+++ b/server/src/mailbox_worker.rs
@@ -25,7 +25,7 @@ use crate::{
     AppState,
     db::mailbox_authorization_repo::{ActiveMailboxAuthorization, MailboxAuthorizationRepository},
     errors::ApiError,
-    push::{PushNotificationData, send_push_notification},
+    push::{PushNotificationData, send_expo_push_notification, send_push_notification},
     types::{LightningClaimRequestNotification, NotificationData},
 };
 
@@ -485,7 +485,7 @@ async fn process_mailbox_message(
                 "mailbox incoming lightning payment received; sending claim push notification"
             );
 
-            send_push_notification(
+            send_expo_push_notification(
                 app_state.clone(),
                 notification,
                 Some(mailbox.pubkey.to_string()),

--- a/server/src/push.rs
+++ b/server/src/push.rs
@@ -18,6 +18,18 @@ fn is_expo_token(token: &str) -> bool {
             .is_match(token)
 }
 
+fn notification_type_for_log(data: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(data)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("notification_type")
+                .and_then(|notification_type| notification_type.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
 #[derive(Serialize, Clone, Debug)]
 pub struct PushNotificationData {
     pub title: Option<String>,
@@ -206,12 +218,18 @@ async fn send_push_notification_internal(
     } else {
         push_token_repo.find_all().await?
     };
+    let notification_type = notification_type_for_log(&data.data);
 
     if push_tokens.is_empty() {
+        tracing::warn!(
+            notification_type,
+            "send_push_notification: no push tokens found for notification"
+        );
         return Ok(());
     }
 
-    tracing::debug!(
+    tracing::info!(
+        notification_type,
         "send_push_notification: Sending to {} tokens",
         push_tokens.len()
     );
@@ -282,9 +300,9 @@ async fn send_push_notification_internal(
             .await;
     }
 
-    tracing::debug!(
-        "send_push_notification: Sent push notification with data: {:?}",
-        data.data
+    tracing::info!(
+        notification_type,
+        "send_push_notification: Sent push notification"
     );
 
     Ok(())

--- a/server/src/push.rs
+++ b/server/src/push.rs
@@ -57,7 +57,24 @@ pub async fn send_push_notification(
     data: PushNotificationData,
     pubkey: Option<String>,
 ) -> anyhow::Result<(), ApiError> {
-    send_push_notification_internal(app_state, data, pubkey).await
+    send_push_notification_internal(app_state, data, pubkey, true).await
+}
+
+pub async fn send_expo_push_notification(
+    app_state: AppState,
+    data: PushNotificationData,
+    pubkey: Option<String>,
+) -> anyhow::Result<(), ApiError> {
+    send_push_notification_internal(app_state, data, pubkey, false).await
+}
+
+pub async fn has_expo_push_token(app_state: &AppState, pubkey: &str) -> Result<bool, ApiError> {
+    let push_token_repo = PushTokenRepository::new(&app_state.db_pool);
+    let Some(push_token) = push_token_repo.find_by_pubkey(pubkey).await? else {
+        return Ok(false);
+    };
+
+    Ok(is_expo_token(&push_token))
 }
 
 pub async fn send_push_notification_with_unique_k1(
@@ -201,6 +218,7 @@ async fn send_push_notification_internal(
     app_state: AppState,
     data: PushNotificationData,
     pubkey: Option<String>,
+    allow_unified_push: bool,
 ) -> anyhow::Result<(), ApiError> {
     let expo = Expo::new(ExpoClientOptions {
         access_token: Some(app_state.config.expo_access_token.clone()),
@@ -236,6 +254,24 @@ async fn send_push_notification_internal(
 
     let (expo_tokens, unified_tokens): (Vec<_>, Vec<_>) =
         push_tokens.into_iter().partition(|t| is_expo_token(t));
+
+    if !allow_unified_push {
+        if !unified_tokens.is_empty() {
+            tracing::info!(
+                notification_type,
+                skipped_unified_push_tokens = unified_tokens.len(),
+                "send_push_notification: skipping UnifiedPush tokens for Expo-only notification"
+            );
+        }
+
+        if expo_tokens.is_empty() {
+            tracing::warn!(
+                notification_type,
+                "send_push_notification: no Expo push tokens found for Expo-only notification"
+            );
+            return Ok(());
+        }
+    }
 
     if !expo_tokens.is_empty() {
         let chunks = expo_tokens
@@ -276,7 +312,7 @@ async fn send_push_notification_internal(
             .await;
     }
 
-    if !unified_tokens.is_empty() {
+    if allow_unified_push && !unified_tokens.is_empty() {
         let ntfy_auth = app_state.config.ntfy_auth_token.clone();
         let data_clone = data.clone();
         stream::iter(unified_tokens)

--- a/server/src/routes/public_api_v0.rs
+++ b/server/src/routes/public_api_v0.rs
@@ -18,7 +18,10 @@ use crate::{
     AppState,
     auth::mint_access_token,
     cache::email_verification_store::EmailVerificationStore,
-    db::{device_repo::DeviceRepository, user_repo::UserRepository},
+    db::{
+        device_repo::DeviceRepository, mailbox_authorization_repo::MailboxAuthorizationRepository,
+        user_repo::UserRepository,
+    },
     errors::ApiError,
     push::{PushNotificationData, has_expo_push_token, send_expo_push_notification},
     types::{
@@ -247,6 +250,20 @@ pub async fn lnurlp_request(
         );
         return Err(ApiError::InvalidArgument(
             "Lightning payments are not supported on this device right now.".to_string(),
+        ));
+    }
+
+    let mailbox_repo = MailboxAuthorizationRepository::new(&state.db_pool);
+    if !mailbox_repo
+        .has_active_authorization(&pubkey, chrono::Utc::now().timestamp())
+        .await?
+    {
+        tracing::warn!(
+            pubkey = %pubkey,
+            "Lightning LNURL invoice request rejected because user has no active mailbox authorization"
+        );
+        return Err(ApiError::InvalidArgument(
+            "Lightning payments require mailbox notifications to be enabled.".to_string(),
         ));
     }
 

--- a/server/src/routes/public_api_v0.rs
+++ b/server/src/routes/public_api_v0.rs
@@ -20,7 +20,7 @@ use crate::{
     cache::email_verification_store::EmailVerificationStore,
     db::{device_repo::DeviceRepository, user_repo::UserRepository},
     errors::ApiError,
-    push::{PushNotificationData, send_push_notification},
+    push::{PushNotificationData, has_expo_push_token, send_expo_push_notification},
     types::{
         AppVersionCheckPayload, AppVersionInfo, AuthEvent, AuthLoginPayload, AuthLoginResponse,
         AuthenticatedUser, EmailVerificationResponse, LightningInvoiceRequestNotification,
@@ -240,6 +240,16 @@ pub async fn lnurlp_request(
         ));
     }
 
+    if !has_expo_push_token(&state, &pubkey).await? {
+        tracing::warn!(
+            pubkey = %pubkey,
+            "Lightning LNURL invoice request rejected because user has no Expo push token"
+        );
+        return Err(ApiError::InvalidArgument(
+            "Lightning payments are not supported on this device right now.".to_string(),
+        ));
+    }
+
     // Generate a unique transaction ID for this payment request
     let transaction_id = Uuid::new_v4().to_string();
 
@@ -264,7 +274,7 @@ pub async fn lnurlp_request(
             priority: Priority::High,
             content_available: true,
         };
-        if let Err(e) = send_push_notification(state_clone, data, Some(pubkey)).await {
+        if let Err(e) = send_expo_push_notification(state_clone, data, Some(pubkey)).await {
             tracing::error!("Failed to send push notification: {}", e);
         }
     });

--- a/server/src/tests/public_api_v0.rs
+++ b/server/src/tests/public_api_v0.rs
@@ -1,8 +1,13 @@
+use crate::db::{
+    mailbox_authorization_repo::MailboxAuthorizationRepository,
+    push_token_repo::PushTokenRepository,
+};
 use crate::routes::public_api_v0::{GetK1, LnurlpDefaultResponse};
-use crate::tests::common::setup_public_test_app;
-use crate::types::{AppVersionCheckPayload, AppVersionInfo};
+use crate::tests::common::{TestUser, create_test_user, setup_public_test_app};
+use crate::types::{ApiErrorResponse, AppVersionCheckPayload, AppVersionInfo};
 use axum::body::Body;
 use axum::http::{self, Request, StatusCode};
+use chrono::Utc;
 use http_body_util::BodyExt;
 use tower::ServiceExt;
 
@@ -36,6 +41,80 @@ async fn test_lnurlp_request_default() {
 
     assert_eq!(res.tag, "payRequest");
     assert_eq!(res.callback, "https://localhost/.well-known/lnurlp/test");
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_lnurlp_invoice_request_rejects_missing_mailbox_authorization() {
+    let (app, app_state, _guard) = setup_public_test_app().await;
+    let user = TestUser::new();
+    let pubkey = user.pubkey().to_string();
+    create_test_user(&app_state, &user, None).await;
+
+    PushTokenRepository::new(&app_state.db_pool)
+        .upsert(&pubkey, "ExpoPushToken[test-token]")
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/.well-known/lnurlp/test?amount=330000")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let err: ApiErrorResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(err.code, "INVALID_ARGUMENT");
+    assert_eq!(
+        err.message,
+        "Lightning payments require mailbox notifications to be enabled."
+    );
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_lnurlp_invoice_request_rejects_expired_mailbox_authorization() {
+    let (app, app_state, _guard) = setup_public_test_app().await;
+    let user = TestUser::new();
+    let pubkey = user.pubkey().to_string();
+    create_test_user(&app_state, &user, None).await;
+
+    PushTokenRepository::new(&app_state.db_pool)
+        .upsert(&pubkey, "ExpoPushToken[test-token]")
+        .await
+        .unwrap();
+    MailboxAuthorizationRepository::new(&app_state.db_pool)
+        .upsert(&pubkey, "deadbeef", "cafebabe", Utc::now().timestamp() - 60)
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/.well-known/lnurlp/test?amount=330000")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let err: ApiErrorResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(err.code, "INVALID_ARGUMENT");
+    assert_eq!(
+        err.message,
+        "Lightning payments require mailbox notifications to be enabled."
+    );
 }
 
 #[tracing_test::traced_test]

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -310,6 +310,14 @@ pub struct LightningInvoiceRequestNotification {
 
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]
 #[ts(export, export_to = "../../client/src/types/serverTypes.ts")]
+pub struct LightningClaimRequestNotification {
+    pub payment_hash: Option<String>,
+    #[ts(type = "number | null")]
+    pub amount_sat: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS, Clone)]
+#[ts(export, export_to = "../../client/src/types/serverTypes.ts")]
 pub struct BackupTriggerNotification {
     pub notification_k1: String,
 }
@@ -386,6 +394,7 @@ impl NotificationRequestData {
 pub enum NotificationData {
     Maintenance(MaintenanceNotification),
     LightningInvoiceRequest(LightningInvoiceRequestNotification),
+    LightningClaimRequest(LightningClaimRequestNotification),
     BackupTrigger(BackupTriggerNotification),
     Heartbeat(HeartbeatNotification),
 }
@@ -402,12 +411,14 @@ impl NotificationData {
     ///
     /// # Examples
     /// - `BackupTrigger` → `"backup_trigger"`
+    /// - `LightningClaimRequest` → `"lightning_claim_request"`
     /// - `LightningInvoiceRequest` → `"lightning_invoice_request"`
     /// - `Maintenance` → `"maintenance"`
     pub fn notification_type(&self) -> &'static str {
         match self {
             NotificationData::Maintenance(_) => "maintenance",
             NotificationData::LightningInvoiceRequest(_) => "lightning_invoice_request",
+            NotificationData::LightningClaimRequest(_) => "lightning_claim_request",
             NotificationData::BackupTrigger(_) => "backup_trigger",
             NotificationData::Heartbeat(_) => "heartbeat",
         }
@@ -426,7 +437,9 @@ impl NotificationData {
         match self {
             NotificationData::Maintenance(n) => n.notification_k1 = k1,
             NotificationData::BackupTrigger(n) => n.notification_k1 = k1,
-            NotificationData::Heartbeat(_) | NotificationData::LightningInvoiceRequest(_) => {}
+            NotificationData::Heartbeat(_)
+            | NotificationData::LightningInvoiceRequest(_)
+            | NotificationData::LightningClaimRequest(_) => {}
         }
     }
 }


### PR DESCRIPTION
## Summary

- Handle `IncomingLightningPayment` mailbox messages on the server and send a second silent `lightning_claim_request` push with the payment hash.
- Keep the first LNURL push focused on invoice generation; the app no longer waits in that task for payment settlement.
- Wake the app from the claim push, claim pending Lightning receives, refresh widgets, and schedule a local Expo notification after a successful claim.
- Share notification handling across background and foreground delivery paths so iOS active/background behavior is covered.
- Add server/client logging around mailbox receive, silent push dispatch, Lightning claim success, and local notification scheduling.
- Regenerate shared TS types for the new `lightning_claim_request` payload.

## Validation

- `cargo fmt --check`
- `cargo test types::export_bindings_`
- `cargo test mailbox_worker::tests::`
- `bun client check`
- `git diff --check`