### PR TITLE
Add support for unilateral exit in the wallet

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
         "react-native-gesture-handler": "~2.30.0",
         "react-native-keychain": "^10.0.0",
         "react-native-mmkv": "^4.3.1",
-        "react-native-nitro-ark": "0.0.106",
+        "react-native-nitro-ark": "0.0.109",
         "react-native-nitro-modules": "0.35.6",
         "react-native-qrcode-svg": "^6.3.21",
         "react-native-quick-base64": "^2.2.2",
@@ -1674,7 +1674,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@4.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg=="],
 
-    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.106", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-ZB3glWk6zB7SeRnWDo3z2pI+3iQk0IRSPSZCtwbr9e+YXfuY6ZqYs1lmMGF8ufejcnxgcK3NrdtXjFZfJjtkTQ=="],
+    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.109", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-ukOQrIKS4AtUsNDW3S/PVLmf04J/ABI/WtDeW+Qv418TiwcPdmxii6/CHy5w8vctTxMp0XwemxMu0RtS7eTo+g=="],
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.35.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g=="],
 

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -245,7 +245,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.14.1)
   - hermes-engine/Pre-built (0.14.1)
   - MMKVCore (2.4.0)
-  - NitroArk (0.0.106):
+  - NitroArk (0.0.109):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -3133,7 +3133,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 32e9ed0301d0fcbc1b2b341dd7fcbf291f51eb83
   hermes-engine: 9288d96d73c49b8a0e1a8af173848fff3c6852e6
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: 169740e33316c30b89df7f2e3e067adeb192a155
+  NitroArk: 6763c72506f2ce173da4c46c32afd352a574991d
   NitroMmkv: 0145b5b7e648fa8e69f2bcb42f059d1d906bccc6
   NitroModules: 1985a9de2cf4a6de1265c5936b7cc9d7f30e45d8
   NoahTools: 0b8d872de81b6ad62e24902983300c5cc53dbf57

--- a/client/package.json
+++ b/client/package.json
@@ -104,7 +104,7 @@
     "react-native-gesture-handler": "~2.30.0",
     "react-native-keychain": "^10.0.0",
     "react-native-mmkv": "^4.3.1",
-    "react-native-nitro-ark": "0.0.106",
+    "react-native-nitro-ark": "0.0.109",
     "react-native-nitro-modules": "0.35.6",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-quick-base64": "^2.2.2",

--- a/client/src/Navigators.tsx
+++ b/client/src/Navigators.tsx
@@ -48,6 +48,8 @@ import { getMnemonic } from "~/lib/crypto";
 import { walletDataExists, clearStaleKeychain } from "~/lib/walletApi";
 import VTXOsScreen, { type VTXOWithStatus } from "~/screens/VTXOsScreen";
 import VTXODetailScreen from "~/screens/VTXODetailScreen";
+import UnilateralExitScreen from "~/screens/UnilateralExitScreen";
+import ExitVtxoDetailScreen from "~/screens/ExitVtxoDetailScreen";
 import PushNotificationsRequiredScreen from "~/screens/PushNotificationsRequiredScreen";
 import UnifiedPushScreen from "~/screens/UnifiedPushScreen";
 import {
@@ -74,6 +76,8 @@ export type SettingsStackParamList = {
   ArkInfo: undefined;
   VTXOs: undefined;
   VTXODetail: { vtxo: VTXOWithStatus };
+  UnilateralExit: { vtxoIds?: string[] } | undefined;
+  ExitVtxoDetail: { vtxoId: string };
   NoahStory: undefined;
   UnifiedPush: { fromOnboarding?: boolean } | undefined;
   Debug: undefined;
@@ -131,6 +135,16 @@ const SettingsStackNav = () => (
     <Stack.Screen
       name="VTXODetail"
       component={VTXODetailScreen}
+      options={{ animation: "default" }}
+    />
+    <Stack.Screen
+      name="UnilateralExit"
+      component={UnilateralExitScreen}
+      options={{ animation: "default" }}
+    />
+    <Stack.Screen
+      name="ExitVtxoDetail"
+      component={ExitVtxoDetailScreen}
       options={{ animation: "default" }}
     />
     <Stack.Screen name="NoahStory" component={NoahStoryScreen} options={{ animation: "default" }} />

--- a/client/src/hooks/useUnilateralExit.ts
+++ b/client/src/hooks/useUnilateralExit.ts
@@ -1,0 +1,248 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { queryClient } from "~/queryClient";
+import { useAlert } from "~/contexts/AlertProvider";
+import { useWalletStore } from "~/store/walletStore";
+import { getBlockHeight } from "~/hooks/useMarketData";
+import {
+  allClaimableAtHeight,
+  claimExits,
+  getExitStatus,
+  getExitVtxos,
+  hasPendingExits,
+  listClaimable,
+  pendingExitTotal,
+  progressExits,
+  startExitForEntireWallet,
+  startExitForVtxos,
+  syncExit,
+  type ExitClaimResult,
+} from "~/lib/exitApi";
+import { getVtxos } from "~/lib/walletApi";
+import type { Result } from "neverthrow";
+import type {
+  ExitProgressStatusResult,
+  ExitStatusResult,
+  ExitVtxoResult,
+} from "react-native-nitro-ark";
+import logger from "~/lib/log";
+
+const log = logger("useUnilateralExit");
+
+export type ExitOverview = {
+  exits: ExitVtxoResult[];
+  statuses: Record<string, ExitStatusResult | undefined>;
+  claimable: ExitVtxoResult[];
+  spendableVtxoCount: number;
+  spendableVtxoTotal: number;
+  hasPending: boolean;
+  pendingTotal: number;
+  allClaimableAtHeight?: number;
+  blockHeight?: number;
+};
+
+export type ClaimExitsVariables = {
+  vtxoIds: string[];
+  destinationAddress: string;
+  feeRateSatPerKvb?: number;
+};
+
+const invalidateExitQueries = async () => {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["exit-overview"] }),
+    queryClient.invalidateQueries({ queryKey: ["balance"] }),
+    queryClient.invalidateQueries({ queryKey: ["vtxos"] }),
+    queryClient.invalidateQueries({ queryKey: ["getBlockHeight"] }),
+  ]);
+};
+
+const readResult = <T>(result: Result<T, Error>): T => {
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+export function useExitOverview() {
+  const { isInitialized } = useWalletStore();
+
+  return useQuery({
+    queryKey: ["exit-overview"],
+    queryFn: async (): Promise<ExitOverview> => {
+      log.d("Loading exit overview");
+      readResult(await syncExit());
+
+      const [
+        exitsResult,
+        claimableResult,
+        hasPendingResult,
+        pendingTotalResult,
+        allClaimableAtHeightResult,
+        spendableVtxosResult,
+        blockHeightResult,
+      ] = await Promise.all([
+        getExitVtxos(),
+        listClaimable(),
+        hasPendingExits(),
+        pendingExitTotal(),
+        allClaimableAtHeight(),
+        getVtxos(),
+        getBlockHeight(),
+      ]);
+
+      const exits = readResult(exitsResult);
+      const spendableVtxos = readResult(spendableVtxosResult).filter(
+        (vtxo) => vtxo.state === "Spendable",
+      );
+      const statusResults = await Promise.all(
+        exits.map(async (exit) => ({
+          vtxoId: exit.vtxo_id,
+          result: await getExitStatus(exit.vtxo_id, true, false),
+        })),
+      );
+
+      const statuses = statusResults.reduce<Record<string, ExitStatusResult | undefined>>(
+        (acc, item) => {
+          acc[item.vtxoId] = readResult(item.result);
+          return acc;
+        },
+        {},
+      );
+
+      const overview = {
+        exits,
+        statuses,
+        claimable: readResult(claimableResult),
+        spendableVtxoCount: spendableVtxos.length,
+        spendableVtxoTotal: spendableVtxos.reduce((total, vtxo) => total + vtxo.amount, 0),
+        hasPending: readResult(hasPendingResult),
+        pendingTotal: readResult(pendingTotalResult),
+        allClaimableAtHeight: readResult(allClaimableAtHeightResult),
+        blockHeight: readResult(blockHeightResult),
+      };
+
+      log.d("Loaded exit overview", [
+        {
+          exit_count: overview.exits.length,
+          claimable_count: overview.claimable.length,
+          spendable_vtxo_count: overview.spendableVtxoCount,
+          spendable_vtxo_total_sat: overview.spendableVtxoTotal,
+          has_pending: overview.hasPending,
+          pending_total_sat: overview.pendingTotal,
+          all_claimable_at_height: overview.allClaimableAtHeight,
+          block_height: overview.blockHeight,
+        },
+      ]);
+
+      return overview;
+    },
+    enabled: isInitialized,
+    retry: false,
+    refetchInterval: (query) => (query.state.data?.hasPending ? 60_000 : false),
+  });
+}
+
+export function useStartWalletExit() {
+  const { showAlert } = useAlert();
+
+  return useMutation<void, Error>({
+    mutationFn: async () => {
+      log.i("User requested wallet exit start");
+      readResult(await startExitForEntireWallet());
+    },
+    onSuccess: async () => {
+      await invalidateExitQueries();
+      showAlert({
+        title: "Exit Started",
+        description: "Your wallet exits have been registered. Progress them until claimable.",
+      });
+    },
+    onError: (error) => {
+      log.e("Wallet exit start mutation failed", [error]);
+      showAlert({ title: "Failed to Start Exit", description: error.message });
+    },
+  });
+}
+
+export function useStartVtxoExit() {
+  const { showAlert } = useAlert();
+
+  return useMutation<void, Error, string[]>({
+    mutationFn: async (vtxoIds) => {
+      log.i("User requested selected VTXO exit start", [{ vtxo_ids: vtxoIds }]);
+      readResult(await startExitForVtxos(vtxoIds));
+    },
+    onSuccess: async () => {
+      await invalidateExitQueries();
+      showAlert({
+        title: "Exit Started",
+        description: "The selected VTXOs have been registered for emergency exit.",
+      });
+    },
+    onError: (error) => {
+      log.e("Selected VTXO exit start mutation failed", [error]);
+      showAlert({ title: "Failed to Start Exit", description: error.message });
+    },
+  });
+}
+
+export function useProgressExits() {
+  const { showAlert } = useAlert();
+
+  return useMutation<ExitProgressStatusResult[], Error, number | undefined>({
+    mutationFn: async (feeRateSatPerKvb) => {
+      log.i("User requested exit progress", [{ fee_rate_sat_per_kvb: feeRateSatPerKvb }]);
+      return readResult(await progressExits(feeRateSatPerKvb));
+    },
+    onSuccess: async () => {
+      await invalidateExitQueries();
+      showAlert({
+        title: "Exit Progressed",
+        description: "Exit status has been refreshed. Some transactions may have been broadcast.",
+      });
+    },
+    onError: (error) => {
+      log.e("Exit progress mutation failed", [error]);
+      showAlert({ title: "Failed to Progress Exit", description: error.message });
+    },
+  });
+}
+
+export function useSyncExits() {
+  const { showAlert } = useAlert();
+
+  return useMutation<void, Error>({
+    mutationFn: async () => {
+      log.i("User requested exit sync");
+      readResult(await syncExit());
+    },
+    onSuccess: async () => {
+      await invalidateExitQueries();
+    },
+    onError: (error) => {
+      log.e("Exit sync mutation failed", [error]);
+      showAlert({ title: "Failed to Sync Exits", description: error.message });
+    },
+  });
+}
+
+export function useClaimExits() {
+  const { showAlert } = useAlert();
+
+  return useMutation<ExitClaimResult, Error, ClaimExitsVariables>({
+    mutationFn: async (variables) => {
+      log.i("User requested exit claim", [{ vtxo_ids: variables.vtxoIds }]);
+      return readResult(await claimExits(variables));
+    },
+    onSuccess: async (result) => {
+      await invalidateExitQueries();
+      showAlert({
+        title: "Claim Broadcasted",
+        description: `Claim transaction broadcasted: ${result.txid}`,
+      });
+    },
+    onError: (error) => {
+      log.e("Exit claim mutation failed", [error]);
+      showAlert({ title: "Failed to Claim Exits", description: error.message });
+    },
+  });
+}

--- a/client/src/lib/exitApi.ts
+++ b/client/src/lib/exitApi.ts
@@ -1,0 +1,326 @@
+import * as NitroArk from "react-native-nitro-ark";
+import { err, ok, Result, ResultAsync } from "neverthrow";
+import logger from "~/lib/log";
+import type {
+  ExitProgressStatusResult,
+  ExitStateDetails,
+  ExitStatusResult,
+  ExitVtxoResult,
+} from "react-native-nitro-ark";
+
+const log = logger("exitApi");
+
+export type ExitClaimResult = {
+  txid: string;
+  txHex: string;
+};
+
+const summarizeVtxoId = (vtxoId: string) => vtxoId;
+
+const summarizeBlockRef = (block?: { height: number; hash: string }) =>
+  block ? { height: block.height, hash: block.hash } : undefined;
+
+const summarizeStateDetails = (details: ExitStateDetails) => ({
+  kind: details.kind,
+  tip_height: details.tip_height,
+  transaction_count: details.transactions?.length ?? 0,
+  transaction_statuses: details.transactions?.map((tx) => ({
+    txid: tx.txid,
+    status: tx.status.kind,
+    child_txid: tx.status.child_txid,
+    block: summarizeBlockRef(tx.status.block),
+  })),
+  confirmed_block: summarizeBlockRef(details.confirmed_block),
+  claimable_height: details.claimable_height,
+  claimable_since: summarizeBlockRef(details.claimable_since),
+  last_scanned_block: summarizeBlockRef(details.last_scanned_block),
+  claim_txid: details.claim_txid,
+  txid: details.txid,
+  block: summarizeBlockRef(details.block),
+});
+
+const summarizeExit = (exit: ExitVtxoResult) => ({
+  vtxo_id: summarizeVtxoId(exit.vtxo_id),
+  amount_sat: exit.amount_sat,
+  state: exit.state,
+  state_details: summarizeStateDetails(exit.state_details),
+  is_claimable: exit.is_claimable,
+  is_initialized: exit.is_initialized,
+  txids: exit.txids,
+  history: exit.history,
+  history_details: exit.history_details.map(summarizeStateDetails),
+});
+
+const summarizeProgress = (progress: ExitProgressStatusResult) => ({
+  vtxo_id: summarizeVtxoId(progress.vtxo_id),
+  state: progress.state,
+  state_details: summarizeStateDetails(progress.state_details),
+  error: progress.error,
+});
+
+export const startExitForEntireWallet = async (): Promise<Result<void, Error>> => {
+  log.i("Starting exit for entire wallet");
+  const result = await ResultAsync.fromPromise(
+    NitroArk.startExitForEntireWallet(),
+    (e) => e as Error,
+  );
+
+  if (result.isErr()) {
+    log.e("Failed to start exit for entire wallet", [result.error]);
+  } else {
+    log.i("Started exit for entire wallet");
+  }
+  return result;
+};
+
+export const startExitForVtxos = async (vtxoIds: string[]): Promise<Result<void, Error>> => {
+  log.i("Starting exit for selected VTXOs", [{ vtxo_ids: vtxoIds }]);
+  const result = await ResultAsync.fromPromise(NitroArk.startExitForVtxos(vtxoIds), (e) => e as Error);
+
+  if (result.isErr()) {
+    log.e("Failed to start exit for selected VTXOs", [{ vtxo_ids: vtxoIds }, result.error]);
+  } else {
+    log.i("Started exit for selected VTXOs", [{ vtxo_ids: vtxoIds }]);
+  }
+  return result;
+};
+
+export const syncExit = async (): Promise<Result<void, Error>> => {
+  log.d("Syncing exits with progress allowed");
+  const result = await ResultAsync.fromPromise(NitroArk.syncExit(), (e) => e as Error);
+
+  if (result.isErr()) {
+    log.e("Failed to sync exits", [result.error]);
+  } else {
+    log.d("Synced exits");
+  }
+  return result;
+};
+
+export const syncNoProgress = async (): Promise<Result<void, Error>> => {
+  log.d("Syncing exits without progress");
+  const result = await ResultAsync.fromPromise(NitroArk.syncNoProgress(), (e) => e as Error);
+
+  if (result.isErr()) {
+    log.e("Failed to sync exits without progress", [result.error]);
+  } else {
+    log.d("Synced exits without progress");
+  }
+  return result;
+};
+
+export const progressExits = async (
+  feeRateSatPerKvb?: number,
+): Promise<Result<ExitProgressStatusResult[], Error>> => {
+  log.i("Progressing exits", [{ fee_rate_sat_per_kvb: feeRateSatPerKvb }]);
+
+  const syncResult = await syncNoProgress();
+  if (syncResult.isErr()) {
+    log.e("Failed to sync exits before progressing", [
+      { fee_rate_sat_per_kvb: feeRateSatPerKvb },
+      syncResult.error,
+    ]);
+    return err(syncResult.error);
+  }
+
+  const result = await ResultAsync.fromPromise(
+    NitroArk.progressExits(feeRateSatPerKvb),
+    (e) => e as Error,
+  );
+
+  if (result.isErr()) {
+    log.e("Failed to progress exits", [{ fee_rate_sat_per_kvb: feeRateSatPerKvb }, result.error]);
+    return result;
+  }
+
+  const progress = result.value.map(summarizeProgress);
+  const failures = progress.filter((item) => item.error);
+  log.i("Exit progress result", [{ count: progress.length, progress }]);
+
+  if (failures.length > 0) {
+    log.w("Some exits failed to progress", [{ failures }]);
+  }
+
+  return result;
+};
+
+export const getExitVtxos = async (): Promise<Result<ExitVtxoResult[], Error>> => {
+  const result = await ResultAsync.fromPromise(NitroArk.getExitVtxos(), (e) => e as Error);
+
+  if (result.isErr()) {
+    log.e("Failed to get exit VTXOs", [result.error]);
+  } else {
+    log.d("Loaded exit VTXOs", [
+      { count: result.value.length, exits: result.value.map(summarizeExit) },
+    ]);
+  }
+  return result;
+};
+
+export const listClaimable = async (): Promise<Result<ExitVtxoResult[], Error>> => {
+  const result = await ResultAsync.fromPromise(NitroArk.listClaimable(), (e) => e as Error);
+
+  if (result.isErr()) {
+    log.e("Failed to list claimable exits", [result.error]);
+  } else {
+    log.d("Loaded claimable exits", [
+      { count: result.value.length, exits: result.value.map(summarizeExit) },
+    ]);
+  }
+  return result;
+};
+
+export const getExitStatus = async (
+  vtxoId: string,
+  includeHistory = true,
+  includeTransactions = false,
+): Promise<Result<ExitStatusResult | undefined, Error>> => {
+  const result = await ResultAsync.fromPromise(
+    NitroArk.getExitStatus(vtxoId, includeHistory, includeTransactions),
+    (e) => e as Error,
+  );
+
+  if (result.isErr()) {
+    log.e("Failed to get exit status", [
+      { vtxo_id: summarizeVtxoId(vtxoId), includeHistory, includeTransactions },
+      result.error,
+    ]);
+  } else {
+    log.d("Loaded exit status", [
+      {
+        vtxo_id: summarizeVtxoId(vtxoId),
+        state: result.value?.state,
+        state_details: result.value?.state_details
+          ? summarizeStateDetails(result.value.state_details)
+          : undefined,
+        history: result.value?.history,
+        history_details: result.value?.history_details.map(summarizeStateDetails),
+        transaction_count: result.value?.transactions.length ?? 0,
+      },
+    ]);
+  }
+  return result;
+};
+
+export const hasPendingExits = async (): Promise<Result<boolean, Error>> => {
+  const result = await ResultAsync.fromPromise(NitroArk.hasPendingExits(), (e) => e as Error);
+
+  if (result.isErr()) {
+    log.e("Failed to check pending exits", [result.error]);
+  } else {
+    log.d("Checked pending exits", [{ has_pending: result.value }]);
+  }
+  return result;
+};
+
+export const pendingExitTotal = async (): Promise<Result<number, Error>> => {
+  const result = await ResultAsync.fromPromise(NitroArk.pendingExitTotal(), (e) => e as Error);
+
+  if (result.isErr()) {
+    log.e("Failed to get pending exit total", [result.error]);
+  } else {
+    log.d("Loaded pending exit total", [{ amount_sat: result.value }]);
+  }
+  return result;
+};
+
+export const allClaimableAtHeight = async (): Promise<Result<number | undefined, Error>> => {
+  const result = await ResultAsync.fromPromise(NitroArk.allClaimableAtHeight(), (e) => e as Error);
+
+  if (result.isErr()) {
+    log.e("Failed to get all-claimable height", [result.error]);
+  } else {
+    log.d("Loaded all-claimable height", [{ height: result.value }]);
+  }
+  return result;
+};
+
+export const drainExits = async (
+  vtxoIds: string[],
+  destinationAddress: string,
+  feeRateSatPerKvb?: number,
+): Promise<Result<string, Error>> => {
+  log.i("Building exit claim transaction PSBT", [
+    { vtxo_ids: vtxoIds, fee_rate_sat_per_kvb: feeRateSatPerKvb },
+  ]);
+  const result = await ResultAsync.fromPromise(
+    NitroArk.drainExits(vtxoIds, destinationAddress, feeRateSatPerKvb),
+    (e) => e as Error,
+  );
+
+  if (result.isErr()) {
+    log.e("Failed to build exit claim transaction PSBT", [
+      { vtxo_ids: vtxoIds, fee_rate_sat_per_kvb: feeRateSatPerKvb },
+      result.error,
+    ]);
+  } else {
+    log.i("Built exit claim transaction PSBT", [{ vtxo_ids: vtxoIds }]);
+  }
+  return result;
+};
+
+export const extractTransaction = async (psbt: string): Promise<Result<string, Error>> => {
+  log.d("Extracting claim transaction from PSBT");
+  const result = await ResultAsync.fromPromise(NitroArk.extractTransaction(psbt), (e) => e as Error);
+
+  if (result.isErr()) {
+    log.e("Failed to extract claim transaction from PSBT", [result.error]);
+  } else {
+    log.d("Extracted claim transaction from PSBT", [{ tx_hex_length: result.value.length }]);
+  }
+  return result;
+};
+
+export const broadcastTransaction = async (txHex: string): Promise<Result<string, Error>> => {
+  log.i("Broadcasting claim transaction", [{ tx_hex_length: txHex.length }]);
+  const result = await ResultAsync.fromPromise(NitroArk.broadcastTransaction(txHex), (e) => e as Error);
+
+  if (result.isErr()) {
+    log.e("Failed to broadcast claim transaction", [result.error]);
+  } else {
+    log.i("Broadcasted claim transaction", [{ txid: result.value }]);
+  }
+  return result;
+};
+
+export const claimExits = async ({
+  vtxoIds,
+  destinationAddress,
+  feeRateSatPerKvb,
+}: {
+  vtxoIds: string[];
+  destinationAddress: string;
+  feeRateSatPerKvb?: number;
+}): Promise<Result<ExitClaimResult, Error>> => {
+  if (vtxoIds.length === 0) {
+    log.w("Claim exits called with no VTXOs");
+    return err(new Error("No claimable exits selected."));
+  }
+
+  log.i("Claiming exits", [{ vtxo_ids: vtxoIds, fee_rate_sat_per_kvb: feeRateSatPerKvb }]);
+
+  const psbtResult = await drainExits(vtxoIds, destinationAddress, feeRateSatPerKvb);
+  if (psbtResult.isErr()) {
+    return err(psbtResult.error);
+  }
+
+  const txHexResult = await extractTransaction(psbtResult.value);
+  if (txHexResult.isErr()) {
+    return err(txHexResult.error);
+  }
+
+  const txidResult = await broadcastTransaction(txHexResult.value);
+  if (txidResult.isErr()) {
+    return err(txidResult.error);
+  }
+
+  const syncResult = await syncExit();
+  if (syncResult.isErr()) {
+    log.w("Claim transaction broadcasted but exit sync failed", [syncResult.error]);
+  }
+
+  return ok({
+    txid: txidResult.value,
+    txHex: txHexResult.value,
+  });
+};

--- a/client/src/lib/exitTimeline.ts
+++ b/client/src/lib/exitTimeline.ts
@@ -1,0 +1,303 @@
+import type {
+  ExitProgressState,
+  ExitStateDetails,
+  ExitStatusResult,
+  ExitVtxoResult,
+} from "react-native-nitro-ark";
+import { getMempoolTxUrl } from "~/constants";
+
+export const EXIT_STATE_ORDER: ExitProgressState[] = [
+  "Start",
+  "Processing",
+  "AwaitingDelta",
+  "Claimable",
+  "ClaimInProgress",
+  "Claimed",
+];
+
+export const EXIT_STATE_LABELS: Record<ExitProgressState, string> = {
+  Start: "Started",
+  Processing: "Processing",
+  AwaitingDelta: "Waiting",
+  Claimable: "Claimable",
+  ClaimInProgress: "Claiming",
+  Claimed: "Claimed",
+};
+
+export type ExitDetailRow = {
+  label: string;
+  value: string;
+  explorerUrl?: string | null;
+};
+
+export type ExitTimelineItem = {
+  state: ExitProgressState;
+  label: string;
+  count: number;
+  startHeight?: number;
+  endHeight?: number;
+  description: string;
+  details: ExitDetailRow[];
+  isCurrent: boolean;
+};
+
+export const truncateMiddle = (value: string, prefix = 8, suffix = 8) => {
+  if (value.length <= prefix + suffix + 3) {
+    return value;
+  }
+  return `${value.slice(0, prefix)}...${value.slice(-suffix)}`;
+};
+
+export const formatBlockRef = (block?: { height: number; hash: string }) =>
+  block ? `${block.height} (${truncateMiddle(block.hash, 6, 6)})` : undefined;
+
+export const formatBlocksRemaining = (currentHeight?: number, targetHeight?: number) => {
+  if (currentHeight === undefined || targetHeight === undefined) {
+    return undefined;
+  }
+  const remaining = targetHeight - currentHeight;
+  if (remaining <= 0) {
+    return "Now";
+  }
+  return `${remaining} ${remaining === 1 ? "block" : "blocks"}`;
+};
+
+export const formatKind = (kind?: string) =>
+  kind
+    ? kind
+        .split("-")
+        .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+        .join(" ")
+    : undefined;
+
+export const getClaimableHeight = (details?: ExitStateDetails) =>
+  details?.claimable_height ?? details?.claimable_since?.height;
+
+export const isClaimableExit = (exit: ExitVtxoResult, status?: ExitStatusResult) => {
+  const state = status?.state ?? exit.state;
+  const kind = status?.state_details.kind ?? exit.state_details.kind;
+  return exit.is_claimable || state === "Claimable" || kind === "claimable";
+};
+
+export const getProcessingTransactionSummary = (details?: ExitStateDetails) => {
+  const transactions = details?.transactions ?? [];
+  if (transactions.length === 0) {
+    return undefined;
+  }
+
+  const confirmed = transactions.filter((tx) => tx.status.kind === "confirmed").length;
+  const broadcast = transactions.filter((tx) => tx.status.kind === "broadcast-with-cpfp").length;
+  return `${confirmed}/${transactions.length} confirmed, ${broadcast} broadcast`;
+};
+
+export const getExitBlockRows = ({
+  state,
+  details,
+  currentBlockHeight,
+}: {
+  state: ExitProgressState;
+  details?: ExitStateDetails;
+  currentBlockHeight?: number;
+}) => {
+  const rows: ExitDetailRow[] = [];
+  const addRow = (label: string, value?: string | number, txid?: string) => {
+    if (value !== undefined && value !== "") {
+      rows.push({ label, value: `${value}`, explorerUrl: txid ? getMempoolTxUrl(txid) : null });
+    }
+  };
+
+  addRow("Synced tip", details?.tip_height);
+
+  switch (state) {
+    case "Processing":
+      addRow("Transactions", getProcessingTransactionSummary(details));
+      details?.transactions?.forEach((tx, index) => {
+        addRow(`Exit tx ${index + 1}`, truncateMiddle(tx.txid, 10, 10), tx.txid);
+        if (tx.status.child_txid) {
+          addRow(
+            `Child tx ${index + 1}`,
+            truncateMiddle(tx.status.child_txid, 10, 10),
+            tx.status.child_txid,
+          );
+        }
+        if (tx.status.block) {
+          addRow(`Confirmed ${index + 1}`, formatBlockRef(tx.status.block));
+        }
+      });
+      break;
+    case "AwaitingDelta": {
+      const claimableHeight = getClaimableHeight(details);
+      addRow("Confirmed block", formatBlockRef(details?.confirmed_block));
+      addRow("Claimable at", claimableHeight);
+      addRow("Remaining", formatBlocksRemaining(currentBlockHeight, claimableHeight));
+      break;
+    }
+    case "Claimable":
+      addRow("Claimable since", formatBlockRef(details?.claimable_since));
+      addRow("Last scanned", formatBlockRef(details?.last_scanned_block));
+      break;
+    case "ClaimInProgress":
+      addRow("Claimable since", formatBlockRef(details?.claimable_since));
+      addRow(
+        "Claim tx",
+        details?.claim_txid ? truncateMiddle(details.claim_txid, 10, 10) : undefined,
+        details?.claim_txid,
+      );
+      break;
+    case "Claimed":
+      addRow("Claimed block", formatBlockRef(details?.block));
+      addRow(
+        "Claim tx",
+        details?.txid ? truncateMiddle(details.txid, 10, 10) : undefined,
+        details?.txid,
+      );
+      break;
+    default:
+      addRow("State detail", formatKind(details?.kind));
+      break;
+  }
+
+  return rows;
+};
+
+export const getExitStatusText = ({
+  state,
+  details,
+  currentBlockHeight,
+}: {
+  state: ExitProgressState;
+  details?: ExitStateDetails;
+  currentBlockHeight?: number;
+}) => {
+  switch (state) {
+    case "AwaitingDelta": {
+      const claimableHeight = getClaimableHeight(details);
+      const remaining = formatBlocksRemaining(currentBlockHeight, claimableHeight);
+      return claimableHeight
+        ? `Claimable at block ${claimableHeight}${remaining ? ` - ${remaining}` : ""}`
+        : "Waiting for the timelock to mature";
+    }
+    case "Claimable":
+      return details?.claimable_since
+        ? `Claimable since block ${details.claimable_since.height}`
+        : "Ready to claim";
+    case "ClaimInProgress":
+      return details?.claim_txid
+        ? `Claim tx broadcast: ${truncateMiddle(details.claim_txid, 10, 10)}`
+        : "Claim transaction is waiting for confirmation";
+    case "Claimed":
+      return details?.block
+        ? `Claimed in block ${details.block.height}`
+        : "Claim transaction confirmed";
+    case "Processing": {
+      const txSummary = getProcessingTransactionSummary(details);
+      return txSummary ? `Exit transactions: ${txSummary}` : "Preparing or confirming exit transactions";
+    }
+    default:
+      return "Exit has been registered";
+  }
+};
+
+const getTimelineDescription = ({
+  state,
+  details,
+  currentBlockHeight,
+}: {
+  state: ExitProgressState;
+  details?: ExitStateDetails;
+  currentBlockHeight?: number;
+}) => {
+  switch (state) {
+    case "Start":
+      return "Exit tracking was registered for this VTXO.";
+    case "Processing":
+      return getProcessingTransactionSummary(details) ?? "Exit transactions were prepared and monitored.";
+    case "AwaitingDelta": {
+      const claimableHeight = getClaimableHeight(details);
+      const remaining = formatBlocksRemaining(currentBlockHeight, claimableHeight);
+      return claimableHeight
+        ? `Exit transaction confirmed; funds become claimable at block ${claimableHeight}${remaining ? ` (${remaining})` : ""}.`
+        : "Exit transaction confirmed; waiting for the timelock.";
+    }
+    case "Claimable":
+      return details?.claimable_since
+        ? `Funds became sweepable at block ${details.claimable_since.height}.`
+        : "Funds are sweepable to an on-chain address.";
+    case "ClaimInProgress":
+      return details?.claim_txid
+        ? `Final claim transaction ${truncateMiddle(details.claim_txid, 10, 10)} was broadcast.`
+        : "Final claim transaction was broadcast and is waiting for confirmation.";
+    case "Claimed":
+      return details?.block
+        ? `Funds were recovered on-chain in block ${details.block.height}.`
+        : "Funds were recovered on-chain.";
+  }
+};
+
+const getDetailHeight = (details?: ExitStateDetails) =>
+  getClaimableHeight(details) ?? details?.block?.height ?? details?.tip_height;
+
+export const buildExitTimelineItems = ({
+  history,
+  historyDetails,
+  currentState,
+  currentDetails,
+  currentBlockHeight,
+}: {
+  history?: ExitProgressState[];
+  historyDetails?: ExitStateDetails[];
+  currentState: ExitProgressState;
+  currentDetails?: ExitStateDetails;
+  currentBlockHeight?: number;
+}) => {
+  const states =
+    history && history.length > 0 && history.at(-1) !== currentState
+      ? [...history, currentState]
+      : history && history.length > 0
+        ? [...history]
+        : [currentState];
+  const details: (ExitStateDetails | undefined)[] = [...(historyDetails ?? [])];
+  if (details.length < states.length) {
+    details.push(currentDetails);
+  } else if (details.length === states.length) {
+    details[details.length - 1] = currentDetails ?? details[details.length - 1];
+  }
+
+  const items: ExitTimelineItem[] = [];
+  for (let index = 0; index < states.length; index += 1) {
+    const state = states[index];
+    const stateDetails = details[index];
+    const previous = items.at(-1);
+    const height = getDetailHeight(stateDetails);
+
+    if (previous?.state === state) {
+      previous.count += 1;
+      previous.endHeight = height ?? previous.endHeight;
+      previous.description = getTimelineDescription({
+        state,
+        details: stateDetails,
+        currentBlockHeight,
+      });
+      previous.details = getExitBlockRows({ state, details: stateDetails, currentBlockHeight });
+      previous.isCurrent = index === states.length - 1;
+      continue;
+    }
+
+    items.push({
+      state,
+      label: EXIT_STATE_LABELS[state],
+      count: 1,
+      startHeight: height,
+      endHeight: height,
+      description: getTimelineDescription({ state, details: stateDetails, currentBlockHeight }),
+      details: getExitBlockRows({ state, details: stateDetails, currentBlockHeight }),
+      isCurrent: index === states.length - 1,
+    });
+  }
+
+  if (items.length > 0) {
+    items[items.length - 1].isCurrent = true;
+  }
+
+  return items;
+};

--- a/client/src/screens/ExitVtxoDetailScreen.tsx
+++ b/client/src/screens/ExitVtxoDetailScreen.tsx
@@ -1,0 +1,306 @@
+import React from "react";
+import { Linking, Pressable, ScrollView, View } from "react-native";
+import { useNavigation, useRoute, type RouteProp } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import Icon from "@react-native-vector-icons/ionicons";
+import { NoahActivityIndicator } from "~/components/ui/NoahActivityIndicator";
+import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
+import { Button } from "~/components/ui/button";
+import { Text } from "~/components/ui/text";
+import { useIconColor } from "~/hooks/useTheme";
+import { useExitOverview, useSyncExits } from "~/hooks/useUnilateralExit";
+import {
+  buildExitTimelineItems,
+  EXIT_STATE_LABELS,
+  formatBlocksRemaining,
+  getExitBlockRows,
+  getExitStatusText,
+  truncateMiddle,
+  type ExitDetailRow,
+  type ExitTimelineItem,
+} from "~/lib/exitTimeline";
+import { COLORS } from "~/lib/styleConstants";
+import { cn, formatBip177 } from "~/lib/utils";
+import type { SettingsStackParamList } from "~/Navigators";
+import type { ExitProgressState } from "react-native-nitro-ark";
+
+type ExitVtxoDetailRouteProp = RouteProp<SettingsStackParamList, "ExitVtxoDetail">;
+type IconName = React.ComponentProps<typeof Icon>["name"];
+
+const stateTone = (state: ExitProgressState) => {
+  switch (state) {
+    case "Claimable":
+    case "Claimed":
+      return {
+        icon: "checkmark-circle-outline" as IconName,
+        color: "#22c55e",
+        className: "text-green-500",
+        bgClassName: "bg-green-500/10 border-green-500/30",
+      };
+    case "ClaimInProgress":
+    case "AwaitingDelta":
+      return {
+        icon: "time-outline" as IconName,
+        color: "#d97706",
+        className: "text-amber-600 dark:text-amber-300",
+        bgClassName: "bg-amber-500/10 border-amber-500/30",
+      };
+    case "Processing":
+      return {
+        icon: "radio-outline" as IconName,
+        color: "#c98a3c",
+        className: "text-primary",
+        bgClassName: "bg-primary/10 border-primary/30",
+      };
+    default:
+      return {
+        icon: "ellipse-outline" as IconName,
+        color: "#8e8e93",
+        className: "text-muted-foreground",
+        bgClassName: "bg-muted border-border",
+      };
+  }
+};
+
+const ExplorerValue = ({ value, explorerUrl }: { value: string; explorerUrl?: string | null }) => {
+  if (!explorerUrl) {
+    return <Text className="text-right text-sm font-medium text-foreground">{value}</Text>;
+  }
+
+  return (
+    <Pressable
+      onPress={() => Linking.openURL(explorerUrl)}
+      hitSlop={10}
+      className="flex-row items-center justify-end gap-x-1"
+    >
+      <Text className="text-right text-sm font-medium text-foreground">{value}</Text>
+      <Icon name="open-outline" size={15} color={COLORS.BITCOIN_ORANGE} />
+    </Pressable>
+  );
+};
+
+const DetailRow = ({ row }: { row: ExitDetailRow }) => (
+  <View className="flex-row items-center justify-between border-b border-border/30 py-3 last:border-b-0">
+    <Text className="mr-3 text-sm text-muted-foreground">{row.label}</Text>
+    <View className="flex-1">
+      <ExplorerValue value={row.value} explorerUrl={row.explorerUrl} />
+    </View>
+  </View>
+);
+
+const TimelineRow = ({
+  item,
+  isLast,
+}: {
+  item: ExitTimelineItem;
+  isLast: boolean;
+}) => {
+  const tone = stateTone(item.state);
+  const heightLabel =
+    item.startHeight && item.endHeight && item.startHeight !== item.endHeight
+      ? `${item.startHeight} - ${item.endHeight}`
+      : item.endHeight
+        ? `${item.endHeight}`
+        : undefined;
+
+  return (
+    <View className="flex-row">
+      <View className="w-9 items-center">
+        <View className={cn("h-9 w-9 items-center justify-center rounded-full border", tone.bgClassName)}>
+          <Icon name={tone.icon} size={18} color={tone.color} />
+        </View>
+        {!isLast ? <View className="w-px flex-1 bg-border" /> : null}
+      </View>
+      <View className="ml-3 flex-1 pb-5">
+        <View className="rounded-lg border border-border bg-card p-4">
+          <View className="flex-row items-start justify-between">
+            <View className="flex-1">
+              <Text className="text-base font-semibold text-foreground">
+                {item.label}
+                {item.count > 1 ? ` x${item.count}` : ""}
+              </Text>
+              {heightLabel ? (
+                <Text className="mt-1 text-xs text-muted-foreground">Block/tip {heightLabel}</Text>
+              ) : null}
+            </View>
+            {item.isCurrent ? (
+              <View className={cn("rounded-full border px-2 py-1", tone.bgClassName)}>
+                <Text className={cn("text-xs font-semibold", tone.className)}>Current</Text>
+              </View>
+            ) : null}
+          </View>
+          <Text className="mt-3 text-sm leading-5 text-muted-foreground">{item.description}</Text>
+          {item.details.length > 0 ? (
+            <View className="mt-3 rounded-md border border-border/60 bg-background/60 px-3">
+              {item.details.map((row) => (
+                <DetailRow key={`${item.state}-${row.label}-${row.value}`} row={row} />
+              ))}
+            </View>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const ExitVtxoDetailScreen = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList>>();
+  const route = useRoute<ExitVtxoDetailRouteProp>();
+  const iconColor = useIconColor();
+  const overviewQuery = useExitOverview();
+  const syncExits = useSyncExits();
+  const overview = overviewQuery.data;
+  const exit = overview?.exits.find((item) => item.vtxo_id === route.params.vtxoId);
+  const status = exit ? overview?.statuses[exit.vtxo_id] : undefined;
+  const state = status?.state ?? exit?.state;
+  const details = status?.state_details ?? exit?.state_details;
+  const tone = state ? stateTone(state) : stateTone("Start");
+  const timelineItems =
+    exit && state
+      ? buildExitTimelineItems({
+          history: status?.history ?? exit.history,
+          historyDetails:
+            status?.history_details && status.history_details.length > 0
+              ? status.history_details
+              : exit.history_details,
+          currentState: state,
+          currentDetails: details,
+          currentBlockHeight: overview?.blockHeight,
+        })
+      : [];
+  const blockRows =
+    state && details
+      ? getExitBlockRows({ state, details, currentBlockHeight: overview?.blockHeight })
+      : [];
+  const claimableHeight = details?.claimable_height ?? details?.claimable_since?.height;
+  const remaining = formatBlocksRemaining(overview?.blockHeight, claimableHeight);
+
+  return (
+    <NoahSafeAreaView className="flex-1 bg-background">
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 56 }}
+        showsVerticalScrollIndicator={false}
+      >
+        <View className="mb-8 flex-row items-center justify-between">
+          <View className="flex-row items-center">
+            <Pressable onPress={() => navigation.goBack()} className="mr-4">
+              <Icon name="arrow-back-outline" size={24} color={iconColor} />
+            </Pressable>
+            <Text className="text-2xl font-bold text-foreground">Exit Timeline</Text>
+          </View>
+          <Button
+            variant="ghost"
+            size="icon"
+            onPress={() => syncExits.mutate()}
+            disabled={syncExits.isPending}
+          >
+            {syncExits.isPending ? (
+              <NoahActivityIndicator />
+            ) : (
+              <Icon name="refresh-outline" size={22} color={iconColor} />
+            )}
+          </Button>
+        </View>
+
+        {overviewQuery.isLoading ? (
+          <View className="items-center py-12">
+            <NoahActivityIndicator />
+            <Text className="mt-3 text-muted-foreground">Loading exit timeline...</Text>
+          </View>
+        ) : overviewQuery.error ? (
+          <View className="rounded-lg border border-destructive bg-destructive/10 p-4">
+            <Text className="font-semibold text-destructive">Unable to load exit</Text>
+            <Text className="mt-2 text-sm text-destructive">{overviewQuery.error.message}</Text>
+          </View>
+        ) : !exit || !state || !details ? (
+          <View className="rounded-lg border border-border bg-card p-4">
+            <Text className="text-base font-semibold text-foreground">Exit not found</Text>
+            <Text className="mt-2 text-sm leading-5 text-muted-foreground">
+              This VTXO is not currently tracked as an emergency exit.
+            </Text>
+          </View>
+        ) : (
+          <>
+            <View className="mb-5 rounded-lg border border-border bg-card p-4">
+              <View className="flex-row items-start justify-between">
+                <View className="flex-1">
+                  <Text className="text-3xl font-bold text-foreground">
+                    {formatBip177(exit.amount_sat)}
+                  </Text>
+                  <Text className="mt-2 text-base font-medium text-foreground">
+                    {getExitStatusText({ state, details, currentBlockHeight: overview?.blockHeight })}
+                  </Text>
+                  <Text className="mt-2 text-sm text-muted-foreground">
+                    {truncateMiddle(exit.vtxo_id, 14, 12)}
+                  </Text>
+                </View>
+                <View className={cn("rounded-full border px-3 py-2", tone.bgClassName)}>
+                  <Text className={cn("text-sm font-semibold", tone.className)}>
+                    {EXIT_STATE_LABELS[state]}
+                  </Text>
+                </View>
+              </View>
+            </View>
+
+            <View className="mb-5 rounded-lg border border-border bg-card p-4">
+              <Text className="mb-3 text-lg font-semibold text-foreground">Block Status</Text>
+              <View className="flex-row gap-x-4">
+                <View className="flex-1">
+                  <Text className="text-xs uppercase text-muted-foreground">Current Height</Text>
+                  <Text className="mt-1 text-base font-semibold text-foreground">
+                    {overview?.blockHeight !== undefined ? overview.blockHeight : "Unknown"}
+                  </Text>
+                </View>
+                <View className="flex-1">
+                  <Text className="text-xs uppercase text-muted-foreground">Exit Tip</Text>
+                  <Text className="mt-1 text-base font-semibold text-foreground">
+                    {details.tip_height}
+                  </Text>
+                </View>
+              </View>
+              <View className="mt-4 flex-row gap-x-4">
+                <View className="flex-1">
+                  <Text className="text-xs uppercase text-muted-foreground">Claimable Height</Text>
+                  <Text className="mt-1 text-base font-semibold text-foreground">
+                    {claimableHeight ?? "Unknown"}
+                  </Text>
+                </View>
+                <View className="flex-1">
+                  <Text className="text-xs uppercase text-muted-foreground">Remaining</Text>
+                  <Text className="mt-1 text-base font-semibold text-foreground">
+                    {remaining ?? "Unknown"}
+                  </Text>
+                </View>
+              </View>
+            </View>
+
+            {blockRows.length > 0 ? (
+              <View className="mb-5 rounded-lg border border-border bg-card p-4">
+                <Text className="mb-1 text-lg font-semibold text-foreground">Current State</Text>
+                <View className="mt-2 rounded-md border border-border/60 bg-background/60 px-3">
+                  {blockRows.map((row) => (
+                    <DetailRow key={`${row.label}-${row.value}`} row={row} />
+                  ))}
+                </View>
+              </View>
+            ) : null}
+
+            <View className="mb-2">
+              <Text className="mb-4 text-lg font-semibold text-foreground">Timeline</Text>
+              {timelineItems.map((item, index) => (
+                <TimelineRow
+                  key={`${item.state}-${index}`}
+                  item={item}
+                  isLast={index === timelineItems.length - 1}
+                />
+              ))}
+            </View>
+          </>
+        )}
+      </ScrollView>
+    </NoahSafeAreaView>
+  );
+};
+
+export default ExitVtxoDetailScreen;

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -46,6 +46,7 @@ type Setting = {
     | "backup"
     | "arkInfo"
     | "vtxos"
+    | "emergencyExit"
     | "feedback"
     | "unifiedPush"
     | "debug";
@@ -219,6 +220,8 @@ const SettingsScreen = () => {
       navigation.navigate("ArkInfo");
     } else if (item.id === "vtxos") {
       navigation.navigate("VTXOs");
+    } else if (item.id === "emergencyExit") {
+      navigation.navigate("UnilateralExit");
     } else if (item.id === "feedback") {
       setShowFeedback(true);
     } else if (item.id === "unifiedPush") {
@@ -294,6 +297,12 @@ const SettingsScreen = () => {
       id: "vtxos",
       title: "Show VTXOs",
       description: "VTXOs are to Ark like UTXOs are to Bitcoin",
+      isPressable: true,
+    });
+    walletData.push({
+      id: "emergencyExit",
+      title: "Emergency Exit",
+      description: "Recover funds if the Ark server is unavailable.",
       isPressable: true,
     });
     walletData.push({

--- a/client/src/screens/UnilateralExitScreen.tsx
+++ b/client/src/screens/UnilateralExitScreen.tsx
@@ -1,0 +1,729 @@
+import React, { useState } from "react";
+import {
+  Keyboard,
+  KeyboardAvoidingView,
+  Linking,
+  Pressable,
+  ScrollView,
+  TouchableWithoutFeedback,
+  View,
+} from "react-native";
+import { useNavigation, useRoute, type RouteProp } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import Icon from "@react-native-vector-icons/ionicons";
+import { AlertTriangle } from "lucide-react-native";
+import { validateBitcoinAddress } from "bip-321";
+import { Text } from "~/components/ui/text";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
+import { NoahButton } from "~/components/ui/NoahButton";
+import { NoahActivityIndicator } from "~/components/ui/NoahActivityIndicator";
+import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
+import { ConfirmationDialog } from "~/components/ConfirmationDialog";
+import { useIconColor } from "~/hooks/useTheme";
+import {
+  useClaimExits,
+  useExitOverview,
+  useProgressExits,
+  useStartVtxoExit,
+  useStartWalletExit,
+  useSyncExits,
+} from "~/hooks/useUnilateralExit";
+import { APP_VARIANT } from "~/config";
+import { getMempoolTxUrl } from "~/constants";
+import {
+  buildExitTimelineItems,
+  EXIT_STATE_LABELS,
+  EXIT_STATE_ORDER,
+  formatBlocksRemaining,
+  getExitBlockRows,
+  getExitStatusText,
+  isClaimableExit,
+  truncateMiddle,
+} from "~/lib/exitTimeline";
+import { COLORS } from "~/lib/styleConstants";
+import { cn, formatBip177, isNetworkMatch } from "~/lib/utils";
+import type { SettingsStackParamList } from "~/Navigators";
+import type {
+  ExitProgressState,
+  ExitStateDetails,
+  ExitStatusResult,
+  ExitVtxoResult,
+} from "react-native-nitro-ark";
+
+type UnilateralExitRouteProp = RouteProp<SettingsStackParamList, "UnilateralExit">;
+type IconName = React.ComponentProps<typeof Icon>["name"];
+
+const stateTone = (state: ExitProgressState) => {
+  switch (state) {
+    case "Claimable":
+    case "Claimed":
+      return {
+        icon: "checkmark-circle-outline" as IconName,
+        color: "#22c55e",
+        className: "text-green-500",
+        bgClassName: "bg-green-500/10 border-green-500/30",
+      };
+    case "ClaimInProgress":
+    case "AwaitingDelta":
+      return {
+        icon: "time-outline" as IconName,
+        color: "#d97706",
+        className: "text-amber-600 dark:text-amber-300",
+        bgClassName: "bg-amber-500/10 border-amber-500/30",
+      };
+    case "Processing":
+      return {
+        icon: "radio-outline" as IconName,
+        color: "#c98a3c",
+        className: "text-primary",
+        bgClassName: "bg-primary/10 border-primary/30",
+      };
+    default:
+      return {
+        icon: "ellipse-outline" as IconName,
+        color: "#8e8e93",
+        className: "text-muted-foreground",
+        bgClassName: "bg-muted border-border",
+      };
+  }
+};
+
+const ExplorerValue = ({ value, explorerUrl }: { value: string; explorerUrl?: string | null }) => {
+  if (!explorerUrl) {
+    return (
+      <Text className="ml-3 flex-1 text-right text-sm font-medium text-foreground">{value}</Text>
+    );
+  }
+
+  return (
+    <Pressable
+      onPress={() => Linking.openURL(explorerUrl)}
+      hitSlop={10}
+      className="ml-3 flex-1 flex-row items-center justify-end gap-x-1"
+    >
+      <Text className="text-right text-sm font-medium text-foreground">{value}</Text>
+      <Icon name="open-outline" size={15} color={COLORS.BITCOIN_ORANGE} />
+    </Pressable>
+  );
+};
+
+const ExitSummaryItem = ({ label, value }: { label: string; value: string }) => (
+  <View className="flex-1">
+    <Text className="text-xs uppercase text-muted-foreground">{label}</Text>
+    <Text className="mt-1 text-base font-semibold text-foreground">{value}</Text>
+  </View>
+);
+
+const ExitStep = ({
+  state,
+  isActive,
+  count,
+}: {
+  state: ExitProgressState;
+  isActive: boolean;
+  count: number;
+}) => {
+  const tone = stateTone(state);
+  return (
+    <View className="flex-row items-center">
+      <View
+        className={cn(
+          "h-9 w-9 items-center justify-center rounded-full border",
+          isActive ? tone.bgClassName : "border-border bg-muted/40",
+        )}
+      >
+        <Icon name={tone.icon} size={18} color={isActive ? tone.color : "#8e8e93"} />
+      </View>
+      <View className="ml-3 flex-1 border-b border-border/40 py-3">
+        <View className="flex-row items-center justify-between">
+          <Text className={cn("font-semibold", isActive ? tone.className : "text-foreground")}>
+            {EXIT_STATE_LABELS[state]}
+          </Text>
+          {count > 0 ? (
+            <Text className="text-xs text-muted-foreground">
+              {count} {count === 1 ? "VTXO" : "VTXOs"}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const PHASE_LABELS: Record<ExitProgressState, string> = {
+  Start: "Start",
+  Processing: "Process",
+  AwaitingDelta: "Wait",
+  Claimable: "Ready",
+  ClaimInProgress: "Claim",
+  Claimed: "Done",
+};
+
+const ExitPhaseRail = ({
+  currentState,
+  history,
+  historyDetails,
+  currentDetails,
+  currentBlockHeight,
+}: {
+  currentState: ExitProgressState;
+  history?: ExitProgressState[];
+  historyDetails?: ExitStateDetails[];
+  currentDetails?: ExitStateDetails;
+  currentBlockHeight?: number;
+}) => {
+  const items = buildExitTimelineItems({
+    history,
+    historyDetails,
+    currentState,
+    currentDetails,
+    currentBlockHeight,
+  });
+  const activeIndex = EXIT_STATE_ORDER.indexOf(currentState);
+  const countByState = items.reduce<Partial<Record<ExitProgressState, number>>>((acc, item) => {
+    acc[item.state] = (acc[item.state] ?? 0) + item.count;
+    return acc;
+  }, {});
+
+  return (
+    <View className="mt-3 flex-row items-start">
+      {EXIT_STATE_ORDER.map((state, index) => {
+        const count = countByState[state] ?? 0;
+        const isActive = state === currentState;
+        const isComplete = count > 0 && index < activeIndex;
+        const tone = stateTone(state);
+        return (
+          <View key={state} className="flex-1 items-center">
+            <View className="mb-1 h-5 w-full flex-row items-center">
+              {index > 0 ? (
+                <View
+                  className={cn(
+                    "h-px flex-1",
+                    isComplete || isActive ? "bg-primary/50" : "bg-border",
+                  )}
+                />
+              ) : (
+                <View className="flex-1" />
+              )}
+              <View
+                className={cn(
+                  "h-5 w-5 items-center justify-center rounded-full border",
+                  isActive
+                    ? tone.bgClassName
+                    : isComplete
+                      ? "border-green-500/40 bg-green-500/10"
+                      : count > 0
+                        ? "border-primary/40 bg-primary/10"
+                        : "border-border bg-background",
+                )}
+              >
+                {count > 0 ? (
+                  <Icon
+                    name={isComplete || state === "Claimed" ? "checkmark" : "ellipse"}
+                    size={11}
+                    color={isActive ? tone.color : isComplete ? "#22c55e" : "#c98a3c"}
+                  />
+                ) : null}
+              </View>
+              {index < EXIT_STATE_ORDER.length - 1 ? (
+                <View
+                  className={cn(
+                    "h-px flex-1",
+                    isComplete ? "bg-primary/50" : "bg-border",
+                  )}
+                />
+              ) : (
+                <View className="flex-1" />
+              )}
+            </View>
+            <Text
+              className={cn(
+                "text-center text-[10px]",
+                count > 0 ? "text-foreground" : "text-muted-foreground",
+              )}
+              numberOfLines={1}
+            >
+              {PHASE_LABELS[state]}
+            </Text>
+            {count > 1 ? (
+              <Text className="text-[10px] text-muted-foreground">x{count}</Text>
+            ) : null}
+          </View>
+        );
+      })}
+    </View>
+  );
+};
+
+const ExitVtxoRow = ({
+  exit,
+  status,
+  history,
+  currentBlockHeight,
+  onPress,
+}: {
+  exit: ExitVtxoResult;
+  status?: ExitStatusResult;
+  history?: ExitProgressState[];
+  currentBlockHeight?: number;
+  onPress: () => void;
+}) => {
+  const state = status?.state ?? exit.state;
+  const details = status?.state_details ?? exit.state_details;
+  const historyDetails =
+    status?.history_details && status.history_details.length > 0
+      ? status.history_details
+      : exit.history_details;
+  const tone = stateTone(state);
+  const latestTxid = exit.txids.at(-1);
+  const latestTxExplorerUrl = latestTxid ? getMempoolTxUrl(latestTxid) : null;
+  const blockRows = getExitBlockRows({ state, details, currentBlockHeight });
+  const statusText = getExitStatusText({ state, details, currentBlockHeight });
+
+  return (
+    <Pressable onPress={onPress} className="mb-3 rounded-lg border border-border bg-card p-4">
+      <View>
+          <View className="flex-row items-center justify-between">
+            <Text className="text-xl font-semibold text-foreground">
+              {formatBip177(exit.amount_sat)}
+            </Text>
+            <View className={cn("rounded-full border px-3 py-1.5", tone.bgClassName)}>
+              <Text className={cn("text-sm font-semibold", tone.className)}>
+                {EXIT_STATE_LABELS[state]}
+              </Text>
+            </View>
+          </View>
+          <Text className="mt-3 text-base font-medium text-foreground">{statusText}</Text>
+          <Text className="mt-2 text-base text-muted-foreground">
+            {truncateMiddle(exit.vtxo_id, 12, 10)}
+          </Text>
+          {latestTxid ? (
+            <Pressable
+              onPress={() => {
+                if (latestTxExplorerUrl) {
+                  Linking.openURL(latestTxExplorerUrl);
+                }
+              }}
+              disabled={!latestTxExplorerUrl}
+              hitSlop={8}
+              className="mt-1 flex-row items-center gap-x-1"
+            >
+              <Text className="text-sm text-muted-foreground">
+                Latest tx: {truncateMiddle(latestTxid, 10, 10)}
+              </Text>
+              {latestTxExplorerUrl ? (
+                <Icon name="open-outline" size={15} color={COLORS.BITCOIN_ORANGE} />
+              ) : null}
+            </Pressable>
+          ) : null}
+          {blockRows.length > 0 ? (
+            <View className="mt-3 rounded-md border border-border/60 bg-background/60 px-3 py-2">
+              {blockRows.map((row) => (
+                <View key={row.label} className="flex-row items-center justify-between py-1.5">
+                  <Text className="text-sm text-muted-foreground">{row.label}</Text>
+                  <ExplorerValue value={row.value} explorerUrl={row.explorerUrl} />
+                </View>
+              ))}
+            </View>
+          ) : null}
+          <ExitPhaseRail
+            currentState={state}
+            history={history}
+            historyDetails={historyDetails}
+            currentDetails={details}
+            currentBlockHeight={currentBlockHeight}
+          />
+      </View>
+    </Pressable>
+  );
+};
+
+const EmptyExitState = ({ onStart }: { onStart: () => void }) => (
+  <View className="items-center rounded-lg border border-border bg-card px-4 py-8">
+    <Icon name="shield-outline" size={40} color="#8e8e93" />
+    <Text className="mt-4 text-center text-lg font-semibold text-foreground">
+      No emergency exits
+    </Text>
+    <Text className="mt-2 text-center text-sm leading-5 text-muted-foreground">
+      Start only if the Ark server is unavailable and normal offboarding cannot be used.
+    </Text>
+    <NoahButton onPress={onStart} className="mt-5 w-full">
+      Start Wallet Exit
+    </NoahButton>
+  </View>
+);
+
+const UnilateralExitScreen = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList>>();
+  const route = useRoute<UnilateralExitRouteProp>();
+  const iconColor = useIconColor();
+  const selectedVtxoIds = route.params?.vtxoIds;
+
+  const [destinationAddress, setDestinationAddress] = useState("");
+  const [showStartConfirm, setShowStartConfirm] = useState(false);
+  const [showProgressConfirm, setShowProgressConfirm] = useState(false);
+  const [showClaimConfirm, setShowClaimConfirm] = useState(false);
+
+  const overviewQuery = useExitOverview();
+  const startWalletExit = useStartWalletExit();
+  const startVtxoExit = useStartVtxoExit();
+  const progressExits = useProgressExits();
+  const syncExits = useSyncExits();
+  const claimExits = useClaimExits();
+
+  const overview = overviewQuery.data;
+  const exits = overview?.exits ?? [];
+  const statuses = overview?.statuses ?? {};
+  const claimableById = new Map<string, ExitVtxoResult>();
+  for (const exit of overview?.claimable ?? []) {
+    claimableById.set(exit.vtxo_id, exit);
+  }
+  for (const exit of exits) {
+    if (isClaimableExit(exit, statuses[exit.vtxo_id])) {
+      claimableById.set(exit.vtxo_id, exit);
+    }
+  }
+  const claimable = Array.from(claimableById.values());
+  const claimableIds = claimable.map((exit) => exit.vtxo_id);
+  const claimableTotal = claimable.reduce((total, exit) => total + exit.amount_sat, 0);
+  const stateCounts = exits.reduce<Record<ExitProgressState, number>>(
+    (acc, exit) => {
+      const state = statuses[exit.vtxo_id]?.state ?? exit.state;
+      acc[state] += 1;
+      return acc;
+    },
+    {
+      Start: 0,
+      Processing: 0,
+      AwaitingDelta: 0,
+      Claimable: 0,
+      ClaimInProgress: 0,
+      Claimed: 0,
+    },
+  );
+  const claimInProgressCount = stateCounts.ClaimInProgress;
+  const claimedCount = stateCounts.Claimed;
+  const exitTipHeights = exits
+    .map((exit) => statuses[exit.vtxo_id]?.state_details.tip_height ?? exit.state_details.tip_height)
+    .filter((height): height is number => typeof height === "number");
+  const latestExitTipHeight =
+    exitTipHeights.length > 0 ? Math.max(...exitTipHeights) : undefined;
+  const overviewBlockHeight = overview?.blockHeight;
+  const staleExitCount =
+    overviewBlockHeight === undefined
+      ? 0
+      : exits.filter((exit) => {
+          const tip =
+            statuses[exit.vtxo_id]?.state_details.tip_height ?? exit.state_details.tip_height;
+          return typeof tip === "number" && tip < overviewBlockHeight;
+        }).length;
+
+  const trimmedDestination = destinationAddress.trim();
+  const btcValidation = trimmedDestination ? validateBitcoinAddress(trimmedDestination) : null;
+  const isValidDestination =
+    !!btcValidation?.valid && isNetworkMatch(btcValidation.network, "onchain");
+  const isBusy =
+    startWalletExit.isPending ||
+    startVtxoExit.isPending ||
+    progressExits.isPending ||
+    syncExits.isPending ||
+    claimExits.isPending;
+  const canStartNewExit = (overview?.spendableVtxoCount ?? 0) > 0 && !isBusy;
+
+  const startLabel = selectedVtxoIds?.length ? "Start Selected Exit" : "Start Wallet Exit";
+  const allClaimableHeight = overview?.allClaimableAtHeight;
+  const currentBlockHeight = overview?.blockHeight;
+  const claimableBlockLabel =
+    allClaimableHeight !== undefined && currentBlockHeight !== undefined
+      ? allClaimableHeight <= currentBlockHeight
+        ? "Now"
+        : `${allClaimableHeight} (${allClaimableHeight - currentBlockHeight} blocks)`
+      : allClaimableHeight !== undefined
+        ? `${allClaimableHeight}`
+        : "Unknown";
+  const allClaimableRemainingLabel = formatBlocksRemaining(currentBlockHeight, allClaimableHeight);
+
+  const handleStart = () => {
+    if (selectedVtxoIds?.length) {
+      startVtxoExit.mutate(selectedVtxoIds);
+    } else {
+      startWalletExit.mutate();
+    }
+    setShowStartConfirm(false);
+  };
+
+  const handleClaim = () => {
+    if (!isValidDestination) {
+      return;
+    }
+
+    claimExits.mutate({
+      vtxoIds: claimableIds,
+      destinationAddress: trimmedDestination,
+    });
+    setShowClaimConfirm(false);
+  };
+
+  return (
+    <NoahSafeAreaView className="flex-1 bg-background">
+      <KeyboardAvoidingView behavior="padding" className="flex-1">
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+          <ScrollView
+            className="p-4"
+            contentContainerStyle={{ paddingBottom: 80 }}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View className="mb-6 flex-row items-center justify-between">
+              <View className="flex-row items-center">
+                <Pressable onPress={() => navigation.goBack()} className="mr-4">
+                  <Icon name="arrow-back-outline" size={24} color={iconColor} />
+                </Pressable>
+                <Text className="text-2xl font-bold text-foreground">Emergency Exit</Text>
+              </View>
+              <Button
+                variant="ghost"
+                size="icon"
+                onPress={() => syncExits.mutate()}
+                disabled={isBusy}
+              >
+                {syncExits.isPending ? (
+                  <NoahActivityIndicator />
+                ) : (
+                  <Icon name="refresh-outline" size={22} color={iconColor} />
+                )}
+              </Button>
+            </View>
+
+            <Alert icon={AlertTriangle} className="mb-5 border-amber-500/40 bg-amber-500/10">
+              <AlertTitle className="text-amber-700 dark:text-amber-300">
+                Emergency use only
+              </AlertTitle>
+              <AlertDescription className="text-amber-700/90 dark:text-amber-200/90">
+                Use this only if the Ark server is unresponsive or uncooperative. In normal
+                circumstances, use Offboard Ark.
+              </AlertDescription>
+            </Alert>
+
+            {overviewQuery.isLoading ? (
+              <View className="items-center py-12">
+                <NoahActivityIndicator />
+                <Text className="mt-3 text-muted-foreground">Loading exit status...</Text>
+              </View>
+            ) : overviewQuery.error ? (
+              <View className="rounded-lg border border-destructive bg-destructive/10 p-4">
+                <Text className="font-semibold text-destructive">Unable to load exits</Text>
+                <Text className="mt-2 text-sm text-destructive">
+                  {overviewQuery.error.message}
+                </Text>
+              </View>
+            ) : exits.length === 0 ? (
+              <EmptyExitState onStart={() => setShowStartConfirm(true)} />
+            ) : (
+              <>
+                <View className="mb-5 rounded-lg border border-border bg-card p-4">
+                  <View className="flex-row gap-x-4">
+                    <ExitSummaryItem label="Tracked" value={`${exits.length}`} />
+                    <ExitSummaryItem
+                      label="Pending"
+                      value={formatBip177(overview?.pendingTotal ?? 0)}
+                    />
+                  </View>
+                  <View className="mt-4 flex-row gap-x-4">
+                    <ExitSummaryItem label="Claimable" value={formatBip177(claimableTotal)} />
+                    <ExitSummaryItem label="All Claimable" value={claimableBlockLabel} />
+                  </View>
+                  <View className="mt-4 flex-row gap-x-4">
+                    <ExitSummaryItem label="Claiming" value={`${claimInProgressCount}`} />
+                    <ExitSummaryItem label="Claimed" value={`${claimedCount}`} />
+                  </View>
+                  <View className="mt-4 flex-row gap-x-4">
+                    <ExitSummaryItem
+                      label="Available"
+                      value={`${overview?.spendableVtxoCount ?? 0} ${
+                        overview?.spendableVtxoCount === 1 ? "VTXO" : "VTXOs"
+                      }`}
+                    />
+                    <ExitSummaryItem
+                      label="Available Value"
+                      value={formatBip177(overview?.spendableVtxoTotal ?? 0)}
+                    />
+                  </View>
+                </View>
+
+                <View className="mb-5 rounded-lg border border-border bg-card p-4">
+                  <Text className="mb-3 text-lg font-semibold text-foreground">Block Status</Text>
+                  <View className="flex-row gap-x-4">
+                    <ExitSummaryItem
+                      label="Current Height"
+                      value={overview?.blockHeight !== undefined ? `${overview.blockHeight}` : "Unknown"}
+                    />
+                    <ExitSummaryItem
+                      label="Exit Synced Tip"
+                      value={latestExitTipHeight !== undefined ? `${latestExitTipHeight}` : "Unknown"}
+                    />
+                  </View>
+                  <View className="mt-4 flex-row gap-x-4">
+                    <ExitSummaryItem label="All Claimable" value={claimableBlockLabel} />
+                    <ExitSummaryItem
+                      label="Remaining"
+                      value={allClaimableRemainingLabel ?? "Unknown"}
+                    />
+                  </View>
+                  {staleExitCount > 0 ? (
+                    <Text className="mt-3 text-sm leading-5 text-muted-foreground">
+                      {staleExitCount} {staleExitCount === 1 ? "exit is" : "exits are"} behind
+                      the current chain height. Sync status to refresh chain-derived state.
+                    </Text>
+                  ) : null}
+                </View>
+
+                {claimable.length === 0 && claimInProgressCount > 0 ? (
+                  <View className="mb-5 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+                    <Text className="text-base font-semibold text-amber-700 dark:text-amber-300">
+                      Claim broadcasted
+                    </Text>
+                    <Text className="mt-1 text-sm leading-5 text-amber-700/90 dark:text-amber-200/90">
+                      No further claim action is available for VTXOs in Claiming. Wait for the
+                      claim transaction to confirm, then sync status to mark them claimed.
+                    </Text>
+                  </View>
+                ) : null}
+
+                <View className="mb-5 rounded-lg border border-border bg-card p-4">
+                  <Text className="mb-2 text-lg font-semibold text-foreground">Timeline</Text>
+                  {EXIT_STATE_ORDER.map((state) => (
+                    <ExitStep
+                      key={state}
+                      state={state}
+                      count={stateCounts[state]}
+                      isActive={stateCounts[state] > 0}
+                    />
+                  ))}
+                </View>
+
+                <View className="mb-5">
+                  <View className="mb-3 flex-row items-center justify-between">
+                    <Text className="text-lg font-semibold text-foreground">VTXOs</Text>
+                    <Text className="text-sm text-muted-foreground">
+                      {claimable.length} claimable
+                    </Text>
+                  </View>
+                  {exits.map((exit) => (
+                    <ExitVtxoRow
+                      key={exit.vtxo_id}
+                      exit={exit}
+                      status={statuses[exit.vtxo_id]}
+                      history={statuses[exit.vtxo_id]?.history}
+                      currentBlockHeight={overview?.blockHeight}
+                      onPress={() =>
+                        navigation.navigate("ExitVtxoDetail", { vtxoId: exit.vtxo_id })
+                      }
+                    />
+                  ))}
+                </View>
+
+                <View className="mb-5 flex-row gap-x-3">
+                  <NoahButton
+                    className="flex-1"
+                    style={{ backgroundColor: "#e5e7eb" }}
+                    textClassName="font-bold text-base"
+                    onPress={() => syncExits.mutate()}
+                    disabled={isBusy}
+                    isLoading={syncExits.isPending}
+                  >
+                    Sync Status
+                  </NoahButton>
+                  {canStartNewExit ? (
+                    <NoahButton
+                      className="flex-1"
+                      textClassName="font-bold text-base"
+                      onPress={() => setShowStartConfirm(true)}
+                      disabled={isBusy}
+                    >
+                      Start New Exit
+                    </NoahButton>
+                  ) : null}
+                  {overview?.hasPending ? (
+                    <NoahButton
+                      className="flex-1"
+                      textClassName="font-bold text-base"
+                      onPress={() => setShowProgressConfirm(true)}
+                      disabled={isBusy}
+                      isLoading={progressExits.isPending}
+                    >
+                      Progress
+                    </NoahButton>
+                  ) : null}
+                </View>
+
+                {claimable.length > 0 ? (
+                  <View className="rounded-lg border border-border bg-card p-4">
+                    <Text className="text-lg font-semibold text-foreground">Claim Exits</Text>
+                    <Text className="mt-1 text-sm leading-5 text-muted-foreground">
+                      Sweep claimable exit outputs to an on-chain Bitcoin address.
+                    </Text>
+                    <View className="mt-4 rounded-lg border border-border bg-background px-3 py-2">
+                      <Input
+                        value={destinationAddress}
+                        onChangeText={setDestinationAddress}
+                        placeholder="Bitcoin address"
+                        autoCapitalize="none"
+                        autoCorrect={false}
+                        className="border-0 bg-transparent p-0 text-foreground"
+                      />
+                    </View>
+                    {trimmedDestination && !isValidDestination ? (
+                      <Text className="mt-2 text-sm text-destructive">
+                        Enter a valid {APP_VARIANT} on-chain address.
+                      </Text>
+                    ) : null}
+                    <NoahButton
+                      className="mt-4"
+                      disabled={!isValidDestination || isBusy}
+                      isLoading={claimExits.isPending}
+                      onPress={() => setShowClaimConfirm(true)}
+                    >
+                      Claim Claimable Exits
+                    </NoahButton>
+                  </View>
+                ) : null}
+              </>
+            )}
+
+            <ConfirmationDialog
+              open={showStartConfirm}
+              onOpenChange={setShowStartConfirm}
+              title="Start Emergency Exit"
+              description="This starts unilateral exit tracking for your funds. Use this only if normal offboarding is unavailable."
+              confirmText={startLabel}
+              onConfirm={handleStart}
+            />
+            <ConfirmationDialog
+              open={showProgressConfirm}
+              onOpenChange={setShowProgressConfirm}
+              title="Progress Exits"
+              description="This may broadcast or fee-bump Bitcoin transactions required by the emergency exit process."
+              confirmText="Progress Exits"
+              onConfirm={() => {
+                progressExits.mutate(undefined);
+                setShowProgressConfirm(false);
+              }}
+            />
+            <ConfirmationDialog
+              open={showClaimConfirm}
+              onOpenChange={setShowClaimConfirm}
+              title="Claim Exits"
+              description="This broadcasts the final claim transaction for all currently claimable exits."
+              confirmText="Broadcast Claim"
+              onConfirm={handleClaim}
+            />
+          </ScrollView>
+        </TouchableWithoutFeedback>
+      </KeyboardAvoidingView>
+    </NoahSafeAreaView>
+  );
+};
+
+export default UnilateralExitScreen;

--- a/client/src/screens/VTXODetailScreen.tsx
+++ b/client/src/screens/VTXODetailScreen.tsx
@@ -1,5 +1,6 @@
 import { View, Pressable, ScrollView, Linking } from "react-native";
 import { useRoute, useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Text } from "../components/ui/text";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import Icon from "@react-native-vector-icons/ionicons";
@@ -11,6 +12,8 @@ import type { BarkVtxo } from "react-native-nitro-ark";
 import { useGetBlockHeight } from "~/hooks/useMarketData";
 import { formatBip177 } from "~/lib/utils";
 import { getMempoolTxUrl } from "~/constants";
+import { NoahButton } from "~/components/ui/NoahButton";
+import type { SettingsStackParamList } from "~/Navigators";
 
 type VTXOWithStatus = BarkVtxo & {
   isExpiring: boolean;
@@ -87,7 +90,7 @@ const VTXODetailRow = ({
 
 const VTXODetailScreen = () => {
   const route = useRoute();
-  const navigation = useNavigation();
+  const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList>>();
   const iconColor = useIconColor();
   const { data: blockHeight } = useGetBlockHeight();
   const { vtxo } = route.params as { vtxo: VTXOWithStatus };
@@ -178,6 +181,21 @@ const VTXODetailScreen = () => {
               explorerUrl={anchorExplorerUrl}
             />
             <VTXODetailRow label="Server Public Key" value={vtxo.server_pubkey} copyable />
+          </View>
+
+          <View className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+            <Text className="text-base font-semibold text-amber-700 dark:text-amber-300">
+              Emergency exit
+            </Text>
+            <Text className="mt-1 text-sm leading-5 text-amber-700/90 dark:text-amber-200/90">
+              Use only if the Ark server is unavailable and normal offboarding cannot be used.
+            </Text>
+            <NoahButton
+              className="mt-4"
+              onPress={() => navigation.navigate("UnilateralExit", { vtxoIds: [vtxo.point] })}
+            >
+              Exit This VTXO
+            </NoahButton>
           </View>
         </ScrollView>
       </View>

--- a/docs/unilateral_exits_plan.md
+++ b/docs/unilateral_exits_plan.md
@@ -1,0 +1,171 @@
+# Unilateral Exits Plan
+
+## Goal
+
+Add an emergency-only wallet flow for unilateral Ark exits. The flow must let a user start exits, track each VTXO through the exit state machine, progress pending exits, and claim claimable exits to an on-chain Bitcoin address.
+
+This is not a normal offboarding path. The UI must direct users to offboarding when the Ark server is cooperative.
+
+## Native API Surface
+
+Current `react-native-nitro-ark` exit APIs:
+
+- `startExitForEntireWallet(): Promise<void>`
+- `startExitForVtxos(vtxoIds: string[]): Promise<void>`
+- `syncExit(): Promise<void>`
+- `syncNoProgress(): Promise<void>`
+- `progressExits(feeRateSatPerKvb?: number): Promise<ExitProgressStatusResult[]>`
+- `getExitVtxos(): Promise<ExitVtxoResult[]>`
+- `listClaimable(): Promise<ExitVtxoResult[]>`
+- `getExitStatus(vtxoId, includeHistory?, includeTransactions?)`
+- `hasPendingExits(): Promise<boolean>`
+- `pendingExitTotal(): Promise<number>`
+- `allClaimableAtHeight(): Promise<number | undefined>`
+- `drainExits(vtxoIds, destinationAddress, feeRateSatPerKvb?): Promise<string>`
+
+New APIs required for final in-app claiming:
+
+- `extractTransaction(psbt: string): Promise<string>`
+- `broadcastTransaction(txHex: string): Promise<string>`
+
+`react-native-nitro-ark@0.0.109` exposes structured exit state metadata on
+`ExitProgressStatusResult`, `ExitVtxoResult`, and `ExitStatusResult`:
+
+- `state_details.tip_height`
+- `state_details.confirmed_block`
+- `state_details.claimable_height`
+- `state_details.claimable_since`
+- `state_details.last_scanned_block`
+- `state_details.claim_txid`
+- `state_details.txid`
+- `state_details.block`
+- `history_details`
+
+This lets Noah display per-VTXO claimable heights, claim broadcast txids,
+claimed block heights, and per-exit sync tips.
+
+Final claim sequence:
+
+1. `drainExits(vtxoIds, destinationAddress, feeRateSatPerKvb?)`
+2. `extractTransaction(psbt)`
+3. `broadcastTransaction(txHex)`
+4. `syncExit()` and invalidate wallet queries
+
+`progressExits()` already handles intermediate exit transaction creation/broadcasting through Bark's exit transaction manager. The app should not manually broadcast intermediate exit packages. The Noah wrapper mirrors Bark CLI/REST by calling `syncNoProgress()` before `progressExits()`.
+
+## UX Model
+
+Visual thesis: restrained emergency operations screen with neutral wallet surfaces, amber warning/waiting states, and green only for claimable or completed funds.
+
+Primary screen: `Emergency Exit`.
+
+Entry points:
+
+- Settings -> Wallet -> Emergency Exit
+- Later: VTXO detail -> start emergency exit for this VTXO
+
+Top screen copy:
+
+- Clear emergency disclaimer.
+- Link/action back to normal `Offboard Ark`.
+- Summary: tracked exits, pending amount, claimable amount, all-claimable block if known.
+- Block status: current chain height, all-claimable height, per-exit synced tip height, and blocks remaining.
+
+Timeline states:
+
+- `Start`: Exit registered.
+- `Processing`: Exit transactions are being prepared, broadcast, or confirmed.
+- `AwaitingDelta`: Exit transaction is confirmed and waiting for the timelock.
+- `Claimable`: Funds can be swept to an on-chain address.
+- `ClaimInProgress`: Claim transaction has been broadcast and is waiting for confirmation.
+- `Claimed`: Claim transaction confirmed.
+
+Per-VTXO rows should show:
+
+- Amount.
+- Truncated VTXO id.
+- Current state.
+- Last known transaction id when available.
+- State history when available.
+- State-specific block information from `state_details`, including claimable height, claimable-since block, claim txid, and claimed block.
+
+Actions:
+
+- No tracked exits: `Start wallet exit`.
+- Pending exits: `Progress exits` and `Sync status`.
+- Claimable exits: destination address input and `Claim claimable exits`.
+- Mixed claimable and pending exits: allow claimable sweep while still allowing progress for pending exits.
+
+## Implementation Plan
+
+### Client API Layer
+
+Add `client/src/lib/exitApi.ts`:
+
+- Wrap Nitro calls with `neverthrow`.
+- Expose a single `claimExits()` helper that composes `drainExits`, `extractTransaction`, and `broadcastTransaction`.
+- Keep direct Nitro usage out of screens.
+- Import `extractTransaction` and `broadcastTransaction` directly from `react-native-nitro-ark`.
+
+### Hooks
+
+Add `client/src/hooks/useUnilateralExit.ts`:
+
+- `useExitOverview()`; use `syncExit()` so claim confirmations can transition from `ClaimInProgress` to `Claimed`.
+- `useStartWalletExit()`
+- `useStartVtxoExit()`
+- `useProgressExits()`
+- `useSyncExits()`
+- `useClaimExits()`
+
+Query invalidation after mutations:
+
+- `exit-overview`
+- `balance`
+- `vtxos`
+- `getBlockHeight`
+
+### Screen
+
+Add `client/src/screens/UnilateralExitScreen.tsx`:
+
+- Header/back navigation.
+- Emergency notice.
+- Summary strip.
+- Block status panel.
+- VTXO timeline list.
+- Compact per-VTXO phase rail instead of long inline history text.
+- Claim form.
+- Confirmation dialogs for start/progress/claim.
+
+Add `client/src/screens/ExitVtxoDetailScreen.tsx`:
+
+- Opens from a VTXO card on the emergency exit screen.
+- Shows the selected VTXO amount, current state, block status, current state details, and a collapsed vertical timeline.
+- Collapses repeated states like `Processing x4` while preserving block/tip details and explorer links for txids.
+
+### Navigation
+
+Add `UnilateralExit` to `SettingsStackParamList`:
+
+```ts
+UnilateralExit: { vtxoIds?: string[] } | undefined;
+```
+
+Add Settings row:
+
+- Title: `Emergency Exit`
+- Description: `Recover funds if the Ark server is unavailable.`
+
+## TODO
+
+- [x] Document engineering plan.
+- [x] Add `exitApi` wrappers.
+- [x] Add unilateral exit hooks.
+- [x] Add Settings route and screen.
+- [x] Add VTXO detail entry for single-VTXO exits.
+- [x] Replace temporary Nitro type cast after `react-native-nitro-ark` publishes the new methods.
+- [x] Consume structured exit state details from Nitro.
+- [x] Add compact list timeline and single-VTXO exit timeline screen.
+- [ ] Add focused tests for exit state derivation after the UI model stabilizes.
+- [x] Run `bun client check`.


### PR DESCRIPTION
## Summary

Adds the emergency unilateral exit flow to the wallet.

- Adds an `Emergency Exit` Settings screen for starting wallet-wide or selected-VTXO exits.
- Adds exit API wrappers and hooks around `react-native-nitro-ark`, including start, sync, progress, claim, status overview, and safe logging.
- Implements the final claim flow: `drainExits -> extractTransaction -> broadcastTransaction -> syncExit`.
- Mirrors Bark CLI/REST progress behavior by calling `syncNoProgress()` before `progressExits()`.
- Uses the richer Nitro exit state details to show block heights, synced tips, claimable heights, claim txids, claimed blocks, and explorer links.
- Replaces noisy inline state history with a compact phase rail on each VTXO card.
- Adds a single-VTXO exit timeline screen with collapsed state transitions like `Processing x4` and transaction/block details.
- Adds a VTXO detail entry point for starting an exit for one VTXO.
- Documents the engineering plan in `docs/unilateral_exits_plan.md`.

## UX Notes

This flow is presented as emergency-only recovery for cases where the Ark server is unavailable or uncooperative. Normal offboarding remains the preferred path when the server is cooperative.

The main exit screen is for action and overview. Tapping a VTXO opens the detail timeline for deeper inspection.

## Verification

- `bun client check`
