### PR TITLE
Add explicit user lifecycle status and active-user gating

### DIFF
--- a/client/src/hooks/useMailboxAuthorization.ts
+++ b/client/src/hooks/useMailboxAuthorization.ts
@@ -1,14 +1,11 @@
 import { useEffect, useState } from "react";
-import { authorizeMailbox } from "~/lib/api";
-import { getMailboxAuthorization, loadWalletIfNeeded } from "~/lib/walletApi";
+import { loadWalletIfNeeded } from "~/lib/walletApi";
 import logger from "~/lib/log";
 import { useServerStore } from "~/store/serverStore";
+import { authorizeMailboxForServer, MAILBOX_AUTH_TTL_SECS } from "~/lib/server";
 
 const log = logger("useMailboxAuthorization");
 
-// Keep a buffer below the server's 90-day hard cap so device/server clock skew
-// does not cause the authorization request to be rejected.
-const MAILBOX_AUTH_TTL_SECS = 89 * 24 * 60 * 60;
 const MAILBOX_AUTH_REFRESH_WINDOW_SECS = 7 * 24 * 60 * 60;
 
 export const useMailboxAuthorization = (isReady: boolean) => {
@@ -17,7 +14,6 @@ export const useMailboxAuthorization = (isReady: boolean) => {
     isRegisteredWithServer,
     mailboxAuthorizationExpiry,
     isMailboxAuthorizationEnabled,
-    setMailboxAuthorizationExpiry,
   } = useServerStore();
 
   useEffect(() => {
@@ -51,17 +47,14 @@ export const useMailboxAuthorization = (isReady: boolean) => {
       }
 
       const requestedExpiry = now + MAILBOX_AUTH_TTL_SECS;
-      const mailboxAuthorizationResult = await getMailboxAuthorization(requestedExpiry);
-      if (mailboxAuthorizationResult.isErr()) {
-        log.w("Failed to generate mailbox authorization", [mailboxAuthorizationResult.error]);
-        return;
-      }
-      if (shouldAbort()) {
-        return;
-      }
-      const authorizeResult = await authorizeMailbox(mailboxAuthorizationResult.value);
+      const authorizeResult = await authorizeMailboxForServer({
+        requestedExpiry,
+        shouldAbort,
+      });
       if (authorizeResult.isErr()) {
-        log.w("Failed to store mailbox authorization on server", [authorizeResult.error]);
+        if (!shouldAbort()) {
+          log.w("Failed to grant mailbox authorization on server", [authorizeResult.error]);
+        }
         return;
       }
 
@@ -69,10 +62,7 @@ export const useMailboxAuthorization = (isReady: boolean) => {
         return;
       }
 
-      setMailboxAuthorizationExpiry(mailboxAuthorizationResult.value.expiry);
-      log.d("Successfully granted mailbox authorization", [
-        mailboxAuthorizationResult.value.expiry,
-      ]);
+      log.d("Successfully granted mailbox authorization", [authorizeResult.value]);
     };
 
     registerMailboxAuthorization();
@@ -86,7 +76,6 @@ export const useMailboxAuthorization = (isReady: boolean) => {
     isMailboxAuthorizationEnabled,
     mailboxAuthorizationExpiry,
     refreshTick,
-    setMailboxAuthorizationExpiry,
   ]);
 
   useEffect(() => {

--- a/client/src/hooks/usePushNotifications.ts
+++ b/client/src/hooks/usePushNotifications.ts
@@ -1,13 +1,9 @@
 import { useEffect } from "react";
-import {
-  registerForPushNotificationsAsync,
-  registerPushTokenWithServer,
-  registerUnifiedPushTokenWithServer,
-} from "~/lib/pushNotifications";
 import { useServerStore } from "~/store/serverStore";
 import logger from "~/lib/log";
 import { loadWalletIfNeeded } from "~/lib/walletApi";
 import { BackupService } from "~/lib/backupService";
+import { registerPushNotificationsForServer } from "~/lib/server";
 
 const log = logger("usePushNotifications");
 
@@ -22,24 +18,9 @@ export const usePushNotifications = (isReady: boolean) => {
 
       await loadWalletIfNeeded();
 
-      const tokenResult = await registerForPushNotificationsAsync();
-      if (tokenResult.isErr()) {
-        log.w("Failed to register for push notifications", [tokenResult.error]);
-        return;
-      }
-
-      const tokenPayload = tokenResult.value;
-      if (tokenPayload.kind !== "success") {
-        log.w("Push permission not granted or device unsupported", [tokenPayload.kind]);
-        return;
-      }
-
-      const registerResult =
-        tokenPayload.pushType === "unified"
-          ? await registerUnifiedPushTokenWithServer(tokenPayload.pushToken)
-          : await registerPushTokenWithServer(tokenPayload.pushToken);
+      const registerResult = await registerPushNotificationsForServer();
       if (registerResult.isErr()) {
-        log.w("Failed to register push token with server", [registerResult.error]);
+        log.w("Failed to register for push notifications", [registerResult.error]);
         return;
       }
 

--- a/client/src/lib/server.ts
+++ b/client/src/lib/server.ts
@@ -1,21 +1,36 @@
-import { registerWithServer } from "~/lib/api";
+import { authorizeMailbox, registerWithServer } from "~/lib/api";
 import * as Device from "expo-device";
 import logger from "~/lib/log";
 import { useServerStore } from "~/store/serverStore";
 import { useProfileStore } from "~/store/profileStore";
-import { type Result, err } from "neverthrow";
+import { type Result, err, ok } from "neverthrow";
 import { RegisterResponse } from "~/types/serverTypes";
 import Constants from "expo-constants";
 import { peakAddress } from "~/lib/paymentsApi";
+import {
+  registerForPushNotificationsAsync,
+  registerPushTokenWithServer,
+  registerUnifiedPushTokenWithServer,
+} from "~/lib/pushNotifications";
+import { getMailboxAuthorization, loadWalletIfNeeded } from "~/lib/walletApi";
 
 const log = logger("server");
+export const MAILBOX_AUTH_TTL_SECS = 89 * 24 * 60 * 60;
+
+const applyServerRegistrationResult = (response: RegisterResponse) => {
+  const { setRegisteredWithServer, setEmailVerified } = useServerStore.getState();
+  const { setDisplayName } = useProfileStore.getState();
+  const { lightning_address, display_name, is_email_verified } = response;
+
+  setRegisteredWithServer(true, lightning_address, true);
+  setDisplayName(display_name ?? "");
+  setEmailVerified(is_email_verified);
+};
 
 export const performServerRegistration = async (
   ln_address: string | null,
+  options?: { updateStore?: boolean },
 ): Promise<Result<RegisterResponse, Error>> => {
-  const { setRegisteredWithServer, setEmailVerified } = useServerStore.getState();
-  const { setDisplayName } = useProfileStore.getState();
-
   const addressResult = await peakAddress(0);
   if (addressResult.isErr()) {
     log.e("Failed to generate Ark address for registration", [addressResult.error]);
@@ -41,10 +56,106 @@ export const performServerRegistration = async (
     return result;
   }
 
-  const { lightning_address, display_name, is_email_verified } = result.value;
-  log.d("Successfully registered with server", [is_email_verified]);
-  setRegisteredWithServer(true, lightning_address, true);
-  setDisplayName(display_name ?? "");
-  setEmailVerified(is_email_verified);
+  log.d("Successfully registered with server", [result.value.is_email_verified]);
+  if (options?.updateStore ?? true) {
+    applyServerRegistrationResult(result.value);
+  }
+
   return result;
+};
+
+export const registerPushNotificationsForServer = async (): Promise<Result<void, Error>> => {
+  const tokenResult = await registerForPushNotificationsAsync();
+  if (tokenResult.isErr()) {
+    log.w("Failed to register for push notifications", [tokenResult.error]);
+    return err(tokenResult.error);
+  }
+
+  const tokenPayload = tokenResult.value;
+  if (tokenPayload.kind !== "success") {
+    const error = new Error(
+      `Push notification registration did not complete: ${tokenPayload.kind}`,
+    );
+    log.w("Push notification registration did not complete", [tokenPayload.kind]);
+    return err(error);
+  }
+
+  const registerResult =
+    tokenPayload.pushType === "unified"
+      ? await registerUnifiedPushTokenWithServer(tokenPayload.pushToken)
+      : await registerPushTokenWithServer(tokenPayload.pushToken);
+  if (registerResult.isErr()) {
+    log.w("Failed to register push token with server", [registerResult.error]);
+    return err(registerResult.error);
+  }
+
+  return ok(undefined);
+};
+
+export const authorizeMailboxForServer = async (options?: {
+  requestedExpiry?: number;
+  shouldAbort?: () => boolean;
+}): Promise<Result<number, Error>> => {
+  const { isMailboxAuthorizationEnabled, setMailboxAuthorizationExpiry } =
+    useServerStore.getState();
+  if (!isMailboxAuthorizationEnabled) {
+    return err(new Error("Mailbox authorization is disabled"));
+  }
+
+  if (options?.shouldAbort?.()) {
+    return err(new Error("Mailbox authorization cancelled"));
+  }
+
+  const requestedExpiry =
+    options?.requestedExpiry ?? Math.floor(Date.now() / 1000) + MAILBOX_AUTH_TTL_SECS;
+  const mailboxAuthorizationResult = await getMailboxAuthorization(requestedExpiry);
+  if (mailboxAuthorizationResult.isErr()) {
+    log.w("Failed to generate mailbox authorization", [mailboxAuthorizationResult.error]);
+    return err(mailboxAuthorizationResult.error);
+  }
+
+  if (options?.shouldAbort?.()) {
+    return err(new Error("Mailbox authorization cancelled"));
+  }
+
+  const authorizeResult = await authorizeMailbox(mailboxAuthorizationResult.value);
+  if (authorizeResult.isErr()) {
+    log.w("Failed to store mailbox authorization on server", [authorizeResult.error]);
+    return err(authorizeResult.error);
+  }
+
+  if (options?.shouldAbort?.()) {
+    return err(new Error("Mailbox authorization cancelled"));
+  }
+
+  setMailboxAuthorizationExpiry(mailboxAuthorizationResult.value.expiry);
+  return ok(mailboxAuthorizationResult.value.expiry);
+};
+
+export const resetAndReRegisterWithServer = async (): Promise<Result<RegisterResponse, Error>> => {
+  useServerStore.getState().resetRegistration();
+
+  const registrationResult = await performServerRegistration(null, { updateStore: false });
+  if (registrationResult.isErr()) {
+    return registrationResult;
+  }
+
+  const loadResult = await loadWalletIfNeeded();
+  if (loadResult.isErr()) {
+    log.w("Failed to load wallet before service registration", [loadResult.error]);
+    return err(loadResult.error);
+  }
+
+  const pushResult = await registerPushNotificationsForServer();
+  if (pushResult.isErr()) {
+    return err(pushResult.error);
+  }
+
+  const mailboxResult = await authorizeMailboxForServer();
+  if (mailboxResult.isErr()) {
+    return err(mailboxResult.error);
+  }
+
+  applyServerRegistrationResult(registrationResult.value);
+  return registrationResult;
 };

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -25,7 +25,7 @@ import logoImageLight from "../../assets/All_Files/light_dark_tinted/icon_clear_
 import { COLORS } from "~/lib/styleConstants";
 import { useIconColor, useTheme } from "~/hooks/useTheme";
 import { FeedbackModal } from "~/components/FeedbackModal";
-import { performServerRegistration } from "../lib/server";
+import { resetAndReRegisterWithServer } from "../lib/server";
 import { useBottomTabBarHeight } from "react-native-bottom-tabs";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { revokeMailboxAuthorization } from "~/lib/api";
@@ -67,7 +67,6 @@ const SettingsScreen = () => {
   const suspendWalletMutation = useSuspendWallet();
   const [versionTapCount, setVersionTapCount] = useState(0);
   const {
-    resetRegistration,
     isMailboxAuthorizationEnabled,
     setMailboxAuthorizationExpiry,
     setMailboxAuthorizationEnabled,
@@ -299,10 +298,9 @@ const SettingsScreen = () => {
           title="Reset Server Registration"
           description="Are you sure you want to reset your server registration? This will not delete your wallet, but you will need to register with the server again."
           onConfirm={async () => {
-            resetRegistration();
             setResetError(null);
             setShowResetSuccess(false);
-            const result = await performServerRegistration(null);
+            const result = await resetAndReRegisterWithServer();
             if (result.isOk()) {
               setShowResetSuccess(true);
               setTimeout(() => {

--- a/client/src/types/serverTypes.ts
+++ b/client/src/types/serverTypes.ts
@@ -3,19 +3,19 @@
 /**
  * Represents a structured API error response.
  */
-export type ApiErrorResponse = {
+export type ApiErrorResponse = { 
 /**
  * Always "ERROR" for error responses.
  */
-status: string,
+status: string, 
 /**
  * Stable machine-readable error code.
  */
-code: string,
+code: string, 
 /**
  * User-facing error message.
  */
-message: string,
+message: string, 
 /**
  * Safe error reason for compatibility.
  */
@@ -37,15 +37,15 @@ export type AuthLoginResponse = { access_token: string, token_type: string, expi
 /**
  * Defines the payload for granting mailbox authorization to the server.
  */
-export type AuthorizeMailboxPayload = {
+export type AuthorizeMailboxPayload = { 
 /**
  * Ark mailbox identifier scoped to the loaded wallet.
  */
-mailbox_id: string,
+mailbox_id: string, 
 /**
  * Authorization expiry as a Unix timestamp in seconds.
  */
-expiry: number,
+expiry: number, 
 /**
  * Hex-encoded mailbox authorization.
  */
@@ -86,7 +86,7 @@ export type HeartbeatResponsePayload = { notification_id: string, };
 /**
  * Defines the payload for querying lightning address suggestions.
  */
-export type LightningAddressSuggestionsPayload = {
+export type LightningAddressSuggestionsPayload = { 
 /**
  * Partial lightning address typed in the send screen.
  */
@@ -95,7 +95,7 @@ query: string, };
 /**
  * Represents autocomplete suggestions for lightning addresses.
  */
-export type LightningAddressSuggestionsResponse = {
+export type LightningAddressSuggestionsResponse = { 
 /**
  * Ordered suggestion list.
  */
@@ -112,15 +112,15 @@ export type NotificationData = { "notification_type": "maintenance" } & Maintena
 /**
  * Defines the payload for a user registration request.
  */
-export type RegisterPayload = {
+export type RegisterPayload = { 
 /**
  * User chosen lightning address
  */
-ln_address: string | null,
+ln_address: string | null, 
 /**
  * Optional device information.
  */
-device_info: DeviceInfo | null,
+device_info: DeviceInfo | null, 
 /**
  * Optional Ark address
  */
@@ -129,7 +129,7 @@ ark_address: string | null, };
 /**
  * Defines the payload for registering a push notification token.
  */
-export type RegisterPushToken = {
+export type RegisterPushToken = { 
 /**
  * The Expo push token for the user's device.
  */
@@ -138,31 +138,31 @@ push_token: string, };
 /**
  * Represents the response for an user registration.
  */
-export type RegisterResponse = {
+export type RegisterResponse = { 
 /**
  * The status of the request, either "OK" or "ERROR".
  */
-status: string,
+status: string, 
 /**
  * An optional event indicating the outcome of the authentication.
  */
-event: AuthEvent | null,
+event: AuthEvent | null, 
 /**
  * An optional reason for an error, if one occurred.
  */
-reason: string | null,
+reason: string | null, 
 /**
  * The user's lightning address.
  */
-lightning_address: string | null,
+lightning_address: string | null, 
 /**
  * The user's optional display name.
  */
-display_name: string | null,
+display_name: string | null, 
 /**
  * Whether the user's email is verified.
  */
-is_email_verified: boolean,
+is_email_verified: boolean, 
 /**
  * The user's current operational lifecycle status.
  */
@@ -182,11 +182,11 @@ export type SendEmailVerificationPayload = { email: string, };
 /**
  * Defines the payload for submitting a BOLT11 invoice.
  */
-export type SubmitInvoicePayload = {
+export type SubmitInvoicePayload = { 
 /**
  * The BOLT11 invoice to be paid.
  */
-invoice: string,
+invoice: string, 
 /**
  * The unique identifier for the payment transaction.
  */
@@ -195,7 +195,7 @@ transaction_id: string, };
 /**
  * Defines the payload for updating a user's lightning address.
  */
-export type UpdateLnAddressPayload = {
+export type UpdateLnAddressPayload = { 
 /**
  * The new lightning address for the user.
  */
@@ -204,7 +204,7 @@ ln_address: string, };
 /**
  * Defines the payload for updating a user's profile.
  */
-export type UpdateProfilePayload = {
+export type UpdateProfilePayload = { 
 /**
  * The user's optional display name. Null or empty clears the name.
  */
@@ -215,15 +215,15 @@ export type UploadUrlResponse = { upload_url: string, s3_key: string, };
 /**
  * Represents the response for a user's information.
  */
-export type UserInfoResponse = {
+export type UserInfoResponse = { 
 /**
  * The user's lightning address.
  */
-lightning_address: string,
+lightning_address: string, 
 /**
  * The user's optional display name.
  */
-display_name: string | null,
+display_name: string | null, 
 /**
  * The user's current operational lifecycle status.
  */

--- a/client/src/types/serverTypes.ts
+++ b/client/src/types/serverTypes.ts
@@ -162,7 +162,11 @@ display_name: string | null,
 /**
  * Whether the user's email is verified.
  */
-is_email_verified: boolean, };
+is_email_verified: boolean,
+/**
+ * The user's current operational lifecycle status.
+ */
+user_status: UserStatus, };
 
 export type ReportJobStatusPayload = { notification_k1: string, report_type: ReportType, status: ReportStatus, error_message: string | null, };
 
@@ -219,7 +223,13 @@ lightning_address: string,
 /**
  * The user's optional display name.
  */
-display_name: string | null, };
+display_name: string | null,
+/**
+ * The user's current operational lifecycle status.
+ */
+user_status: UserStatus, };
+
+export type UserStatus = "active" | "inactive" | "deregistered";
 
 /**
  * Defines the payload for verifying an email with a code.

--- a/server/migrations/0014_add_user_status.sql
+++ b/server/migrations/0014_add_user_status.sql
@@ -1,0 +1,8 @@
+ALTER TABLE users
+ADD COLUMN status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'inactive', 'deregistered'));
+
+ALTER TABLE users
+ADD COLUMN status_changed_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+CREATE INDEX idx_users_status ON users(status);

--- a/server/src/cron.rs
+++ b/server/src/cron.rs
@@ -4,10 +4,10 @@ use crate::{
         backup_repo::BackupRepository, heartbeat_repo::HeartbeatRepository,
         job_status_repo::JobStatusRepository,
         mailbox_authorization_repo::MailboxAuthorizationRepository,
-        push_token_repo::PushTokenRepository,
+        push_token_repo::PushTokenRepository, user_repo::UserRepository,
     },
     notification_coordinator::{NotificationCoordinator, NotificationRequest},
-    types::{HeartbeatNotification, NotificationRequestData},
+    types::{HeartbeatNotification, NotificationRequestData, UserStatus},
 };
 use expo_push_notification_client::Priority;
 use tokio_cron_scheduler::{Job, JobScheduler};
@@ -105,6 +105,13 @@ pub async fn check_and_deregister_inactive_users(app_state: AppState) -> anyhow:
 
         // Use a transaction to ensure all or nothing is deleted
         let mut tx = app_state.db_pool.begin().await?;
+
+        if let Err(e) =
+            UserRepository::set_status_tx(&mut tx, &pubkey, UserStatus::Deregistered).await
+        {
+            tracing::error!(job = "deregister_inactive", pubkey = %pubkey, step = "user_status", error = %e, "status update failed");
+            continue;
+        }
 
         if let Err(e) = PushTokenRepository::delete_by_pubkey(&mut tx, &pubkey).await {
             tracing::error!(job = "deregister_inactive", pubkey = %pubkey, step = "push_token", error = %e, "delete failed");

--- a/server/src/db/backup_repo.rs
+++ b/server/src/db/backup_repo.rs
@@ -229,7 +229,11 @@ impl<'a> BackupRepository<'a> {
     /// Finds all pubkeys that have backups enabled.
     pub async fn find_pubkeys_with_backup_enabled(&self) -> Result<Vec<String>> {
         let pubkeys = sqlx::query_scalar::<_, String>(
-            "SELECT pubkey FROM backup_settings WHERE backup_enabled = TRUE",
+            "SELECT bs.pubkey
+             FROM backup_settings bs
+             INNER JOIN users u ON bs.pubkey = u.pubkey
+             WHERE bs.backup_enabled = TRUE
+               AND u.status = 'active'",
         )
         .fetch_all(self.pool)
         .await?;

--- a/server/src/db/heartbeat_repo.rs
+++ b/server/src/db/heartbeat_repo.rs
@@ -32,15 +32,18 @@ impl<'a> HeartbeatRepository<'a> {
         Ok(notification_id)
     }
 
-    /// Marks a heartbeat notification as responded
-    pub async fn mark_as_responded(&self, notification_id: &str) -> Result<bool> {
+    /// Marks a heartbeat notification as responded for the owning user.
+    pub async fn mark_as_responded(&self, notification_id: &str, pubkey: &str) -> Result<bool> {
         let result = sqlx::query(
             "UPDATE heartbeat_notifications
              SET responded_at = now(), status = $1
-             WHERE notification_id = $2 AND status = $3",
+             WHERE notification_id = $2
+               AND pubkey = $3
+               AND status = $4",
         )
         .bind(HeartbeatStatus::Responded.to_string())
         .bind(notification_id)
+        .bind(pubkey)
         .bind(HeartbeatStatus::Pending.to_string())
         .execute(self.pool)
         .await?;

--- a/server/src/db/heartbeat_repo.rs
+++ b/server/src/db/heartbeat_repo.rs
@@ -121,7 +121,8 @@ impl<'a> HeartbeatRepository<'a> {
         let pubkeys = sqlx::query_scalar::<_, String>(
             "SELECT DISTINCT pt.pubkey
              FROM push_tokens pt
-             INNER JOIN users u ON pt.pubkey = u.pubkey",
+             INNER JOIN users u ON pt.pubkey = u.pubkey
+             WHERE u.status = 'active'",
         )
         .fetch_all(self.pool)
         .await?;
@@ -151,9 +152,11 @@ impl<'a> HeartbeatRepository<'a> {
     pub async fn get_users_to_deregister(&self) -> Result<Vec<String>> {
         let pubkeys = sqlx::query_scalar::<_, String>(
             "WITH recent_heartbeats AS (
-                SELECT pubkey, status, sent_at,
-                       ROW_NUMBER() OVER (PARTITION BY pubkey ORDER BY sent_at DESC) as rn
-                FROM heartbeat_notifications
+                SELECT hn.pubkey, hn.status, hn.sent_at,
+                       ROW_NUMBER() OVER (PARTITION BY hn.pubkey ORDER BY hn.sent_at DESC) as rn
+                FROM heartbeat_notifications hn
+                INNER JOIN users u ON hn.pubkey = u.pubkey
+                WHERE u.status = 'active'
             ),
             consecutive_missed AS (
                 SELECT pubkey,

--- a/server/src/db/mailbox_authorization_repo.rs
+++ b/server/src/db/mailbox_authorization_repo.rs
@@ -125,16 +125,18 @@ impl<'a> MailboxAuthorizationRepository<'a> {
     pub async fn find_all_enabled(&self) -> Result<Vec<ActiveMailboxAuthorization>> {
         let records = sqlx::query_as::<_, ActiveMailboxAuthorization>(
             "SELECT
-                pubkey,
-                mailbox_id,
-                authorization_hex,
-                authorization_expires_at,
-                auth_version,
-                last_checkpoint
-             FROM mailbox_authorizations
-             WHERE enabled = TRUE
-               AND authorization_hex IS NOT NULL
-               AND authorization_expires_at IS NOT NULL",
+                ma.pubkey,
+                ma.mailbox_id,
+                ma.authorization_hex,
+                ma.authorization_expires_at,
+                ma.auth_version,
+                ma.last_checkpoint
+             FROM mailbox_authorizations ma
+             INNER JOIN users u ON ma.pubkey = u.pubkey
+             WHERE ma.enabled = TRUE
+               AND ma.authorization_hex IS NOT NULL
+               AND ma.authorization_expires_at IS NOT NULL
+               AND u.status = 'active'",
         )
         .fetch_all(self.pool)
         .await?;
@@ -151,16 +153,18 @@ impl<'a> MailboxAuthorizationRepository<'a> {
     ) -> Result<Vec<ActiveMailboxAuthorization>> {
         let records = sqlx::query_as::<_, ActiveMailboxAuthorization>(
             "WITH candidates AS (
-                SELECT pubkey
-                FROM mailbox_authorizations
-                WHERE enabled = TRUE
-                  AND status = 'active'
-                  AND authorization_hex IS NOT NULL
-                  AND authorization_expires_at IS NOT NULL
-                  AND authorization_expires_at > $1
-                  AND (next_retry_at IS NULL OR next_retry_at <= $2)
-                  AND (lease_expires_at IS NULL OR lease_expires_at <= $2)
-                ORDER BY COALESCE(last_connected_at, to_timestamp(0)) ASC, updated_at ASC
+                SELECT ma.pubkey
+                FROM mailbox_authorizations ma
+                INNER JOIN users u ON ma.pubkey = u.pubkey
+                WHERE ma.enabled = TRUE
+                  AND ma.status = 'active'
+                  AND ma.authorization_hex IS NOT NULL
+                  AND ma.authorization_expires_at IS NOT NULL
+                  AND ma.authorization_expires_at > $1
+                  AND (ma.next_retry_at IS NULL OR ma.next_retry_at <= $2)
+                  AND (ma.lease_expires_at IS NULL OR ma.lease_expires_at <= $2)
+                  AND u.status = 'active'
+                ORDER BY COALESCE(ma.last_connected_at, to_timestamp(0)) ASC, ma.updated_at ASC
                 LIMIT $4
                 FOR UPDATE SKIP LOCKED
              )

--- a/server/src/db/push_token_repo.rs
+++ b/server/src/db/push_token_repo.rs
@@ -57,10 +57,14 @@ impl<'a> PushTokenRepository<'a> {
 
     /// Finds all `(pubkey, push_token)` pairs in the database.
     pub async fn find_all_with_pubkeys(&self) -> Result<Vec<(String, String)>> {
-        let rows =
-            sqlx::query_as::<_, (String, String)>("SELECT pubkey, push_token FROM push_tokens")
-                .fetch_all(self.pool)
-                .await?;
+        let rows = sqlx::query_as::<_, (String, String)>(
+            "SELECT pt.pubkey, pt.push_token
+             FROM push_tokens pt
+             INNER JOIN users u ON pt.pubkey = u.pubkey
+             WHERE u.status = 'active'",
+        )
+        .fetch_all(self.pool)
+        .await?;
 
         Ok(rows)
     }

--- a/server/src/db/user_repo.rs
+++ b/server/src/db/user_repo.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use sqlx::{PgPool, Postgres, Transaction};
+use sqlx::{PgPool, Postgres, Row, Transaction, postgres::PgRow};
+
+use crate::types::UserStatus;
 
 #[derive(Debug, Clone)]
 pub struct LightningAddressTakenError;
@@ -25,7 +27,7 @@ impl std::error::Error for DuplicateArkAddressError {}
 
 // This struct represents a user record from the database.
 // It's a good practice to have a model struct for each of your database tables.
-#[derive(Debug, sqlx::FromRow)]
+#[derive(Debug)]
 pub struct User {
     pub pubkey: String,
     pub lightning_address: Option<String>,
@@ -33,6 +35,29 @@ pub struct User {
     pub display_name: Option<String>,
     pub email: Option<String>,
     pub is_email_verified: bool,
+    pub status: UserStatus,
+}
+
+impl<'r> sqlx::FromRow<'r, PgRow> for User {
+    fn from_row(row: &'r PgRow) -> std::result::Result<Self, sqlx::Error> {
+        let status: String = row.try_get("status")?;
+        let status = status
+            .parse::<UserStatus>()
+            .map_err(|e| sqlx::Error::ColumnDecode {
+                index: "status".to_string(),
+                source: e.into(),
+            })?;
+
+        Ok(Self {
+            pubkey: row.try_get("pubkey")?,
+            lightning_address: row.try_get("lightning_address")?,
+            ark_address: row.try_get("ark_address")?,
+            display_name: row.try_get("display_name")?,
+            email: row.try_get("email")?,
+            is_email_verified: row.try_get("is_email_verified")?,
+            status,
+        })
+    }
 }
 
 // A struct to encapsulate user-related database operations
@@ -50,7 +75,7 @@ impl<'a> UserRepository<'a> {
     /// Finds a user by their public key.
     pub async fn find_by_pubkey(&self, pubkey: &str) -> Result<Option<User>> {
         let user = sqlx::query_as::<_, User>(
-            "SELECT pubkey, lightning_address, ark_address, display_name, email, is_email_verified FROM users WHERE pubkey = $1",
+            "SELECT pubkey, lightning_address, ark_address, display_name, email, is_email_verified, status FROM users WHERE pubkey = $1",
         )
         .bind(pubkey)
         .fetch_optional(self.pool)
@@ -77,7 +102,7 @@ impl<'a> UserRepository<'a> {
     /// Finds a user by their lightning address.
     pub async fn find_by_lightning_address(&self, ln_address: &str) -> Result<Option<User>> {
         let user = sqlx::query_as::<_, User>(
-            "SELECT pubkey, lightning_address, ark_address, display_name, email, is_email_verified FROM users WHERE lightning_address = $1",
+            "SELECT pubkey, lightning_address, ark_address, display_name, email, is_email_verified, status FROM users WHERE lightning_address = $1",
         )
         .bind(ln_address)
         .fetch_optional(self.pool)
@@ -252,6 +277,40 @@ impl<'a> UserRepository<'a> {
                 .await?;
 
         Ok(exists)
+    }
+
+    pub async fn set_status(&self, pubkey: &str, status: UserStatus) -> Result<()> {
+        sqlx::query(
+            "UPDATE users
+             SET status = $1, status_changed_at = now(), updated_at = now()
+             WHERE pubkey = $2
+               AND status <> $1",
+        )
+        .bind(status.as_str())
+        .bind(pubkey)
+        .execute(self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn set_status_tx(
+        tx: &mut Transaction<'_, Postgres>,
+        pubkey: &str,
+        status: UserStatus,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE users
+             SET status = $1, status_changed_at = now(), updated_at = now()
+             WHERE pubkey = $2
+               AND status <> $1",
+        )
+        .bind(status.as_str())
+        .bind(pubkey)
+        .execute(&mut **tx)
+        .await?;
+
+        Ok(())
     }
 
     /// Updates a user's email address. Empty strings are converted to NULL.

--- a/server/src/db/user_repo.rs
+++ b/server/src/db/user_repo.rs
@@ -127,6 +127,7 @@ impl<'a> UserRepository<'a> {
                 "SELECT lightning_address
                 FROM users
                 WHERE lightning_address IS NOT NULL
+                  AND status = 'active'
                   AND lightning_address_domain = $1
                   AND lightning_address_username LIKE $2
                 ORDER BY
@@ -157,6 +158,7 @@ impl<'a> UserRepository<'a> {
                     similarity(lightning_address_username, $3) AS similarity_score
                 FROM users
                 WHERE lightning_address IS NOT NULL
+                  AND status = 'active'
                   AND lightning_address_domain = $1
                   AND (
                       lightning_address_username LIKE $2

--- a/server/src/routes/gated_api_v0.rs
+++ b/server/src/routes/gated_api_v0.rs
@@ -12,7 +12,7 @@ use crate::types::{
     DefaultSuccessPayload, DeleteBackupPayload, DownloadUrlResponse, GetDownloadUrlPayload,
     HeartbeatResponsePayload, LightningAddressSuggestionsPayload,
     LightningAddressSuggestionsResponse, ReportJobStatusPayload, ReportStatus,
-    SubmitInvoicePayload, UpdateProfilePayload, UserInfoResponse,
+    SubmitInvoicePayload, UpdateProfilePayload, UserInfoResponse, UserStatus,
 };
 use crate::{
     AppState,
@@ -99,6 +99,11 @@ pub async fn register_push_token(
         .upsert(&auth_payload.key, &payload.push_token)
         .await?;
 
+    let user_repo = UserRepository::new(&app_state.db_pool);
+    user_repo
+        .set_status(&auth_payload.key, UserStatus::Active)
+        .await?;
+
     // TODO: Implement logic to send notification only once.
     // let app_state_clone = app_state.clone();
     // let pubkey = auth_payload.key.clone();
@@ -170,6 +175,11 @@ pub async fn authorize_mailbox(
             &payload.encoded,
             payload.expiry,
         )
+        .await?;
+
+    let user_repo = UserRepository::new(&app_state.db_pool);
+    user_repo
+        .set_status(&auth_payload.key, UserStatus::Active)
         .await?;
 
     Ok(Json(DefaultSuccessPayload { success: true }))
@@ -291,6 +301,7 @@ pub async fn get_user_info(
     Ok(Json(UserInfoResponse {
         lightning_address,
         display_name: user.display_name,
+        user_status: user.status,
     }))
 }
 
@@ -529,6 +540,7 @@ pub async fn deregister(
     // Use a transaction to ensure all or nothing is deleted
     let mut tx = state.db_pool.begin().await?;
 
+    UserRepository::set_status_tx(&mut tx, &pubkey, UserStatus::Deregistered).await?;
     PushTokenRepository::delete_by_pubkey(&mut tx, &pubkey).await?;
     MailboxAuthorizationRepository::delete_by_pubkey(&mut tx, &pubkey).await?;
     HeartbeatRepository::delete_by_pubkey_tx(&mut tx, &pubkey).await?;
@@ -540,7 +552,7 @@ pub async fn deregister(
 
 pub async fn heartbeat_response(
     State(state): State<AppState>,
-    Extension(_auth_payload): Extension<AuthenticatedUser>,
+    Extension(auth_payload): Extension<AuthenticatedUser>,
     event: Option<Extension<WideEventHandle>>,
     Json(payload): Json<HeartbeatResponsePayload>,
 ) -> anyhow::Result<Json<DefaultSuccessPayload>, ApiError> {
@@ -559,6 +571,11 @@ pub async fn heartbeat_response(
             "Heartbeat notification not found or already responded".to_string(),
         ));
     }
+
+    let user_repo = UserRepository::new(&state.db_pool);
+    user_repo
+        .set_status(&auth_payload.key, UserStatus::Active)
+        .await?;
 
     Ok(Json(DefaultSuccessPayload { success: true }))
 }

--- a/server/src/routes/gated_api_v0.rs
+++ b/server/src/routes/gated_api_v0.rs
@@ -563,7 +563,7 @@ pub async fn heartbeat_response(
     let heartbeat_repo = HeartbeatRepository::new(&state.db_pool);
 
     let updated = heartbeat_repo
-        .mark_as_responded(&payload.notification_id)
+        .mark_as_responded(&payload.notification_id, &auth_payload.key)
         .await?;
 
     if !updated {

--- a/server/src/routes/public_api_v0.rs
+++ b/server/src/routes/public_api_v0.rs
@@ -28,7 +28,7 @@ use crate::{
         AppVersionCheckPayload, AppVersionInfo, AuthEvent, AuthLoginPayload, AuthLoginResponse,
         AuthenticatedUser, EmailVerificationResponse, LightningInvoiceRequestNotification,
         NotificationData, RegisterPayload, RegisterResponse, SendEmailVerificationPayload,
-        VerifyEmailPayload,
+        UserStatus, VerifyEmailPayload,
     },
     utils::{make_k1, verify_auth},
     wide_event::WideEventHandle,
@@ -189,6 +189,17 @@ pub async fn lnurlp_request(
         .await?
         .ok_or_else(|| ApiError::InvalidArgument("User not found".to_string()))?;
     let pubkey = user.pubkey.clone();
+
+    if user.status != UserStatus::Active {
+        tracing::warn!(
+            pubkey = %pubkey,
+            user_status = %user.status,
+            "Lightning LNURL request rejected because user is not active"
+        );
+        return Err(ApiError::InvalidArgument(
+            "Lightning payments are not available for this user right now.".to_string(),
+        ));
+    }
 
     if query.amount.is_none() {
         let metadata = serde_json::json!([
@@ -398,6 +409,7 @@ pub async fn register(
             lightning_address: user.lightning_address,
             display_name: user.display_name,
             is_email_verified: user.is_email_verified,
+            user_status: user.status,
         }));
     }
 
@@ -457,6 +469,7 @@ pub async fn register(
         lightning_address: Some(ln_address),
         display_name: None,
         is_email_verified: false,
+        user_status: UserStatus::Active,
     }))
 }
 

--- a/server/src/tests/gated_heartbeat_tests.rs
+++ b/server/src/tests/gated_heartbeat_tests.rs
@@ -8,10 +8,10 @@ use tower::ServiceExt;
 use crate::db::{
     heartbeat_repo::HeartbeatRepository,
     mailbox_authorization_repo::MailboxAuthorizationRepository,
-    push_token_repo::PushTokenRepository,
+    push_token_repo::PushTokenRepository, user_repo::UserRepository,
 };
 use crate::tests::common::{TestUser, create_test_user, setup_test_app};
-use crate::types::{DefaultSuccessPayload, HeartbeatStatus};
+use crate::types::{DefaultSuccessPayload, HeartbeatStatus, UserStatus};
 
 #[tracing_test::traced_test]
 #[tokio::test]
@@ -715,4 +715,11 @@ async fn test_check_and_deregister_inactive_users_removes_mailbox_authorization(
         heartbeat_count, 0,
         "Heartbeat notifications should be deleted"
     );
+
+    let user_record = UserRepository::new(&app_state.db_pool)
+        .find_by_pubkey(&pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(user_record.status, UserStatus::Deregistered);
 }

--- a/server/src/tests/gated_heartbeat_tests.rs
+++ b/server/src/tests/gated_heartbeat_tests.rs
@@ -120,7 +120,7 @@ async fn test_heartbeat_response_already_responded() {
 
     // Mark it as responded first
     heartbeat_repo
-        .mark_as_responded(&notification_id)
+        .mark_as_responded(&notification_id, &user.pubkey().to_string())
         .await
         .unwrap();
 
@@ -146,6 +146,64 @@ async fn test_heartbeat_response_already_responded() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_heartbeat_response_rejects_other_users_notification() {
+    let (app, app_state, _guard) = setup_test_app().await;
+
+    let owner = TestUser::new();
+    create_test_user(&app_state, &owner, None).await;
+
+    let responder = TestUser::new_with_key(&[0xab; 32]);
+    sqlx::query("INSERT INTO users (pubkey, lightning_address, ark_address) VALUES ($1, $2, NULL)")
+        .bind(responder.pubkey().to_string())
+        .bind("responder@localhost")
+        .execute(&app_state.db_pool)
+        .await
+        .unwrap();
+    let responder_access_token = responder.access_token(&app_state);
+
+    let heartbeat_repo = HeartbeatRepository::new(&app_state.db_pool);
+    let notification_id = heartbeat_repo
+        .create_notification(&owner.pubkey().to_string())
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/heartbeat_response")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", responder_access_token),
+                )
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "notification_id": notification_id
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let (status, responded_at): (String, Option<chrono::DateTime<Utc>>) = sqlx::query_as(
+        "SELECT status, responded_at FROM heartbeat_notifications WHERE notification_id = $1",
+    )
+    .bind(&notification_id)
+    .fetch_one(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    assert_eq!(status, HeartbeatStatus::Pending.to_string());
+    assert!(responded_at.is_none());
 }
 
 #[tracing_test::traced_test]

--- a/server/src/tests/gated_suggestions_tests.rs
+++ b/server/src/tests/gated_suggestions_tests.rs
@@ -4,8 +4,11 @@ use http_body_util::BodyExt;
 use serde_json::json;
 use tower::ServiceExt;
 
+use crate::db::user_repo::UserRepository;
 use crate::tests::common::{TestUser, create_test_user, setup_test_app};
-use crate::types::{LightningAddressSuggestionsPayload, LightningAddressSuggestionsResponse};
+use crate::types::{
+    LightningAddressSuggestionsPayload, LightningAddressSuggestionsResponse, UserStatus,
+};
 
 #[tracing_test::traced_test]
 #[tokio::test]
@@ -106,6 +109,104 @@ async fn test_ln_address_suggestions_prefix() {
             "alicia@localhost".to_string()
         ]
     );
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_ln_address_suggestions_excludes_inactive_short_prefix_matches() {
+    let (app, app_state, _guard) = setup_test_app().await;
+    let user = TestUser::new();
+    create_test_user(&app_state, &user, None).await;
+    let access_token = user.access_token(&app_state);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, lightning_address, ark_address, status) VALUES
+            ('active-short', 'al@localhost', NULL, 'active'),
+            ('inactive-short', 'alex@localhost', NULL, 'inactive'),
+            ('deregistered-short', 'ally@localhost', NULL, 'deregistered')",
+    )
+    .execute(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    let payload = LightningAddressSuggestionsPayload {
+        query: "al".to_string(),
+    };
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/ln_address_suggestions")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::from(serde_json::to_string(&payload).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let res: LightningAddressSuggestionsResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(res.suggestions, vec!["al@localhost".to_string()]);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_ln_address_suggestions_excludes_inactive_fuzzy_matches() {
+    let (app, app_state, _guard) = setup_test_app().await;
+    let user = TestUser::new();
+    create_test_user(&app_state, &user, None).await;
+    let access_token = user.access_token(&app_state);
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, lightning_address, ark_address) VALUES
+            ('active-fuzzy', 'alice@localhost', NULL),
+            ('inactive-fuzzy', 'alicia@localhost', NULL),
+            ('deregistered-fuzzy', 'alina@localhost', NULL)",
+    )
+    .execute(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    let user_repo = UserRepository::new(&app_state.db_pool);
+    user_repo
+        .set_status("inactive-fuzzy", UserStatus::Inactive)
+        .await
+        .unwrap();
+    user_repo
+        .set_status("deregistered-fuzzy", UserStatus::Deregistered)
+        .await
+        .unwrap();
+
+    let payload = LightningAddressSuggestionsPayload {
+        query: "ali".to_string(),
+    };
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/ln_address_suggestions")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::from(serde_json::to_string(&payload).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let res: LightningAddressSuggestionsResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(res.suggestions, vec!["alice@localhost".to_string()]);
 }
 
 #[tracing_test::traced_test]

--- a/server/src/tests/gated_user_tests.rs
+++ b/server/src/tests/gated_user_tests.rs
@@ -12,7 +12,7 @@ use crate::db::mailbox_authorization_repo::MailboxAuthorizationRepository;
 use crate::db::push_token_repo::PushTokenRepository;
 use crate::db::user_repo::UserRepository;
 use crate::tests::common::{TestUser, create_test_user, setup_test_app};
-use crate::types::UserInfoResponse;
+use crate::types::{UserInfoResponse, UserStatus};
 
 #[tracing_test::traced_test]
 #[tokio::test]
@@ -35,6 +35,7 @@ async fn test_get_user_info() {
     tx.commit().await.unwrap();
 
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method(http::Method::POST)
@@ -57,6 +58,7 @@ async fn test_get_user_info() {
 
     assert_eq!(res.lightning_address, "existing@localhost");
     assert_eq!(res.display_name, None);
+    assert_eq!(res.user_status, UserStatus::Active);
 }
 
 #[tracing_test::traced_test]
@@ -80,6 +82,7 @@ async fn test_update_ln_address() {
     tx.commit().await.unwrap();
 
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method(http::Method::POST)
@@ -313,6 +316,7 @@ async fn test_deregister_user() {
 
     // 2. Call deregister endpoint
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method(http::Method::POST)
@@ -353,7 +357,8 @@ async fn test_deregister_user() {
         .find_by_pubkey(&user.pubkey().to_string())
         .await
         .unwrap();
-    assert!(user_record.is_some(), "User should not be deleted");
+    let user_record = user_record.expect("User should not be deleted");
+    assert_eq!(user_record.status, UserStatus::Deregistered);
 
     let backup_repo = BackupRepository::new(&app_state.db_pool);
     let metadata = backup_repo
@@ -379,6 +384,75 @@ async fn test_deregister_user() {
         heartbeat_count, 0,
         "Heartbeat notifications should be deleted"
     );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/user_info")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Deregistered users should still be able to make authenticated requests"
+    );
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_register_push_token_reactivates_deregistered_user() {
+    let (app, app_state, _guard) = setup_test_app().await;
+    let user = TestUser::new();
+    let access_token = user.access_token(&app_state);
+    let pubkey = user.pubkey().to_string();
+
+    let mut tx = app_state.db_pool.begin().await.unwrap();
+    UserRepository::create(&mut tx, &pubkey, "test@localhost", None)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let user_repo = UserRepository::new(&app_state.db_pool);
+    user_repo
+        .set_status(&pubkey, UserStatus::Deregistered)
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/register_push_token")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "push_token": "ExpoPushToken[test-token]"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let user_record = user_repo.find_by_pubkey(&pubkey).await.unwrap().unwrap();
+    assert_eq!(user_record.status, UserStatus::Active);
 }
 
 #[tracing_test::traced_test]

--- a/server/src/tests/public_api_v0.rs
+++ b/server/src/tests/public_api_v0.rs
@@ -1,10 +1,10 @@
 use crate::db::{
     mailbox_authorization_repo::MailboxAuthorizationRepository,
-    push_token_repo::PushTokenRepository,
+    push_token_repo::PushTokenRepository, user_repo::UserRepository,
 };
 use crate::routes::public_api_v0::{GetK1, LnurlpDefaultResponse};
 use crate::tests::common::{TestUser, create_test_user, setup_public_test_app};
-use crate::types::{ApiErrorResponse, AppVersionCheckPayload, AppVersionInfo};
+use crate::types::{ApiErrorResponse, AppVersionCheckPayload, AppVersionInfo, UserStatus};
 use axum::body::Body;
 use axum::http::{self, Request, StatusCode};
 use chrono::Utc;
@@ -41,6 +41,41 @@ async fn test_lnurlp_request_default() {
 
     assert_eq!(res.tag, "payRequest");
     assert_eq!(res.callback, "https://localhost/.well-known/lnurlp/test");
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_lnurlp_request_rejects_deregistered_user() {
+    let (app, app_state, _guard) = setup_public_test_app().await;
+    let user = TestUser::new();
+    let pubkey = user.pubkey().to_string();
+    create_test_user(&app_state, &user, None).await;
+
+    UserRepository::new(&app_state.db_pool)
+        .set_status(&pubkey, UserStatus::Deregistered)
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/.well-known/lnurlp/test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let err: ApiErrorResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(err.code, "INVALID_ARGUMENT");
+    assert_eq!(
+        err.message,
+        "Lightning payments are not available for this user right now."
+    );
 }
 
 #[tracing_test::traced_test]

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -100,6 +100,46 @@ pub struct RegisterResponse {
     pub display_name: Option<String>,
     /// Whether the user's email is verified.
     pub is_email_verified: bool,
+    /// The user's current operational lifecycle status.
+    pub user_status: UserStatus,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, TS)]
+#[serde(rename_all = "lowercase")]
+#[ts(export, export_to = "../../client/src/types/serverTypes.ts")]
+pub enum UserStatus {
+    Active,
+    Inactive,
+    Deregistered,
+}
+
+impl UserStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UserStatus::Active => "active",
+            UserStatus::Inactive => "inactive",
+            UserStatus::Deregistered => "deregistered",
+        }
+    }
+}
+
+impl std::fmt::Display for UserStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl std::str::FromStr for UserStatus {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "active" => Ok(UserStatus::Active),
+            "inactive" => Ok(UserStatus::Inactive),
+            "deregistered" => Ok(UserStatus::Deregistered),
+            _ => Err(anyhow::anyhow!("Invalid user status: {}", value)),
+        }
+    }
 }
 
 /// Defines device information captured during registration.
@@ -157,6 +197,8 @@ pub struct UserInfoResponse {
     pub lightning_address: String,
     /// The user's optional display name.
     pub display_name: Option<String>,
+    /// The user's current operational lifecycle status.
+    pub user_status: UserStatus,
 }
 
 /// Defines the payload for submitting a BOLT11 invoice.


### PR DESCRIPTION
## Summary
- Add `active`, `inactive`, and `deregistered` user lifecycle states to `users` with a migration and typed API surface.
- Keep authenticated access intact while using user status to drive operational behavior like deregistration, push/heartbeat targeting, mailbox workers, and LNURL pay availability.
- Reactivate users when they reconnect through push token registration, mailbox authorization, or a successful heartbeat response.

## Testing
- Added and updated server unit/integration tests for user info, deregistration, reactivation, heartbeat cleanup, and LNURL pay rejection for non-active users.
- Ran the full Rust test suite, plus client linting and TypeScript typecheck.