### PR TITLE
[codex] make email optional and update lightning sends

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "react-native-gesture-handler": "~2.31.1",
         "react-native-keychain": "^10.0.0",
         "react-native-mmkv": "^4.3.1",
-        "react-native-nitro-ark": "0.0.115",
+        "react-native-nitro-ark": "0.0.116",
         "react-native-nitro-modules": "0.35.6",
         "react-native-qrcode-svg": "^6.3.21",
         "react-native-quick-base64": "^2.2.2",
@@ -1590,7 +1590,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@4.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg=="],
 
-    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.115", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-mkWYiOEVw/2t2k3aIwqPPayX7OV/RbmtO0AV2PVb0NtHRKuAGxGKwCAlANQIGqXIVB55apCBYuvZUR864bWS/A=="],
+    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.116", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-gUYdKCsfQ6mSRdKhb6AoQ+n4sI0naZ5Im3u5vRSHXcF4D7twVHyro8UVuhr///uP3+xbd1ZOMvuEREhPeHJoRQ=="],
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.35.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "react-native-gesture-handler": "~2.31.1",
         "react-native-keychain": "^10.0.0",
         "react-native-mmkv": "^4.3.1",
-        "react-native-nitro-ark": "0.0.114",
+        "react-native-nitro-ark": "0.0.115",
         "react-native-nitro-modules": "0.35.6",
         "react-native-qrcode-svg": "^6.3.21",
         "react-native-quick-base64": "^2.2.2",
@@ -1590,7 +1590,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@4.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg=="],
 
-    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.114", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-hy9PBncKzREeHLYcCseFKm16DAJ/P764+Mkd6a5VK7B9VkLRmexwB5c1z6woPX5ta1C/iwB5X/jdtq2G66ibMA=="],
+    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.115", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-mkWYiOEVw/2t2k3aIwqPPayX7OV/RbmtO0AV2PVb0NtHRKuAGxGKwCAlANQIGqXIVB55apCBYuvZUR864bWS/A=="],
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.35.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "react-native-gesture-handler": "~2.31.1",
         "react-native-keychain": "^10.0.0",
         "react-native-mmkv": "^4.3.1",
-        "react-native-nitro-ark": "0.0.113",
+        "react-native-nitro-ark": "0.0.114",
         "react-native-nitro-modules": "0.35.6",
         "react-native-qrcode-svg": "^6.3.21",
         "react-native-quick-base64": "^2.2.2",
@@ -1590,7 +1590,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@4.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg=="],
 
-    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.113", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-UmyhMowie3v/NmCed5gkpjGcJXgm0tDyLbPBtlpuRB3lEYWI8Xyg6kYVhLg4Z4hp6n6g9OHTEk4+NNt1Ax5zGQ=="],
+    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.114", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-hy9PBncKzREeHLYcCseFKm16DAJ/P764+Mkd6a5VK7B9VkLRmexwB5c1z6woPX5ta1C/iwB5X/jdtq2G66ibMA=="],
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.35.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g=="],
 

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -253,7 +253,7 @@ PODS:
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
   - MMKVCore (2.4.0)
-  - NitroArk (0.0.115):
+  - NitroArk (0.0.116):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -3163,7 +3163,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   hermes-engine: 7ba2a073edd246f02086a03c12186700e155b4c7
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: b52e081c5f8194f6140b1229bc5eaf920c28cc37
+  NitroArk: 632cd91817a14968aecce9e8794d1d8d9e675ccd
   NitroMmkv: 1ff46eceb958298b1d7c013a6314432438b77a62
   NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
   NoahTools: efecfcff1688c6e63b9acb210286badaa3eaac36

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -253,7 +253,7 @@ PODS:
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
   - MMKVCore (2.4.0)
-  - NitroArk (0.0.114):
+  - NitroArk (0.0.115):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -3163,7 +3163,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   hermes-engine: 7ba2a073edd246f02086a03c12186700e155b4c7
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: b65271fbfc75af5d08cae9844e05788b27dfb14e
+  NitroArk: b52e081c5f8194f6140b1229bc5eaf920c28cc37
   NitroMmkv: 1ff46eceb958298b1d7c013a6314432438b77a62
   NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
   NoahTools: efecfcff1688c6e63b9acb210286badaa3eaac36

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -253,7 +253,7 @@ PODS:
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
   - MMKVCore (2.4.0)
-  - NitroArk (0.0.113):
+  - NitroArk (0.0.114):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -3163,7 +3163,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   hermes-engine: 7ba2a073edd246f02086a03c12186700e155b4c7
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: ce0d193fd7f39ef39f28f9d44b7a4e8f3194abeb
+  NitroArk: b65271fbfc75af5d08cae9844e05788b27dfb14e
   NitroMmkv: 1ff46eceb958298b1d7c013a6314432438b77a62
   NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
   NoahTools: efecfcff1688c6e63b9acb210286badaa3eaac36

--- a/client/package.json
+++ b/client/package.json
@@ -105,7 +105,7 @@
     "react-native-gesture-handler": "~2.31.1",
     "react-native-keychain": "^10.0.0",
     "react-native-mmkv": "^4.3.1",
-    "react-native-nitro-ark": "0.0.114",
+    "react-native-nitro-ark": "0.0.115",
     "react-native-nitro-modules": "0.35.6",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-quick-base64": "^2.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -105,7 +105,7 @@
     "react-native-gesture-handler": "~2.31.1",
     "react-native-keychain": "^10.0.0",
     "react-native-mmkv": "^4.3.1",
-    "react-native-nitro-ark": "0.0.113",
+    "react-native-nitro-ark": "0.0.114",
     "react-native-nitro-modules": "0.35.6",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-quick-base64": "^2.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -105,7 +105,7 @@
     "react-native-gesture-handler": "~2.31.1",
     "react-native-keychain": "^10.0.0",
     "react-native-mmkv": "^4.3.1",
-    "react-native-nitro-ark": "0.0.115",
+    "react-native-nitro-ark": "0.0.116",
     "react-native-nitro-modules": "0.35.6",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-quick-base64": "^2.2.2",

--- a/client/src/Navigators.tsx
+++ b/client/src/Navigators.tsx
@@ -74,6 +74,7 @@ export type SettingsStackParamList = {
   Profile: undefined;
   Mnemonic: { fromOnboarding: boolean };
   Logs: undefined;
+  EmailVerification: { fromSettings?: boolean } | undefined;
   LightningAddress: { fromOnboarding?: boolean };
   BackupSettings: undefined;
   ArkInfo: undefined;
@@ -92,7 +93,7 @@ export type OnboardingStackParamList = {
   ArkServerAccessToken: { mode: "create" } | { mode: "restore"; mnemonic: string };
   Mnemonic: { fromOnboarding: boolean };
   RestoreWallet: undefined;
-  EmailVerification: undefined;
+  EmailVerification: { fromSettings?: boolean } | undefined;
   LightningAddress: { fromOnboarding: boolean };
   UnifiedPush: { fromOnboarding?: boolean } | undefined;
 };
@@ -130,6 +131,11 @@ const SettingsStackNav = () => (
     <Stack.Screen name="Profile" component={ProfileScreen} options={{ animation: "default" }} />
     <Stack.Screen name="Mnemonic" component={MnemonicScreen} options={{ animation: "default" }} />
     <Stack.Screen name="Logs" component={LogScreen} options={{ animation: "default" }} />
+    <Stack.Screen
+      name="EmailVerification"
+      component={EmailVerificationScreen}
+      options={{ animation: "default" }}
+    />
     <Stack.Screen
       name="LightningAddress"
       component={LightningAddressScreen}

--- a/client/src/components/EmailVerificationBanner.tsx
+++ b/client/src/components/EmailVerificationBanner.tsx
@@ -1,35 +1,45 @@
 import React from "react";
 import { View, Pressable } from "react-native";
-import { ChevronRight, Mail } from "lucide-react-native";
+import { ChevronRight, Mail, X } from "lucide-react-native";
 import { Text } from "./ui/text";
 import { useIconColor } from "~/hooks/useTheme";
 import { COLORS } from "~/lib/styleConstants";
 
 interface EmailVerificationBannerProps {
   onPress: () => void;
+  onDismiss: () => void;
 }
 
-export const EmailVerificationBanner: React.FC<EmailVerificationBannerProps> = ({ onPress }) => {
+export const EmailVerificationBanner: React.FC<EmailVerificationBannerProps> = ({
+  onPress,
+  onDismiss,
+}) => {
   const iconColor = useIconColor();
 
   return (
-    <Pressable onPress={onPress} className="mx-4 mt-4 mb-2">
-      <View className="bg-card border border-border rounded-xl p-4">
+    <View className="mx-4 mt-4 mb-2 bg-card border border-border rounded-xl">
+      <Pressable onPress={onPress} className="p-4 pr-12">
         <View className="flex-row items-center justify-between mb-2">
           <View className="flex-row items-center gap-2">
             <Mail size={20} color={COLORS.BITCOIN_ORANGE} />
             <Text className="text-base font-semibold" style={{ color: COLORS.BITCOIN_ORANGE }}>
-              Verify Your Email
+              Add Emergency Email
             </Text>
           </View>
           <ChevronRight size={20} color={iconColor} />
         </View>
 
         <Text className="text-sm text-muted-foreground">
-          Your wallet is currently limited. Verify your email to enable full functionality including
-          payments and backups.
+          Optional alerts can help us reach you if your VTXOs need attention before they expire.
         </Text>
-      </View>
-    </Pressable>
+      </Pressable>
+      <Pressable
+        onPress={onDismiss}
+        accessibilityLabel="Dismiss emergency email prompt"
+        className="absolute right-3 top-3 h-8 w-8 items-center justify-center rounded-full"
+      >
+        <X size={18} color={iconColor} />
+      </Pressable>
+    </View>
   );
 };

--- a/client/src/components/FeeEstimateSummary.tsx
+++ b/client/src/components/FeeEstimateSummary.tsx
@@ -16,6 +16,7 @@ type FeeEstimateSummaryProps = {
   feeLabel?: string;
   grossLabel?: string;
   unavailableText?: string;
+  note?: string | null;
 };
 
 const FeeEstimateRow = ({
@@ -43,6 +44,7 @@ export const FeeEstimateSummary = ({
   feeLabel = "Estimated fee",
   grossLabel = "Total deducted",
   unavailableText = "Fee estimate unavailable. The final fee will be calculated when you send.",
+  note = null,
 }: FeeEstimateSummaryProps) => {
   const colors = useThemeColors();
 
@@ -90,6 +92,7 @@ export const FeeEstimateSummary = ({
               {estimate.vtxos_spent.length === 1 ? "" : "s"}
             </Text>
           ) : null}
+          {note ? <Text className="mt-2 text-xs text-muted-foreground">{note}</Text> : null}
         </>
       ) : error ? (
         <Text className="text-sm leading-5" style={{ color: COLORS.BITCOIN_ORANGE }}>

--- a/client/src/components/SendConfirmation.tsx
+++ b/client/src/components/SendConfirmation.tsx
@@ -33,6 +33,7 @@ interface SendConfirmationProps {
   isEstimatingFee?: boolean;
   feeEstimateError?: Error | null;
   feeEstimateUnavailableText?: string | null;
+  feeEstimateNote?: string | null;
 }
 
 const truncateValue = (value: string) => {
@@ -65,6 +66,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
   isEstimatingFee = false,
   feeEstimateError = null,
   feeEstimateUnavailableText = null,
+  feeEstimateNote = null,
 }) => {
   const colors = useThemeColors();
   const isOnchainDestination =
@@ -262,6 +264,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
           feeEstimateUnavailableText ? new Error(feeEstimateUnavailableText) : feeEstimateError
         }
         unavailableText={feeEstimateUnavailableText ?? undefined}
+        note={feeEstimateNote}
         compact
       />
 

--- a/client/src/components/SendConfirmation.tsx
+++ b/client/src/components/SendConfirmation.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View } from "react-native";
+import { Pressable, View } from "react-native";
 import { Text } from "./ui/text";
 import { NoahButton } from "./ui/NoahButton";
 import { Button } from "./ui/button";
@@ -9,7 +9,7 @@ import { useThemeColors } from "~/hooks/useTheme";
 import { COLORS } from "~/lib/styleConstants";
 import { Bip321Picker } from "./Bip321Picker";
 import { FeeEstimateSummary } from "./FeeEstimateSummary";
-import type { BarkFeeEstimate } from "~/lib/paymentsApi";
+import type { BarkFeeEstimate, OnchainSendSource } from "~/lib/paymentsApi";
 
 interface SendConfirmationProps {
   destination: string;
@@ -20,12 +20,19 @@ interface SendConfirmationProps {
   bip321Data?: ParsedBip321 | null;
   selectedPaymentMethod?: "ark" | "lightning" | "onchain" | "offer";
   onSelectPaymentMethod?: (type: "ark" | "lightning" | "onchain" | "offer") => void;
+  onchainSourceOptions?: OnchainSendSource[];
+  selectedOnchainSource?: OnchainSendSource | null;
+  onSelectOnchainSource?: (source: OnchainSendSource) => void;
+  onchainWalletBalance?: number;
+  offchainWalletBalance?: number;
   onConfirm: () => void;
   onCancel: () => void;
+  isConfirmDisabled?: boolean;
   isLoading?: boolean;
   feeEstimate?: BarkFeeEstimate;
   isEstimatingFee?: boolean;
   feeEstimateError?: Error | null;
+  feeEstimateUnavailableText?: string | null;
 }
 
 const truncateValue = (value: string) => {
@@ -45,14 +52,30 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
   bip321Data,
   selectedPaymentMethod,
   onSelectPaymentMethod,
+  onchainSourceOptions = [],
+  selectedOnchainSource = null,
+  onSelectOnchainSource,
+  onchainWalletBalance = 0,
+  offchainWalletBalance = 0,
   onConfirm,
   onCancel,
+  isConfirmDisabled = false,
   isLoading = false,
   feeEstimate,
   isEstimatingFee = false,
   feeEstimateError = null,
+  feeEstimateUnavailableText = null,
 }) => {
   const colors = useThemeColors();
+  const isOnchainDestination =
+    destinationType === "onchain" ||
+    (destinationType === "bip321" && selectedPaymentMethod === "onchain");
+
+  const getOnchainSourceLabel = (source: OnchainSendSource) =>
+    source === "offchain" ? "Ark balance" : "Onchain wallet";
+
+  const getOnchainSourceBalance = (source: OnchainSendSource) =>
+    source === "offchain" ? offchainWalletBalance : onchainWalletBalance;
 
   const getPaymentMethodLabel = () => {
     if (destinationType === "bip321") {
@@ -160,6 +183,54 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
           <View className="mt-3 h-px bg-border" />
         )}
 
+        {isOnchainDestination && onchainSourceOptions.length > 0 ? (
+          <>
+            <View className="h-px bg-border" />
+            <View className="py-3">
+              <Text className="text-xs font-medium uppercase tracking-[2px] text-muted-foreground">
+                Send from
+              </Text>
+              {onchainSourceOptions.length > 1 && onSelectOnchainSource ? (
+                <View className="mt-3 flex-row gap-2">
+                  {onchainSourceOptions.map((source) => {
+                    const isSelected = selectedOnchainSource === source;
+                    return (
+                      <Pressable
+                        key={source}
+                        onPress={() => onSelectOnchainSource(source)}
+                        className="flex-1 rounded-2xl border px-3 py-3"
+                        style={{
+                          borderColor: isSelected
+                            ? COLORS.BITCOIN_ORANGE
+                            : `${colors.mutedForeground}26`,
+                          backgroundColor: isSelected
+                            ? "rgba(201, 138, 60, 0.14)"
+                            : `${colors.card}99`,
+                        }}
+                      >
+                        <Text
+                          className={`text-sm font-semibold ${
+                            isSelected ? "text-foreground" : "text-muted-foreground"
+                          }`}
+                        >
+                          {getOnchainSourceLabel(source)}
+                        </Text>
+                        <Text className="mt-1 text-xs text-muted-foreground">
+                          {formatBip177(getOnchainSourceBalance(source))}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              ) : selectedOnchainSource ? (
+                <Text className="mt-1 text-sm font-semibold text-foreground">
+                  {getOnchainSourceLabel(selectedOnchainSource)}
+                </Text>
+              ) : null}
+            </View>
+          </>
+        ) : null}
+
         <View className="py-3">
           <Text className="text-xs font-medium uppercase tracking-[2px] text-muted-foreground">
             Destination
@@ -187,7 +258,10 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
       <FeeEstimateSummary
         estimate={feeEstimate}
         isLoading={isEstimatingFee}
-        error={feeEstimateError}
+        error={
+          feeEstimateUnavailableText ? new Error(feeEstimateUnavailableText) : feeEstimateError
+        }
+        unavailableText={feeEstimateUnavailableText ?? undefined}
         compact
       />
 
@@ -203,7 +277,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
         <NoahButton
           onPress={onConfirm}
           isLoading={isLoading}
-          disabled={isLoading}
+          disabled={isLoading || isConfirmDisabled}
           className="flex-1 rounded-2xl py-3"
         >
           Confirm & Send

--- a/client/src/components/SendConfirmation.tsx
+++ b/client/src/components/SendConfirmation.tsx
@@ -34,6 +34,7 @@ interface SendConfirmationProps {
   feeEstimateError?: Error | null;
   feeEstimateUnavailableText?: string | null;
   feeEstimateNote?: string | null;
+  feeEstimateWarning?: string | null;
 }
 
 const truncateValue = (value: string) => {
@@ -67,6 +68,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
   feeEstimateError = null,
   feeEstimateUnavailableText = null,
   feeEstimateNote = null,
+  feeEstimateWarning = null,
 }) => {
   const colors = useThemeColors();
   const isOnchainDestination =
@@ -267,6 +269,14 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
         note={feeEstimateNote}
         compact
       />
+
+      {feeEstimateWarning ? (
+        <View className="mt-3 rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-3">
+          <Text className="text-sm leading-5 text-amber-700 dark:text-amber-200">
+            {feeEstimateWarning}
+          </Text>
+        </View>
+      ) : null}
 
       <View className="mt-5 flex-row gap-3">
         <Button

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -171,6 +171,20 @@ export const getBlockheightEndpoint = () => {
   }
 };
 
+export const getEsploraApiBaseUrl = (): string | null => {
+  if (APP_VARIANT === "regtest") {
+    return null;
+  }
+
+  const esplora = ACTIVE_WALLET_CONFIG.config?.esplora;
+  if (!esplora) {
+    return null;
+  }
+
+  const withProtocol = /^https?:\/\//.test(esplora) ? esplora : `https://${esplora}`;
+  return withProtocol.replace(/\/+$/, "");
+};
+
 export const getMempoolTxUrl = (anchorPoint: string): string | null => {
   const txid = anchorPoint.split(":")[0];
   if (!txid) {

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -10,9 +10,8 @@ import {
   payLightningInvoice,
   payLightningAddress,
   payLightningOffer,
-  checkLightningPayment,
   type ArkoorPaymentResult,
-  type LightningSendResult,
+  type LightningPayment,
   type OnchainPaymentResult,
   type BarkFeeEstimate,
   boardAllArk,
@@ -168,7 +167,7 @@ type SendVariables = {
   btcPrice?: number;
 };
 
-type SendResult = ArkoorPaymentResult | LightningSendResult | OnchainPaymentResult;
+type SendResult = ArkoorPaymentResult | LightningPayment | OnchainPaymentResult;
 
 export type SendFeeEstimateParams =
   | {
@@ -236,32 +235,21 @@ export function useOffboardAllFeeEstimate(destinationAddress: string | null) {
   });
 }
 
-const awaitLightningPayment = async (
-  paymentPromise: Promise<Result<LightningSendResult, Error>>,
-): Promise<LightningSendResult> => {
+const readLightningPayment = async (
+  paymentPromise: Promise<Result<LightningPayment, Error>>,
+): Promise<LightningPayment> => {
   const result = await paymentPromise;
 
   if (result.isErr()) {
-    log.e("awaitLightningPayment error", [result.error]);
+    log.e("readLightningPayment error", [result.error]);
     throw result.error;
   }
-  if (result.value.preimage) {
-    return result.value;
+
+  if (result.value.state !== "paid") {
+    log.w("Lightning payment did not complete", [result.value]);
+    throw new Error("Lightning payment did not complete.");
   }
 
-  log.d("awaitLightningPayment value", [result.value]);
-
-  const checkResult = await checkLightningPayment(result.value.payment_hash, true);
-  if (checkResult.isErr()) {
-    log.e("checkLightningPayment error", [checkResult.error]);
-    throw checkResult.error;
-  }
-  if (!checkResult.value) {
-    log.w("Lightning payment did not return a preimage", [result.value.payment_hash]);
-    throw new Error("Lightning payment did not complete. No preimage was returned.");
-  }
-
-  result.value.preimage = checkResult.value;
   return result.value;
 };
 
@@ -290,7 +278,7 @@ export function useSend(destinationType: DestinationTypes) {
           result = await sendArkoorPayment(destination, amountSat);
           break;
         case "lightning":
-          return awaitLightningPayment(payLightningInvoice(destination, amountSat));
+          return readLightningPayment(payLightningInvoice(destination, amountSat));
         case "lnurl": {
           if (amountSat === undefined) {
             throw new Error("Amount is required for LNURL payments");
@@ -304,18 +292,18 @@ export function useSend(destinationType: DestinationTypes) {
               }
               const data = noahResult.value;
               if ("payment_hash" in data) {
-                return awaitLightningPayment(
-                  Promise.resolve(noahResult as Result<LightningSendResult, Error>),
+                return readLightningPayment(
+                  Promise.resolve(noahResult as Result<LightningPayment, Error>),
                 );
               }
               return data;
             }
           }
 
-          return awaitLightningPayment(payLightningAddress(destination, amountSat, comment || ""));
+          return readLightningPayment(payLightningAddress(destination, amountSat, comment || ""));
         }
         case "offer":
-          return awaitLightningPayment(payLightningOffer(destination, amountSat));
+          return readLightningPayment(payLightningOffer(destination, amountSat));
         default:
           throw new Error("Invalid destination type");
       }
@@ -339,7 +327,7 @@ async function handleNoahWalletPayment(
   destination: string,
   amountSat: number,
   comment: string | null,
-): Promise<Result<ArkoorPaymentResult | LightningSendResult | OnchainPaymentResult, Error> | null> {
+): Promise<Result<ArkoorPaymentResult | LightningPayment | OnchainPaymentResult, Error> | null> {
   try {
     const [user, domain] = destination.split("@");
     const lnurlEndpoint = `https://${domain}/.well-known/lnurlp/${user}`;

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -16,6 +16,7 @@ import {
   type NoahOnchainPaymentResult,
   type OnchainSendSource,
   type BarkFeeEstimate,
+  type OnchainWalletFeeEstimate,
   boardAllArk,
   offboardAllArk,
   estimateArkoorPaymentFee,
@@ -185,9 +186,11 @@ export type SendFeeEstimateParams =
       amountSat: number;
     };
 
-const readEstimateResult = async (
-  estimatePromise: Promise<Result<BarkFeeEstimate, Error>>,
-): Promise<BarkFeeEstimate> => {
+export type SendFeeEstimate = BarkFeeEstimate | OnchainWalletFeeEstimate;
+
+const readEstimateResult = async <T extends SendFeeEstimate>(
+  estimatePromise: Promise<Result<T, Error>>,
+): Promise<T> => {
   const result = await estimatePromise;
   if (result.isErr()) {
     throw result.error;

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -6,13 +6,15 @@ import {
   boardArk,
   bolt11Invoice,
   onchainSend,
+  sendOnchainFromOffchain,
   sendArkoorPayment,
   payLightningInvoice,
   payLightningAddress,
   payLightningOffer,
   type ArkoorPaymentResult,
   type LightningPayment,
-  type OnchainPaymentResult,
+  type NoahOnchainPaymentResult,
+  type OnchainSendSource,
   type BarkFeeEstimate,
   boardAllArk,
   offboardAllArk,
@@ -164,10 +166,11 @@ type SendVariables = {
   amountSat: number | undefined;
   resolvedAmountSat: number;
   comment: string | null;
+  onchainSource?: OnchainSendSource;
   btcPrice?: number;
 };
 
-type SendResult = ArkoorPaymentResult | LightningPayment | OnchainPaymentResult;
+type SendResult = ArkoorPaymentResult | LightningPayment | NoahOnchainPaymentResult;
 
 export type SendFeeEstimateParams =
   | {
@@ -176,6 +179,7 @@ export type SendFeeEstimateParams =
     }
   | {
       method: "onchain";
+      source: "offchain";
       destination: string;
       amountSat: number;
     };
@@ -258,7 +262,7 @@ export function useSend(destinationType: DestinationTypes) {
 
   return useMutation<SendResult, Error, SendVariables>({
     mutationFn: async (variables) => {
-      const { destination, amountSat, comment } = variables;
+      const { destination, amountSat, comment, onchainSource } = variables;
       if (amountSat === undefined && destinationType !== "lightning") {
         throw new Error("Amount is required");
       }
@@ -269,7 +273,10 @@ export function useSend(destinationType: DestinationTypes) {
           if (amountSat === undefined) {
             throw new Error("Amount is required for onchain payments");
           }
-          result = await onchainSend({ destination, amountSat });
+          result =
+            onchainSource === "offchain"
+              ? await sendOnchainFromOffchain({ destination, amountSat })
+              : await onchainSend({ destination, amountSat });
           break;
         case "ark":
           if (amountSat === undefined) {
@@ -327,7 +334,7 @@ async function handleNoahWalletPayment(
   destination: string,
   amountSat: number,
   comment: string | null,
-): Promise<Result<ArkoorPaymentResult | LightningPayment | OnchainPaymentResult, Error> | null> {
+): Promise<Result<ArkoorPaymentResult | LightningPayment | NoahOnchainPaymentResult, Error> | null> {
   try {
     const [user, domain] = destination.split("@");
     const lnurlEndpoint = `https://${domain}/.well-known/lnurlp/${user}`;

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -21,6 +21,7 @@ import {
   estimateArkoorPaymentFee,
   estimateLightningSendFee,
   estimateSendOnchainFee,
+  estimateOnchainWalletSendFee,
   estimateOffboardAllFee,
 } from "../lib/paymentsApi";
 import { queryClient } from "~/queryClient";
@@ -179,7 +180,7 @@ export type SendFeeEstimateParams =
     }
   | {
       method: "onchain";
-      source: "offchain";
+      source: OnchainSendSource;
       destination: string;
       amountSat: number;
     };
@@ -209,12 +210,14 @@ export function useSendFeeEstimate(params: SendFeeEstimateParams | null) {
         case "lightning":
           return readEstimateResult(estimateLightningSendFee(params.amountSat));
         case "onchain":
-          return readEstimateResult(
-            estimateSendOnchainFee({
-              destination: params.destination,
-              amountSat: params.amountSat,
-            }),
-          );
+          return params.source === "offchain"
+            ? readEstimateResult(
+                estimateSendOnchainFee({
+                  destination: params.destination,
+                  amountSat: params.amountSat,
+                }),
+              )
+            : readEstimateResult(estimateOnchainWalletSendFee({ amountSat: params.amountSat }));
       }
     },
     enabled: params !== null && params.amountSat > 0,

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -10,7 +10,7 @@ import {
 } from "../lib/sendUtils";
 import { useSend, useSendFeeEstimate, type SendFeeEstimateParams } from "./usePayments";
 import {
-  ONCHAIN_WALLET_ESTIMATE_VBYTES,
+  type OnchainWalletFeeEstimate,
   type OnchainSendSource,
   type PaymentResult,
 } from "../lib/paymentsApi";
@@ -33,6 +33,24 @@ type DisplayResult = {
 };
 
 type SendScreenRouteProp = RouteProp<{ params: { destination?: string } }, "params">;
+
+const formatFeeRate = (feeRateSatVb: number) => {
+  if (Number.isInteger(feeRateSatVb)) {
+    return feeRateSatVb.toString();
+  }
+
+  return feeRateSatVb.toFixed(2).replace(/\.?0+$/, "");
+};
+
+const isOnchainWalletFeeEstimate = (
+  estimate: unknown,
+): estimate is OnchainWalletFeeEstimate => {
+  const maybeEstimate = estimate as Partial<OnchainWalletFeeEstimate>;
+  return (
+    typeof maybeEstimate.fee_rate_sat_vb === "number" &&
+    typeof maybeEstimate.estimated_vbytes === "number"
+  );
+};
 
 export const useSendScreen = () => {
   const route = useRoute<SendScreenRouteProp>();
@@ -177,11 +195,6 @@ export const useSendScreen = () => {
   const isOnchainSourceSelectionRequired =
     isOnchainSend && onchainSourceOptions.length > 1 && resolvedOnchainSource === null;
 
-  const feeEstimateNote =
-    isOnchainSend && resolvedOnchainSource === "onchain"
-      ? `Regular fee rate, estimated as a ${ONCHAIN_WALLET_ESTIMATE_VBYTES} vB 2-in/2-out SegWit transaction.`
-      : null;
-
   const feeEstimateParams = useMemo<SendFeeEstimateParams | null>(() => {
     if (!showConfirmation) {
       return null;
@@ -262,6 +275,19 @@ export const useSendScreen = () => {
   }, [feeEstimateParams]);
 
   const feeEstimateQuery = useSendFeeEstimate(debouncedFeeEstimateParams);
+
+  const feeEstimateNote = useMemo(() => {
+    if (!isOnchainSend || resolvedOnchainSource !== "onchain") {
+      return null;
+    }
+
+    const estimate = feeEstimateQuery.data;
+    if (!isOnchainWalletFeeEstimate(estimate)) {
+      return null;
+    }
+
+    return `Regular fee rate: ${formatFeeRate(estimate.fee_rate_sat_vb)} sat/vB. Estimated as a ${estimate.estimated_vbytes} vB 2-in/2-out SegWit transaction.`;
+  }, [feeEstimateQuery.data, isOnchainSend, resolvedOnchainSource]);
 
   useEffect(() => {
     if (!feeEstimateQuery.error) {

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -45,6 +45,10 @@ const formatFeeRate = (feeRateSatVb: number) => {
 const isOnchainWalletFeeEstimate = (
   estimate: unknown,
 ): estimate is OnchainWalletFeeEstimate => {
+  if (!estimate || typeof estimate !== "object") {
+    return false;
+  }
+
   const maybeEstimate = estimate as Partial<OnchainWalletFeeEstimate>;
   return (
     typeof maybeEstimate.fee_rate_sat_vb === "number" &&

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -9,7 +9,11 @@ import {
   ParsedBip321,
 } from "../lib/sendUtils";
 import { useSend, useSendFeeEstimate, type SendFeeEstimateParams } from "./usePayments";
-import { type OnchainSendSource, type PaymentResult } from "../lib/paymentsApi";
+import {
+  ONCHAIN_WALLET_ESTIMATE_VBYTES,
+  type OnchainSendSource,
+  type PaymentResult,
+} from "../lib/paymentsApi";
 import { useQRCodeScanner } from "~/hooks/useQRCodeScanner";
 import { useBtcToUsdRate } from "./useMarketData";
 import { useBalance } from "./useWallet";
@@ -173,9 +177,9 @@ export const useSendScreen = () => {
   const isOnchainSourceSelectionRequired =
     isOnchainSend && onchainSourceOptions.length > 1 && resolvedOnchainSource === null;
 
-  const onchainWalletFeeUnavailableText =
+  const feeEstimateNote =
     isOnchainSend && resolvedOnchainSource === "onchain"
-      ? "Fee estimate unavailable. The final onchain wallet fee will be calculated when you send."
+      ? `Regular fee rate, estimated as a ${ONCHAIN_WALLET_ESTIMATE_VBYTES} vB 2-in/2-out SegWit transaction.`
       : null;
 
   const feeEstimateParams = useMemo<SendFeeEstimateParams | null>(() => {
@@ -196,10 +200,10 @@ export const useSendScreen = () => {
         case "offer":
           return bip321Data.offer ? { method: "lightning", amountSat } : null;
         case "onchain":
-          return bip321Data.onchainAddress && resolvedOnchainSource === "offchain"
+          return bip321Data.onchainAddress && resolvedOnchainSource !== null
             ? {
                 method: "onchain",
-                source: "offchain",
+                source: resolvedOnchainSource,
                 destination: bip321Data.onchainAddress,
                 amountSat,
               }
@@ -217,8 +221,13 @@ export const useSendScreen = () => {
       case "offer":
         return { method: "lightning", amountSat };
       case "onchain":
-        return cleanedDestination && resolvedOnchainSource === "offchain"
-          ? { method: "onchain", source: "offchain", destination: cleanedDestination, amountSat }
+        return cleanedDestination && resolvedOnchainSource !== null
+          ? {
+              method: "onchain",
+              source: resolvedOnchainSource,
+              destination: cleanedDestination,
+              amountSat,
+            }
           : null;
       default:
         return null;
@@ -555,6 +564,7 @@ export const useSendScreen = () => {
     feeEstimate: feeEstimateQuery.data,
     isEstimatingFee: feeEstimateQuery.isFetching,
     feeEstimateError: feeEstimateQuery.error,
-    feeEstimateUnavailableText: onchainWalletFeeUnavailableText,
+    feeEstimateUnavailableText: null,
+    feeEstimateNote,
   };
 };

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -250,8 +250,8 @@ export const useSendScreen = () => {
         };
       }
 
-      // Check for lightning payment (has invoice)
-      if ("invoice" in res) {
+      // Check for lightning payment
+      if ("payment_hash" in res) {
         if (!res.preimage) {
           log.e("Lightning payment result missing preimage", [res]);
           showAlert({
@@ -268,8 +268,8 @@ export const useSendScreen = () => {
 
         return {
           success: true,
-          amount_sat: res.amount,
-          destination: res.invoice,
+          amount_sat: res.amount ?? amountSat,
+          destination: res.invoice ?? res.payment_hash,
           preimage: res.preimage,
           type: "Lightning",
         };

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -9,9 +9,10 @@ import {
   ParsedBip321,
 } from "../lib/sendUtils";
 import { useSend, useSendFeeEstimate, type SendFeeEstimateParams } from "./usePayments";
-import { type PaymentResult } from "../lib/paymentsApi";
+import { type OnchainSendSource, type PaymentResult } from "../lib/paymentsApi";
 import { useQRCodeScanner } from "~/hooks/useQRCodeScanner";
 import { useBtcToUsdRate } from "./useMarketData";
+import { useBalance } from "./useWallet";
 import { useLightningAddressSuggestions } from "./useLightningAddressSuggestions";
 import { satsToUsd, usdToSats } from "../lib/utils";
 import logger from "~/lib/log";
@@ -33,6 +34,7 @@ export const useSendScreen = () => {
   const route = useRoute<SendScreenRouteProp>();
   const { showAlert } = useAlert();
   const { data: btcPrice } = useBtcToUsdRate();
+  const { data: balance } = useBalance();
   const [destination, setDestination] = useState("");
   const [amount, setAmount] = useState("");
   const [isAmountEditable, setIsAmountEditable] = useState(true);
@@ -45,6 +47,9 @@ export const useSendScreen = () => {
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
     "ark" | "lightning" | "onchain" | "offer"
   >("onchain");
+  const [selectedOnchainSource, setSelectedOnchainSource] = useState<OnchainSendSource | null>(
+    null,
+  );
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
   const [isDestinationFocused, setIsDestinationFocused] = useState(false);
@@ -129,6 +134,50 @@ export const useSendScreen = () => {
     return 0;
   }, [amount, currency, btcPrice]);
 
+  const isOnchainSend = finalDestinationType === "onchain";
+  const onchainWalletBalance = balance?.onchain.confirmed ?? 0;
+  const offchainWalletBalance = balance?.offchain.spendable ?? 0;
+
+  const onchainSourceOptions = useMemo<OnchainSendSource[]>(() => {
+    if (!isOnchainSend || amountSat <= 0 || !balance) {
+      return [];
+    }
+
+    const options: OnchainSendSource[] = [];
+    if (offchainWalletBalance >= amountSat) {
+      options.push("offchain");
+    }
+    if (onchainWalletBalance >= amountSat) {
+      options.push("onchain");
+    }
+    return options;
+  }, [amountSat, balance, isOnchainSend, offchainWalletBalance, onchainWalletBalance]);
+
+  useEffect(() => {
+    if (!isOnchainSend || amountSat <= 0) {
+      setSelectedOnchainSource(null);
+      return;
+    }
+
+    if (
+      selectedOnchainSource !== null &&
+      !onchainSourceOptions.includes(selectedOnchainSource)
+    ) {
+      setSelectedOnchainSource(null);
+    }
+  }, [amountSat, isOnchainSend, onchainSourceOptions, selectedOnchainSource]);
+
+  const resolvedOnchainSource =
+    selectedOnchainSource ?? (onchainSourceOptions.length === 1 ? onchainSourceOptions[0] : null);
+
+  const isOnchainSourceSelectionRequired =
+    isOnchainSend && onchainSourceOptions.length > 1 && resolvedOnchainSource === null;
+
+  const onchainWalletFeeUnavailableText =
+    isOnchainSend && resolvedOnchainSource === "onchain"
+      ? "Fee estimate unavailable. The final onchain wallet fee will be calculated when you send."
+      : null;
+
   const feeEstimateParams = useMemo<SendFeeEstimateParams | null>(() => {
     if (!showConfirmation) {
       return null;
@@ -147,8 +196,13 @@ export const useSendScreen = () => {
         case "offer":
           return bip321Data.offer ? { method: "lightning", amountSat } : null;
         case "onchain":
-          return bip321Data.onchainAddress
-            ? { method: "onchain", destination: bip321Data.onchainAddress, amountSat }
+          return bip321Data.onchainAddress && resolvedOnchainSource === "offchain"
+            ? {
+                method: "onchain",
+                source: "offchain",
+                destination: bip321Data.onchainAddress,
+                amountSat,
+              }
             : null;
       }
     }
@@ -163,8 +217,8 @@ export const useSendScreen = () => {
       case "offer":
         return { method: "lightning", amountSat };
       case "onchain":
-        return cleanedDestination
-          ? { method: "onchain", destination: cleanedDestination, amountSat }
+        return cleanedDestination && resolvedOnchainSource === "offchain"
+          ? { method: "onchain", source: "offchain", destination: cleanedDestination, amountSat }
           : null;
       default:
         return null;
@@ -175,6 +229,7 @@ export const useSendScreen = () => {
     destination,
     destinationType,
     finalDestinationType,
+    resolvedOnchainSource,
     selectedPaymentMethod,
     showConfirmation,
   ]);
@@ -236,7 +291,7 @@ export const useSendScreen = () => {
           amount_sat: res.amount_sat,
           destination: res.destination_address,
           txid: res.txid,
-          type: "Onchain",
+          type: res.source === "offchain" ? "Onchain from Ark" : "Onchain",
         };
       }
 
@@ -313,6 +368,22 @@ export const useSendScreen = () => {
       showAlert({ title: "Invalid Amount", description: "Please enter a valid amount." });
       return;
     }
+    if (isOnchainSend) {
+      if (!balance) {
+        showAlert({
+          title: "Balance Unavailable",
+          description: "Unable to check wallet balances. Please try again.",
+        });
+        return;
+      }
+      if (onchainSourceOptions.length === 0) {
+        showAlert({
+          title: "Insufficient Funds",
+          description: "Neither your Ark balance nor onchain wallet can cover this payment.",
+        });
+        return;
+      }
+    }
 
     // Show confirmation instead of sending immediately
     setIsDestinationFocused(false);
@@ -346,6 +417,13 @@ export const useSendScreen = () => {
         });
         return;
       }
+      if (newDestinationType === "onchain" && resolvedOnchainSource === null) {
+        showAlert({
+          title: "Choose Send Source",
+          description: "Choose whether to send from your Ark balance or onchain wallet.",
+        });
+        return;
+      }
 
       send({
         destination: destinationToSend,
@@ -356,10 +434,19 @@ export const useSendScreen = () => {
             : amountSat,
         resolvedAmountSat: amountSat,
         comment: comment || null,
+        onchainSource:
+          newDestinationType === "onchain" ? resolvedOnchainSource ?? undefined : undefined,
         btcPrice,
       });
     } else {
       const cleanedDestination = destination.replace(/^(bitcoin:|lightning:)/i, "");
+      if (finalDestinationType === "onchain" && resolvedOnchainSource === null) {
+        showAlert({
+          title: "Choose Send Source",
+          description: "Choose whether to send from your Ark balance or onchain wallet.",
+        });
+        return;
+      }
 
       send({
         destination: cleanedDestination,
@@ -367,6 +454,8 @@ export const useSendScreen = () => {
           finalDestinationType === "lightning" && !isAmountEditable ? undefined : amountSat,
         resolvedAmountSat: amountSat,
         comment: comment || null,
+        onchainSource:
+          finalDestinationType === "onchain" ? resolvedOnchainSource ?? undefined : undefined,
         btcPrice,
       });
     }
@@ -452,6 +541,13 @@ export const useSendScreen = () => {
     bip321Data,
     selectedPaymentMethod,
     setSelectedPaymentMethod,
+    onchainSourceOptions,
+    selectedOnchainSource: resolvedOnchainSource,
+    setSelectedOnchainSource,
+    resolvedOnchainSource,
+    isOnchainSourceSelectionRequired,
+    onchainWalletBalance,
+    offchainWalletBalance,
     showConfirmation,
     destinationType,
     showSuccess,
@@ -459,5 +555,6 @@ export const useSendScreen = () => {
     feeEstimate: feeEstimateQuery.data,
     isEstimatingFee: feeEstimateQuery.isFetching,
     feeEstimateError: feeEstimateQuery.error,
+    feeEstimateUnavailableText: onchainWalletFeeUnavailableText,
   };
 };

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -18,7 +18,7 @@ import { useQRCodeScanner } from "~/hooks/useQRCodeScanner";
 import { useBtcToUsdRate } from "./useMarketData";
 import { useBalance } from "./useWallet";
 import { useLightningAddressSuggestions } from "./useLightningAddressSuggestions";
-import { satsToUsd, usdToSats } from "../lib/utils";
+import { formatBip177, satsToUsd, usdToSats } from "../lib/utils";
 import logger from "~/lib/log";
 
 const log = logger("useSendScreen");
@@ -292,6 +292,29 @@ export const useSendScreen = () => {
 
     return `Regular fee rate: ${formatFeeRate(estimate.fee_rate_sat_vb)} sat/vB. Estimated as a ${estimate.estimated_vbytes} vB 2-in/2-out SegWit transaction.`;
   }, [feeEstimateQuery.data, isOnchainSend, resolvedOnchainSource]);
+
+  const feeEstimateWarning = useMemo(() => {
+    if (!isOnchainSend || resolvedOnchainSource === null || !feeEstimateQuery.data) {
+      return null;
+    }
+
+    const sourceBalance =
+      resolvedOnchainSource === "offchain" ? offchainWalletBalance : onchainWalletBalance;
+    const estimatedTotal = feeEstimateQuery.data.gross_amount_sat;
+
+    if (estimatedTotal <= sourceBalance) {
+      return null;
+    }
+
+    const sourceLabel = resolvedOnchainSource === "offchain" ? "Ark" : "onchain";
+    return `Estimated total is ${formatBip177(estimatedTotal)}, but your ${sourceLabel} balance is ${formatBip177(sourceBalance)}. The send may fail if the final fee is not lower.`;
+  }, [
+    feeEstimateQuery.data,
+    isOnchainSend,
+    offchainWalletBalance,
+    onchainWalletBalance,
+    resolvedOnchainSource,
+  ]);
 
   useEffect(() => {
     if (!feeEstimateQuery.error) {
@@ -596,5 +619,6 @@ export const useSendScreen = () => {
     feeEstimateError: feeEstimateQuery.error,
     feeEstimateUnavailableText: null,
     feeEstimateNote,
+    feeEstimateWarning,
   };
 };

--- a/client/src/hooks/useTransactions.ts
+++ b/client/src/hooks/useTransactions.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { validateBitcoinAddress } from "bip-321";
-import { history } from "~/lib/paymentsApi";
+import { history, onchainTransactions } from "~/lib/paymentsApi";
 import { loadWalletIfNeeded } from "~/lib/walletApi";
 import { useWalletStore } from "~/store/walletStore";
 import type { Transaction, PaymentTypes } from "~/types/transaction";
-import type { BarkMovement, MovementStatus } from "react-native-nitro-ark";
+import type { BarkMovement, MovementStatus, OnchainTransactionInfo } from "react-native-nitro-ark";
 import type { MovementKind } from "~/types/movement";
 import { INCOMING_MOVEMENT_KINDS } from "~/types/movement";
 import { getHistoricalBtcToUsdRate } from "~/hooks/useMarketData";
@@ -20,6 +20,7 @@ import {
 } from "~/lib/barkMovement";
 
 const log = logger("useTransactions");
+const UNKNOWN_ONCHAIN_DATE_ISO = new Date(0).toISOString();
 
 const SUBSYSTEM_KIND_TO_MOVEMENT_KIND: Partial<Record<BarkSubsystemId, MovementKind>> = {
   [`${BARK_SUBSYSTEM.BOARD.name}:${BARK_SUBSYSTEM.BOARD.kind}`]: "onboard",
@@ -216,8 +217,10 @@ const transformMovementToTransaction = async (movement: BarkMovement): Promise<T
     txid,
     amount,
     date: dateIso,
+    sortTimestamp: new Date(dateIso).getTime(),
     direction,
     type: transactionType,
+    source: "ark",
     btcPrice,
     description: "",
     destination: destination ?? "",
@@ -242,6 +245,69 @@ const transformMovementToTransaction = async (movement: BarkMovement): Promise<T
     outputVtxos: movement.output_vtxos,
     exitedVtxos: movement.exited_vtxos,
   };
+};
+
+const shouldIncludeOnchainTransaction = (transaction: OnchainTransactionInfo): boolean => {
+  return transaction.balance_change_sat !== 0;
+};
+
+const getOnchainTransactionLabel = (transaction: OnchainTransactionInfo): string => {
+  if (transaction.has_confirmation) {
+    return `Confirmed at block ${transaction.confirmation_height}`;
+  }
+
+  return "Unconfirmed";
+};
+
+const transformOnchainTransaction = (transaction: OnchainTransactionInfo): Transaction => {
+  const isOutgoing = transaction.balance_change_sat < 0;
+
+  return {
+    id: `onchain-wallet-${transaction.txid}`,
+    txid: transaction.txid,
+    txHex: transaction.tx_hex,
+    amount: Math.abs(transaction.balance_change_sat),
+    date: UNKNOWN_ONCHAIN_DATE_ISO,
+    dateLabel: getOnchainTransactionLabel(transaction),
+    sortHeight: transaction.has_confirmation ? transaction.confirmation_height : undefined,
+    direction: isOutgoing ? "outgoing" : "incoming",
+    type: "Onchain",
+    source: "onchain-wallet",
+    description: "",
+    balanceChangeSat: transaction.balance_change_sat,
+    hasOnchainFee: transaction.has_onchain_fee,
+    onchainFeeSat: transaction.has_onchain_fee ? transaction.onchain_fee_sat : undefined,
+    hasConfirmation: transaction.has_confirmation,
+    confirmationHeight: transaction.has_confirmation
+      ? transaction.confirmation_height
+      : undefined,
+    confirmationHash: transaction.has_confirmation
+      ? transaction.confirmation_hash
+      : undefined,
+  };
+};
+
+const compareTransactions = (a: Transaction, b: Transaction): number => {
+  const aIsOnchainWallet = a.source === "onchain-wallet";
+  const bIsOnchainWallet = b.source === "onchain-wallet";
+  const aIsUnconfirmedOnchainWallet = aIsOnchainWallet && !a.hasConfirmation;
+  const bIsUnconfirmedOnchainWallet = bIsOnchainWallet && !b.hasConfirmation;
+
+  if (aIsUnconfirmedOnchainWallet !== bIsUnconfirmedOnchainWallet) {
+    return aIsUnconfirmedOnchainWallet ? -1 : 1;
+  }
+
+  if (aIsOnchainWallet && bIsOnchainWallet) {
+    return (b.sortHeight ?? 0) - (a.sortHeight ?? 0);
+  }
+
+  if (aIsOnchainWallet !== bIsOnchainWallet) {
+    return aIsOnchainWallet ? 1 : -1;
+  }
+
+  const aSortTimestamp = a.sortTimestamp ?? new Date(a.date).getTime();
+  const bSortTimestamp = b.sortTimestamp ?? new Date(b.date).getTime();
+  return bSortTimestamp - aSortTimestamp;
 };
 
 const shouldIncludeMovement = (movement: BarkMovement): boolean => {
@@ -270,22 +336,32 @@ const fetchAndTransformTransactions = async (): Promise<Transaction[]> => {
     return [];
   }
 
-  const movementsResult = await history();
+  const [movementsResult, onchainTransactionsResult] = await Promise.all([
+    history(),
+    onchainTransactions(),
+  ]);
 
   if (movementsResult.isErr()) {
     log.e("Failed to fetch movements:", [movementsResult.error]);
     throw movementsResult.error;
   }
 
-  const movements = movementsResult.value.filter(shouldIncludeMovement);
+  if (onchainTransactionsResult.isErr()) {
+    log.e("Failed to fetch onchain wallet transactions:", [onchainTransactionsResult.error]);
+    throw onchainTransactionsResult.error;
+  }
 
-  if (movements.length === 0) {
+  const movements = movementsResult.value.filter(shouldIncludeMovement);
+  const walletTransactions = onchainTransactionsResult.value.filter(shouldIncludeOnchainTransaction);
+
+  if (movements.length === 0 && walletTransactions.length === 0) {
     return [];
   }
 
-  const transactions = await Promise.all(movements.map(transformMovementToTransaction));
+  const movementTransactions = await Promise.all(movements.map(transformMovementToTransaction));
+  const onchainWalletTransactions = walletTransactions.map(transformOnchainTransaction);
 
-  return transactions.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  return [...movementTransactions, ...onchainWalletTransactions].sort(compareTransactions);
 };
 
 export const useTransactions = (options?: { enabled?: boolean }) => {

--- a/client/src/hooks/useTransactions.ts
+++ b/client/src/hooks/useTransactions.ts
@@ -1,5 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { validateBitcoinAddress } from "bip-321";
+import ky from "ky";
+import { getEsploraApiBaseUrl } from "~/constants";
 import { history, onchainTransactions } from "~/lib/paymentsApi";
 import { loadWalletIfNeeded } from "~/lib/walletApi";
 import { useWalletStore } from "~/store/walletStore";
@@ -21,6 +23,15 @@ import {
 
 const log = logger("useTransactions");
 const UNKNOWN_ONCHAIN_DATE_ISO = new Date(0).toISOString();
+
+type EsploraTransactionResponse = {
+  status?: {
+    confirmed?: boolean;
+    block_height?: number;
+    block_hash?: string;
+    block_time?: number;
+  };
+};
 
 const SUBSYSTEM_KIND_TO_MOVEMENT_KIND: Partial<Record<BarkSubsystemId, MovementKind>> = {
   [`${BARK_SUBSYSTEM.BOARD.name}:${BARK_SUBSYSTEM.BOARD.kind}`]: "onboard",
@@ -259,20 +270,62 @@ const getOnchainTransactionLabel = (transaction: OnchainTransactionInfo): string
   return "Unconfirmed";
 };
 
-const transformOnchainTransaction = (transaction: OnchainTransactionInfo): Transaction => {
+const getOnchainTransactionBlockTime = async (
+  transaction: OnchainTransactionInfo,
+): Promise<number | undefined> => {
+  if (!transaction.has_confirmation) {
+    return undefined;
+  }
+
+  const esploraBaseUrl = getEsploraApiBaseUrl();
+  if (!esploraBaseUrl) {
+    return undefined;
+  }
+
+  try {
+    const response = await ky
+      .get(`${esploraBaseUrl}/tx/${transaction.txid}`)
+      .json<EsploraTransactionResponse>();
+
+    if (!response.status?.confirmed || typeof response.status.block_time !== "number") {
+      return undefined;
+    }
+
+    return response.status.block_time;
+  } catch (error) {
+    log.w("Failed to fetch onchain transaction timestamp", [transaction.txid, error]);
+    return undefined;
+  }
+};
+
+const transformOnchainTransaction = async (
+  transaction: OnchainTransactionInfo,
+): Promise<Transaction> => {
   const isOutgoing = transaction.balance_change_sat < 0;
+  const blockTime = await getOnchainTransactionBlockTime(transaction);
+  const date = blockTime ? new Date(blockTime * 1000).toISOString() : UNKNOWN_ONCHAIN_DATE_ISO;
+
+  let btcPrice: number | undefined;
+  if (blockTime) {
+    const btcPriceResult = await getHistoricalBtcToUsdRate(date);
+    if (btcPriceResult.isOk()) {
+      btcPrice = btcPriceResult.value;
+    }
+  }
 
   return {
     id: `onchain-wallet-${transaction.txid}`,
     txid: transaction.txid,
     txHex: transaction.tx_hex,
     amount: Math.abs(transaction.balance_change_sat),
-    date: UNKNOWN_ONCHAIN_DATE_ISO,
-    dateLabel: getOnchainTransactionLabel(transaction),
+    date,
+    dateLabel: blockTime ? undefined : getOnchainTransactionLabel(transaction),
+    sortTimestamp: blockTime ? blockTime * 1000 : undefined,
     sortHeight: transaction.has_confirmation ? transaction.confirmation_height : undefined,
     direction: isOutgoing ? "outgoing" : "incoming",
     type: "Onchain",
     source: "onchain-wallet",
+    btcPrice,
     description: "",
     balanceChangeSat: transaction.balance_change_sat,
     hasOnchainFee: transaction.has_onchain_fee,
@@ -292,17 +345,23 @@ const compareTransactions = (a: Transaction, b: Transaction): number => {
   const bIsOnchainWallet = b.source === "onchain-wallet";
   const aIsUnconfirmedOnchainWallet = aIsOnchainWallet && !a.hasConfirmation;
   const bIsUnconfirmedOnchainWallet = bIsOnchainWallet && !b.hasConfirmation;
+  const aHasReliableTimestamp = typeof a.sortTimestamp === "number" && a.sortTimestamp > 0;
+  const bHasReliableTimestamp = typeof b.sortTimestamp === "number" && b.sortTimestamp > 0;
 
   if (aIsUnconfirmedOnchainWallet !== bIsUnconfirmedOnchainWallet) {
     return aIsUnconfirmedOnchainWallet ? -1 : 1;
+  }
+
+  if (aHasReliableTimestamp && bHasReliableTimestamp) {
+    return (b.sortTimestamp ?? 0) - (a.sortTimestamp ?? 0);
   }
 
   if (aIsOnchainWallet && bIsOnchainWallet) {
     return (b.sortHeight ?? 0) - (a.sortHeight ?? 0);
   }
 
-  if (aIsOnchainWallet !== bIsOnchainWallet) {
-    return aIsOnchainWallet ? 1 : -1;
+  if (aHasReliableTimestamp !== bHasReliableTimestamp) {
+    return aHasReliableTimestamp ? -1 : 1;
   }
 
   const aSortTimestamp = a.sortTimestamp ?? new Date(a.date).getTime();
@@ -359,7 +418,9 @@ const fetchAndTransformTransactions = async (): Promise<Transaction[]> => {
   }
 
   const movementTransactions = await Promise.all(movements.map(transformMovementToTransaction));
-  const onchainWalletTransactions = walletTransactions.map(transformOnchainTransaction);
+  const onchainWalletTransactions = await Promise.all(
+    walletTransactions.map(transformOnchainTransaction),
+  );
 
   return [...movementTransactions, ...onchainWalletTransactions].sort(compareTransactions);
 };

--- a/client/src/lib/paymentsApi.ts
+++ b/client/src/lib/paymentsApi.ts
@@ -12,7 +12,7 @@ import {
   bolt11Invoice as bolt11InvoiceNitro,
   type ArkoorPaymentResult,
   type OnchainPaymentResult,
-  type LightningSendResult,
+  type LightningPayment,
   newAddress as newAddressNitro,
   onchainAddress as onchainAddressNitro,
   payLightningInvoice as payLightningInvoiceNitro,
@@ -35,7 +35,7 @@ import {
 } from "react-native-nitro-ark";
 import { err, ok, Result, ResultAsync } from "neverthrow";
 
-export type { ArkoorPaymentResult, OnchainPaymentResult, LightningSendResult, BarkFeeEstimate };
+export type { ArkoorPaymentResult, OnchainPaymentResult, LightningPayment, BarkFeeEstimate };
 export type { BarkNotificationEvent };
 
 export type BarkNotificationSubscription = {
@@ -43,7 +43,7 @@ export type BarkNotificationSubscription = {
   isActive(): boolean;
 };
 
-export type PaymentResult = ArkoorPaymentResult | OnchainPaymentResult | LightningSendResult;
+export type PaymentResult = ArkoorPaymentResult | OnchainPaymentResult | LightningPayment;
 
 export const newAddress = async (): Promise<Result<NewAddressResult, Error>> => {
   return ResultAsync.fromPromise(
@@ -127,8 +127,8 @@ export const sendArkoorPayment = async (
 export const payLightningInvoice = async (
   destination: string,
   amountSat: number | undefined,
-): Promise<Result<LightningSendResult, Error>> => {
-  return ResultAsync.fromPromise(payLightningInvoiceNitro(destination, amountSat), (error) => {
+): Promise<Result<LightningPayment, Error>> => {
+  return ResultAsync.fromPromise(payLightningInvoiceNitro(destination, true, amountSat), (error) => {
     const e = new Error(
       `Failed to send bolt11 payment: ${error instanceof Error ? error.message : String(error)}`,
     );
@@ -139,8 +139,8 @@ export const payLightningInvoice = async (
 export const payLightningOffer = async (
   destination: string,
   amountSat: number | undefined,
-): Promise<Result<LightningSendResult, Error>> => {
-  return ResultAsync.fromPromise(payLightningOfferNitro(destination, amountSat), (error) => {
+): Promise<Result<LightningPayment, Error>> => {
+  return ResultAsync.fromPromise(payLightningOfferNitro(destination, true, amountSat), (error) => {
     const e = new Error(
       `Failed to send bolt12 payment: ${error instanceof Error ? error.message : String(error)}`,
     );
@@ -220,8 +220,8 @@ export const payLightningAddress = async (
   addr: string,
   amountSat: number,
   comment: string,
-): Promise<Result<LightningSendResult, Error>> => {
-  return ResultAsync.fromPromise(payLightningAddressNitro(addr, amountSat, comment), (error) => {
+): Promise<Result<LightningPayment, Error>> => {
+  return ResultAsync.fromPromise(payLightningAddressNitro(addr, amountSat, comment, true), (error) => {
     const e = new Error(
       `Failed to send to lightning address: ${
         error instanceof Error ? error.message : String(error)
@@ -235,7 +235,7 @@ export const payLightningAddress = async (
 export const checkLightningPayment = async (
   paymentHash: string,
   wait: boolean = false,
-): Promise<Result<string | null, Error>> => {
+): Promise<Result<LightningPayment, Error>> => {
   return ResultAsync.fromPromise(checkLightningPaymentNitro(paymentHash, wait), (error) => {
     const e = new Error(
       `Failed to check lightning payment: ${

--- a/client/src/lib/paymentsApi.ts
+++ b/client/src/lib/paymentsApi.ts
@@ -60,6 +60,11 @@ export type NoahOnchainPaymentResult = OnchainPaymentResult & {
 
 export type PaymentResult = ArkoorPaymentResult | NoahOnchainPaymentResult | LightningPayment;
 
+export type OnchainWalletFeeEstimate = BarkFeeEstimate & {
+  fee_rate_sat_vb: number;
+  estimated_vbytes: number;
+};
+
 export const newAddress = async (): Promise<Result<NewAddressResult, Error>> => {
   return ResultAsync.fromPromise(
     newAddressNitro(),
@@ -267,19 +272,22 @@ export const estimateOnchainWalletSendFee = async ({
   amountSat,
 }: {
   amountSat: number;
-}): Promise<Result<BarkFeeEstimate, Error>> => {
+}): Promise<Result<OnchainWalletFeeEstimate, Error>> => {
   const ratesResult = await onchainFeeRates();
   if (ratesResult.isErr()) {
     return err(ratesResult.error);
   }
 
-  const feeSat = Math.ceil(ratesResult.value.regular * ONCHAIN_WALLET_ESTIMATE_VBYTES);
+  const feeRateSatVb = ratesResult.value.regular;
+  const feeSat = Math.ceil(feeRateSatVb * ONCHAIN_WALLET_ESTIMATE_VBYTES);
 
   return ok({
     gross_amount_sat: amountSat + feeSat,
     fee_sat: feeSat,
     net_amount_sat: amountSat,
     vtxos_spent: [],
+    fee_rate_sat_vb: feeRateSatVb,
+    estimated_vbytes: ONCHAIN_WALLET_ESTIMATE_VBYTES,
   });
 };
 

--- a/client/src/lib/paymentsApi.ts
+++ b/client/src/lib/paymentsApi.ts
@@ -19,6 +19,7 @@ import {
   onchainSend as onchainSendNitro,
   sendOnchain as sendOnchainNitro,
   onchainFeeRates as onchainFeeRatesNitro,
+  onchainTransactions as onchainTransactionsNitro,
   estimateArkoorPaymentFee as estimateArkoorPaymentFeeNitro,
   estimateLightningSendFee as estimateLightningSendFeeNitro,
   estimateSendOnchain as estimateSendOnchainNitro,
@@ -32,6 +33,7 @@ import {
   BarkNotificationEvent,
   BarkFeeEstimate,
   BarkFeeRates,
+  OnchainTransactionInfo,
   Bolt11Invoice,
   BoardResult,
   LightningReceive,
@@ -44,6 +46,7 @@ export type {
   LightningPayment,
   BarkFeeEstimate,
   BarkFeeRates,
+  OnchainTransactionInfo,
 };
 export type { BarkNotificationEvent };
 
@@ -348,6 +351,18 @@ export const history = async (): Promise<Result<BarkMovement[], Error>> => {
   return ResultAsync.fromPromise(historyNitro(), (error) => {
     const e = new Error(
       `Failed to get movements: ${error instanceof Error ? error.message : String(error)}`,
+    );
+
+    return e;
+  });
+};
+
+export const onchainTransactions = async (): Promise<Result<OnchainTransactionInfo[], Error>> => {
+  return ResultAsync.fromPromise(onchainTransactionsNitro(), (error) => {
+    const e = new Error(
+      `Failed to get onchain wallet transactions: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
     );
 
     return e;

--- a/client/src/lib/paymentsApi.ts
+++ b/client/src/lib/paymentsApi.ts
@@ -17,6 +17,7 @@ import {
   onchainAddress as onchainAddressNitro,
   payLightningInvoice as payLightningInvoiceNitro,
   onchainSend as onchainSendNitro,
+  sendOnchain as sendOnchainNitro,
   estimateArkoorPaymentFee as estimateArkoorPaymentFeeNitro,
   estimateLightningSendFee as estimateLightningSendFeeNitro,
   estimateSendOnchain as estimateSendOnchainNitro,
@@ -43,7 +44,13 @@ export type BarkNotificationSubscription = {
   isActive(): boolean;
 };
 
-export type PaymentResult = ArkoorPaymentResult | OnchainPaymentResult | LightningPayment;
+export type OnchainSendSource = "onchain" | "offchain";
+
+export type NoahOnchainPaymentResult = OnchainPaymentResult & {
+  source: OnchainSendSource;
+};
+
+export type PaymentResult = ArkoorPaymentResult | NoahOnchainPaymentResult | LightningPayment;
 
 export const newAddress = async (): Promise<Result<NewAddressResult, Error>> => {
   return ResultAsync.fromPromise(
@@ -154,14 +161,37 @@ export const onchainSend = async ({
 }: {
   destination: string;
   amountSat: number;
-}): Promise<Result<OnchainPaymentResult, Error>> => {
+}): Promise<Result<NoahOnchainPaymentResult, Error>> => {
   return ResultAsync.fromPromise(onchainSendNitro(destination, amountSat), (error) => {
     const e = new Error(
       `Failed to send onchain funds: ${error instanceof Error ? error.message : String(error)}`,
     );
 
     return e;
-  });
+  }).map((result) => ({ ...result, source: "onchain" }));
+};
+
+export const sendOnchainFromOffchain = async ({
+  destination,
+  amountSat,
+}: {
+  destination: string;
+  amountSat: number;
+}): Promise<Result<NoahOnchainPaymentResult, Error>> => {
+  return ResultAsync.fromPromise(sendOnchainNitro(destination, amountSat), (error) => {
+    const e = new Error(
+      `Failed to send onchain funds from Ark balance: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+
+    return e;
+  }).map((txid) => ({
+    txid,
+    amount_sat: amountSat,
+    destination_address: destination,
+    source: "offchain",
+  }));
 };
 
 export const estimateArkoorPaymentFee = async (

--- a/client/src/lib/paymentsApi.ts
+++ b/client/src/lib/paymentsApi.ts
@@ -18,6 +18,7 @@ import {
   payLightningInvoice as payLightningInvoiceNitro,
   onchainSend as onchainSendNitro,
   sendOnchain as sendOnchainNitro,
+  onchainFeeRates as onchainFeeRatesNitro,
   estimateArkoorPaymentFee as estimateArkoorPaymentFeeNitro,
   estimateLightningSendFee as estimateLightningSendFeeNitro,
   estimateSendOnchain as estimateSendOnchainNitro,
@@ -30,13 +31,20 @@ import {
   BarkMovement,
   BarkNotificationEvent,
   BarkFeeEstimate,
+  BarkFeeRates,
   Bolt11Invoice,
   BoardResult,
   LightningReceive,
 } from "react-native-nitro-ark";
 import { err, ok, Result, ResultAsync } from "neverthrow";
 
-export type { ArkoorPaymentResult, OnchainPaymentResult, LightningPayment, BarkFeeEstimate };
+export type {
+  ArkoorPaymentResult,
+  OnchainPaymentResult,
+  LightningPayment,
+  BarkFeeEstimate,
+  BarkFeeRates,
+};
 export type { BarkNotificationEvent };
 
 export type BarkNotificationSubscription = {
@@ -231,6 +239,47 @@ export const estimateSendOnchainFee = async ({
         error instanceof Error ? error.message : String(error)
       }`,
     );
+  });
+};
+
+const STANDARD_SEGWIT_INPUT_VBYTES = 68;
+const STANDARD_SEGWIT_OUTPUT_VBYTES = 31;
+const STANDARD_TX_OVERHEAD_VBYTES = 10;
+const ONCHAIN_WALLET_ESTIMATE_INPUTS = 2;
+const ONCHAIN_WALLET_ESTIMATE_OUTPUTS = 2;
+
+export const ONCHAIN_WALLET_ESTIMATE_VBYTES =
+  STANDARD_TX_OVERHEAD_VBYTES +
+  ONCHAIN_WALLET_ESTIMATE_INPUTS * STANDARD_SEGWIT_INPUT_VBYTES +
+  ONCHAIN_WALLET_ESTIMATE_OUTPUTS * STANDARD_SEGWIT_OUTPUT_VBYTES;
+
+export const onchainFeeRates = async (): Promise<Result<BarkFeeRates, Error>> => {
+  return ResultAsync.fromPromise(onchainFeeRatesNitro(), (error) => {
+    return new Error(
+      `Failed to fetch onchain fee rates: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  });
+};
+
+export const estimateOnchainWalletSendFee = async ({
+  amountSat,
+}: {
+  amountSat: number;
+}): Promise<Result<BarkFeeEstimate, Error>> => {
+  const ratesResult = await onchainFeeRates();
+  if (ratesResult.isErr()) {
+    return err(ratesResult.error);
+  }
+
+  const feeSat = Math.ceil(ratesResult.value.regular * ONCHAIN_WALLET_ESTIMATE_VBYTES);
+
+  return ok({
+    gross_amount_sat: amountSat + feeSat,
+    fee_sat: feeSat,
+    net_amount_sat: amountSat,
+    vtxos_spent: [],
   });
 };
 

--- a/client/src/screens/EmailVerificationScreen.tsx
+++ b/client/src/screens/EmailVerificationScreen.tsx
@@ -78,6 +78,10 @@ const EmailVerificationScreen = () => {
     }
   }, [navigation]);
 
+  const handleSkip = () => {
+    navigateToNextOnboardingStep();
+  };
+
   const isValidEmail = (emailInput: string) => {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(emailInput);
@@ -191,14 +195,14 @@ const EmailVerificationScreen = () => {
           <Pressable onPress={() => navigation.goBack()} className="mr-4">
             <Icon name="arrow-back-outline" size={24} color={iconColor} />
           </Pressable>
-          <Text className="text-2xl font-bold text-foreground">Verify Your Email</Text>
+          <Text className="text-2xl font-bold text-foreground">Emergency Email</Text>
         </View>
 
         {!codeSent ? (
           <>
             <Text className="text-muted-foreground mb-6">
-              Enter your email address to receive a verification code. This helps us keep your
-              account secure.
+              Email is optional. Noah uses it only for urgent wallet safety messages, such as when
+              your VTXOs are close to expiring and you need to come online to refresh them.
             </Text>
 
             <View className="bg-card rounded-2xl border border-border p-5 space-y-5">
@@ -227,6 +231,13 @@ const EmailVerificationScreen = () => {
             >
               Send Verification Code
             </NoahButton>
+            {!fromSettings && (
+              <Pressable onPress={handleSkip} className="mt-5 items-center">
+                <Text className="text-muted-foreground font-semibold">
+                  Continue without email
+                </Text>
+              </Pressable>
+            )}
           </>
         ) : (
           <>
@@ -298,9 +309,11 @@ const EmailVerificationScreen = () => {
           </>
         )}
 
-        <Text className="text-xs text-muted-foreground text-center mt-8">
-          The verification code will expire in 10 minutes.
-        </Text>
+        {codeSent && (
+          <Text className="text-xs text-muted-foreground text-center mt-8">
+            The verification code will expire in 10 minutes.
+          </Text>
+        )}
       </View>
     </NoahSafeAreaView>
   );

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -79,7 +79,7 @@ const HomeScreen = () => {
   const [fact, setFact] = useState("");
   const bottomTabBarHeight = useBottomTabBarHeight();
   const { isUpdateRequired, minimumVersion, currentVersion } = useAppVersionCheck();
-  const { isEmailVerified } = useServerStore();
+  const { isEmailVerified, isEmailPromptDismissed, setEmailPromptDismissed } = useServerStore();
   const { data: transactions = [], isLoading: isTransactionsLoading } = useTransactions();
   const recentTransactions = transactions.slice(0, 3);
 
@@ -200,9 +200,9 @@ const HomeScreen = () => {
           <Pressable
             onPress={() => navigation.navigate("Settings")}
             accessibilityRole="button"
-            accessibilityLabel="Open profile and settings"
+            accessibilityLabel="Open settings"
           >
-            <Icon name="person-circle-outline" size={30} color={iconColor} />
+            <Icon name="settings-outline" size={28} color={iconColor} />
           </Pressable>
         </View>
       </View>
@@ -228,7 +228,12 @@ const HomeScreen = () => {
             minimumVersion={minimumVersion || "0.0.1"}
           />
         )}
-        {!isEmailVerified && <EmailVerificationBanner onPress={handleEmailVerificationPress} />}
+        {!isEmailVerified && !isEmailPromptDismissed && (
+          <EmailVerificationBanner
+            onPress={handleEmailVerificationPress}
+            onDismiss={() => setEmailPromptDismissed(true)}
+          />
+        )}
         <BackupStatusBanner />
         {isBackgroundJobRunning && (
           <View className="px-4 py-2 bg-blue-500/20 border-b border-blue-500/40">
@@ -367,9 +372,7 @@ const HomeScreen = () => {
                     </View>
                   ) : recentTransactions.length === 0 ? (
                     <View className="py-5">
-                      <Text className="text-sm font-semibold text-foreground">
-                        No activity yet
-                      </Text>
+                      <Text className="text-sm font-semibold text-foreground">No activity yet</Text>
                       <Text className="mt-1 text-sm text-muted-foreground">
                         Receive or send bitcoin to start your history.
                       </Text>
@@ -403,9 +406,7 @@ const HomeScreen = () => {
                         </View>
                         <Text
                           className={`text-sm font-bold ${
-                            transaction.direction === "outgoing"
-                              ? "text-red-500"
-                              : "text-green-500"
+                            transaction.direction === "outgoing" ? "text-red-500" : "text-green-500"
                           }`}
                         >
                           {`${transaction.direction === "outgoing" ? "-" : "+"}${formatBip177(transaction.amount)}`}
@@ -418,10 +419,7 @@ const HomeScreen = () => {
             </>
           )}
         </View>
-        <View
-          className="p-4 items-center justify-center mb-16"
-          style={{ marginTop: "auto" }}
-        >
+        <View className="p-4 items-center justify-center mb-16" style={{ marginTop: "auto" }}>
           <Text className="text-center text-xs text-muted-foreground">{fact}</Text>
         </View>
       </ScrollView>

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -398,10 +398,11 @@ const HomeScreen = () => {
                             {getTransactionLabel(transaction)}
                           </Text>
                           <Text className="mt-1 text-xs text-muted-foreground">
-                            {new Date(transaction.date).toLocaleDateString(undefined, {
-                              month: "short",
-                              day: "numeric",
-                            })}
+                            {transaction.dateLabel ??
+                              new Date(transaction.date).toLocaleDateString(undefined, {
+                                month: "short",
+                                day: "numeric",
+                              })}
                           </Text>
                         </View>
                         <Text

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -67,6 +67,12 @@ const SendScreen = () => {
     bip321Data,
     selectedPaymentMethod,
     setSelectedPaymentMethod,
+    onchainSourceOptions,
+    selectedOnchainSource,
+    setSelectedOnchainSource,
+    isOnchainSourceSelectionRequired,
+    onchainWalletBalance,
+    offchainWalletBalance,
     handleClear,
     showConfirmation,
     destinationType,
@@ -75,6 +81,7 @@ const SendScreen = () => {
     feeEstimate,
     isEstimatingFee,
     feeEstimateError,
+    feeEstimateUnavailableText,
   } = useSendScreen();
   const displayAmount = amount === "" ? (currency === "USD" ? "0.00" : "0") : amount;
 
@@ -363,12 +370,19 @@ const SendScreen = () => {
           bip321Data={bip321Data}
           selectedPaymentMethod={selectedPaymentMethod}
           onSelectPaymentMethod={setSelectedPaymentMethod}
+          onchainSourceOptions={onchainSourceOptions}
+          selectedOnchainSource={selectedOnchainSource}
+          onSelectOnchainSource={setSelectedOnchainSource}
+          onchainWalletBalance={onchainWalletBalance}
+          offchainWalletBalance={offchainWalletBalance}
           onConfirm={handleConfirmSend}
           onCancel={handleCancelConfirmation}
+          isConfirmDisabled={isOnchainSourceSelectionRequired}
           isLoading={isSending}
           feeEstimate={feeEstimate}
           isEstimatingFee={isEstimatingFee}
           feeEstimateError={feeEstimateError}
+          feeEstimateUnavailableText={feeEstimateUnavailableText}
         />
       </BottomSheet>
 

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -83,6 +83,7 @@ const SendScreen = () => {
     feeEstimateError,
     feeEstimateUnavailableText,
     feeEstimateNote,
+    feeEstimateWarning,
   } = useSendScreen();
   const displayAmount = amount === "" ? (currency === "USD" ? "0.00" : "0") : amount;
 
@@ -385,6 +386,7 @@ const SendScreen = () => {
           feeEstimateError={feeEstimateError}
           feeEstimateUnavailableText={feeEstimateUnavailableText}
           feeEstimateNote={feeEstimateNote}
+          feeEstimateWarning={feeEstimateWarning}
         />
       </BottomSheet>
 

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -82,6 +82,7 @@ const SendScreen = () => {
     isEstimatingFee,
     feeEstimateError,
     feeEstimateUnavailableText,
+    feeEstimateNote,
   } = useSendScreen();
   const displayAmount = amount === "" ? (currency === "USD" ? "0.00" : "0") : amount;
 
@@ -383,6 +384,7 @@ const SendScreen = () => {
           isEstimatingFee={isEstimatingFee}
           feeEstimateError={feeEstimateError}
           feeEstimateUnavailableText={feeEstimateUnavailableText}
+          feeEstimateNote={feeEstimateNote}
         />
       </BottomSheet>
 

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -34,6 +34,7 @@ import { formatAutoBoardThreshold } from "~/lib/autoBoarding";
 type Setting = {
   id:
     | "profile"
+    | "emergencyEmail"
     | "showMnemonic"
     | "showLogs"
     | "resetRegistration"
@@ -67,6 +68,7 @@ const SettingsScreen = () => {
   const suspendWalletMutation = useSuspendWallet();
   const [versionTapCount, setVersionTapCount] = useState(0);
   const {
+    isEmailVerified,
     isMailboxAuthorizationEnabled,
     setMailboxAuthorizationExpiry,
     setMailboxAuthorizationEnabled,
@@ -174,6 +176,8 @@ const SettingsScreen = () => {
 
     if (item.id === "profile") {
       navigation.navigate("Profile");
+    } else if (item.id === "emergencyEmail") {
+      navigation.navigate("EmailVerification", { fromSettings: true });
     } else if (item.id === "showMnemonic") {
       navigation.navigate("Mnemonic", { fromOnboarding: false });
     } else if (item.id === "showLogs") {
@@ -208,6 +212,14 @@ const SettingsScreen = () => {
       title: "Profile",
       description: "Manage your Lightning address, name, and public key.",
       isPressable: true,
+    });
+    profileData.push({
+      id: "emergencyEmail",
+      title: "Emergency Email",
+      description: isEmailVerified
+        ? "Email alerts are enabled for urgent wallet communication."
+        : "Optional alerts for urgent wallet communication.",
+      isPressable: !isEmailVerified,
     });
 
     infoData.push({
@@ -439,9 +451,7 @@ const SettingsScreen = () => {
             <View className="p-4 border-b border-border bg-card rounded-lg mb-2 flex-row justify-between items-center">
               <View className="flex-1">
                 <Label className="text-foreground text-lg">Auto-Board to Ark</Label>
-                <Text className="text-base mt-1 text-muted-foreground">
-                  {autoBoardDescription}
-                </Text>
+                <Text className="text-base mt-1 text-muted-foreground">{autoBoardDescription}</Text>
               </View>
               <Switch
                 value={isAutoBoardingEnabled}
@@ -470,8 +480,8 @@ const SettingsScreen = () => {
               <View className="flex-1">
                 <Label className="text-foreground text-lg">Mailbox Notifications</Label>
                 <Text className="text-base mt-1 text-muted-foreground">
-                  Allow Noah to monitor your Ark mailbox so it can wake this app to claim
-                  Lightning payments in the background.
+                  Allow Noah to monitor your Ark mailbox so it can wake this app to claim Lightning
+                  payments in the background.
                 </Text>
               </View>
               <Switch

--- a/client/src/screens/TransactionDetailScreen.tsx
+++ b/client/src/screens/TransactionDetailScreen.tsx
@@ -100,6 +100,7 @@ const TransactionDetailScreen = () => {
     ? (transaction.amount * 0.00000001 * transaction.btcPrice).toFixed(2)
     : "N/A";
   const bitcoinPrice = transaction.btcPrice ? transaction.btcPrice.toLocaleString() : "N/A";
+  const transactionDateLabel = transaction.dateLabel ?? new Date(transaction.date).toLocaleString();
   const movementStatusLabel = formatMovementStatusLabel(transaction.movementStatus);
   const movementKindLabel = formatMovementKindLabel(transaction.movementKind);
   const hasMovementDetails = Boolean(
@@ -112,6 +113,7 @@ const TransactionDetailScreen = () => {
       typeof transaction.offchainFeeSat === "number" ||
       typeof transaction.movementId === "number",
   );
+  const hasOnchainWalletDetails = transaction.source === "onchain-wallet";
 
   return (
     <NoahSafeAreaView className="flex-1 bg-background">
@@ -141,6 +143,46 @@ const TransactionDetailScreen = () => {
             value={`${formatBip177(transaction.amount)} ($${fiatAmount})`}
           />
         </View>
+
+        {hasOnchainWalletDetails ? (
+          <View className="bg-card p-4 rounded-lg mb-4">
+            <Text className="text-lg font-semibold text-foreground mb-3">
+              Onchain Wallet Transaction
+            </Text>
+            <TransactionDetailRow
+              label="Status"
+              value={transaction.hasConfirmation ? "Confirmed" : "Unconfirmed"}
+            />
+            {typeof transaction.balanceChangeSat === "number" ? (
+              <TransactionDetailRow
+                label="Balance Δ"
+                value={formatBip177(transaction.balanceChangeSat)}
+              />
+            ) : null}
+            {transaction.hasOnchainFee && typeof transaction.onchainFeeSat === "number" ? (
+              <TransactionDetailRow
+                label="Onchain Fee"
+                value={formatBip177(transaction.onchainFeeSat)}
+              />
+            ) : null}
+            {typeof transaction.confirmationHeight === "number" ? (
+              <TransactionDetailRow
+                label="Confirmation Height"
+                value={transaction.confirmationHeight.toString()}
+              />
+            ) : null}
+            {transaction.confirmationHash ? (
+              <TransactionDetailRow
+                label="Confirmation Hash"
+                value={transaction.confirmationHash}
+                copyable
+              />
+            ) : null}
+            {transaction.txHex ? (
+              <TransactionDetailRow label="Raw Transaction" value={transaction.txHex} copyable />
+            ) : null}
+          </View>
+        ) : null}
 
         {hasMovementDetails ? (
           <View className="bg-card p-4 rounded-lg mb-4">
@@ -194,8 +236,8 @@ const TransactionDetailScreen = () => {
             <TransactionDetailRow label="Note" value={transaction.description} />
           ) : null}
           <TransactionDetailRow
-            label="Date & time"
-            value={new Date(transaction.date).toLocaleString()}
+            label={transaction.dateLabel ? "Confirmation" : "Date & time"}
+            value={transactionDateLabel}
           />
           <TransactionDetailRow label="Payment ID" value={transaction.id} copyable />
           {transaction.txid ? (

--- a/client/src/screens/TransactionsScreen.tsx
+++ b/client/src/screens/TransactionsScreen.tsx
@@ -65,7 +65,7 @@ const TransactionsScreen = () => {
       "Payment ID,Date,Type,Direction,Amount (₿),BTC Price,Transaction ID,Destination\n";
     const csvRows = filteredTransactions
       .map((transaction) => {
-        const date = new Date(transaction.date).toISOString().split("T")[0];
+        const date = transaction.dateLabel ?? new Date(transaction.date).toISOString().split("T")[0];
         const type =
           transaction.type === "Bolt11" || transaction.type === "Lnurl"
             ? "Lightning"
@@ -237,7 +237,7 @@ const TransactionsScreen = () => {
                             </View>
                           </View>
                           <Text className="text-muted-foreground text-sm mt-1">
-                            {new Date(item.date).toLocaleString()}
+                            {item.dateLabel ?? new Date(item.date).toLocaleString()}
                           </Text>
                         </View>
                       </View>

--- a/client/src/store/serverStore.ts
+++ b/client/src/store/serverStore.ts
@@ -42,6 +42,7 @@ interface ServerState {
   lightningAddress: string | null;
   isBackupEnabled: boolean;
   isEmailVerified: boolean;
+  isEmailPromptDismissed: boolean;
   mailboxAuthorizationExpiry: number | null;
   isMailboxAuthorizationEnabled: boolean;
   setRegisteredWithServer: (
@@ -52,6 +53,7 @@ interface ServerState {
   setLightningAddress: (lightningAddress: string) => void;
   setBackupEnabled: (enabled: boolean) => void;
   setEmailVerified: (verified: boolean) => void;
+  setEmailPromptDismissed: (dismissed: boolean) => void;
   setMailboxAuthorizationExpiry: (expiry: number | null) => void;
   setMailboxAuthorizationEnabled: (enabled: boolean) => void;
   resetRegistration: () => void;
@@ -64,6 +66,7 @@ export const useServerStore = create<ServerState>()(
       lightningAddress: null,
       isBackupEnabled: false,
       isEmailVerified: false,
+      isEmailPromptDismissed: false,
       mailboxAuthorizationExpiry: null,
       isMailboxAuthorizationEnabled: true,
       setRegisteredWithServer: (isRegistered, lightningAddress, isBackupEnabled) =>
@@ -71,6 +74,7 @@ export const useServerStore = create<ServerState>()(
       setLightningAddress: (lightningAddress) => set({ lightningAddress }),
       setBackupEnabled: (enabled) => set({ isBackupEnabled: enabled }),
       setEmailVerified: (verified) => set({ isEmailVerified: verified }),
+      setEmailPromptDismissed: (dismissed) => set({ isEmailPromptDismissed: dismissed }),
       setMailboxAuthorizationExpiry: (mailboxAuthorizationExpiry) =>
         set({ mailboxAuthorizationExpiry }),
       setMailboxAuthorizationEnabled: (isMailboxAuthorizationEnabled) =>
@@ -81,6 +85,7 @@ export const useServerStore = create<ServerState>()(
           lightningAddress: null,
           isBackupEnabled: false,
           isEmailVerified: false,
+          isEmailPromptDismissed: false,
           mailboxAuthorizationExpiry: null,
         }),
     }),

--- a/client/src/types/transaction.ts
+++ b/client/src/types/transaction.ts
@@ -9,9 +9,14 @@ export type Transaction = {
   type: PaymentTypes;
   amount: number;
   date: string;
+  dateLabel?: string;
+  sortTimestamp?: number;
+  sortHeight?: number;
   description?: string;
   direction: "incoming" | "outgoing";
+  source?: "ark" | "onchain-wallet";
   txid?: string;
+  txHex?: string;
   preimage?: string;
   destination?: string;
   btcPrice?: number;
@@ -29,6 +34,12 @@ export type Transaction = {
   inputVtxos?: string[];
   outputVtxos?: string[];
   exitedVtxos?: string[];
+  balanceChangeSat?: number;
+  hasOnchainFee?: boolean;
+  onchainFeeSat?: number;
+  hasConfirmation?: boolean;
+  confirmationHeight?: number;
+  confirmationHash?: string;
 };
 
 export type MovementDestination = {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -233,24 +233,18 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     let user_exists_layer =
         middleware::from_fn_with_state(app_state.clone(), app_middleware::user_exists_middleware);
 
-    // Middleware that checks if user's email is verified
-    let email_verified_layer = middleware::from_fn_with_state(
-        app_state.clone(),
-        app_middleware::email_verified_middleware,
-    );
-
     // Create rate limiters
     let public_rate_limiter = rate_limit::create_public_rate_limiter();
     let auth_login_rate_limiter = rate_limit::create_public_rate_limiter();
     let auth_rate_limiter = rate_limit::create_auth_rate_limiter();
 
-    // Email verification routes - need auth and user to exist, but NOT email verification
+    // Optional email setup routes need auth and a registered user.
     let email_verification_router = Router::new()
         .route("/email/send_verification", post(send_verification_email))
         .route("/email/verify", post(verify_email))
         .layer(user_exists_layer.clone());
 
-    // Fully gated routes - need auth, user to exist, AND email to be verified
+    // Gated routes need auth and a registered user. Email is optional.
     let gated_router = Router::new()
         .route("/register_push_token", post(register_push_token))
         .route("/mailbox/authorize", post(authorize_mailbox))
@@ -270,7 +264,6 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         .route("/report_job_status", post(report_job_status))
         .route("/heartbeat_response", post(heartbeat_response))
         .route("/report_last_login", post(report_last_login))
-        .layer(email_verified_layer)
         .layer(user_exists_layer);
 
     // Routes that need auth but user may not exist (like registration)

--- a/server/src/routes/app_middleware.rs
+++ b/server/src/routes/app_middleware.rs
@@ -5,8 +5,8 @@ use axum::{
 };
 
 use crate::{
-    AppState, auth::verify_access_token, db::user_repo::UserRepository, errors::ApiError,
-    types::AuthenticatedUser, utils::verify_user_exists, wide_event::WideEventHandle,
+    AppState, auth::verify_access_token, errors::ApiError, types::AuthenticatedUser,
+    utils::verify_user_exists, wide_event::WideEventHandle,
 };
 
 pub async fn auth_middleware(
@@ -87,47 +87,6 @@ pub async fn user_exists_middleware(
             "User existence check failed: User not found in database"
         );
         return Err(ApiError::UserNotFound.into_response());
-    }
-
-    Ok(next.run(request).await)
-}
-
-pub async fn email_verified_middleware(
-    State(state): State<AppState>,
-    request: Request,
-    next: Next,
-) -> Result<Response, Response> {
-    let authenticated_user = match request.extensions().get::<AuthenticatedUser>() {
-        Some(payload) => payload,
-        None => {
-            return Err(ApiError::ServerErr(
-                "Authentication failed. Please try again.".to_string(),
-            )
-            .into_response());
-        }
-    };
-
-    let user_repo = UserRepository::new(&state.db_pool);
-    let is_verified = user_repo
-        .is_email_verified(&authenticated_user.key)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Email verification check failed");
-            ApiError::ServerErr("Failed to check email verification status".to_string())
-                .into_response()
-        })?;
-
-    if let Some(event) = request.extensions().get::<WideEventHandle>() {
-        event.set_email_verified(is_verified);
-    }
-
-    if !is_verified {
-        // TODO: Temporarily just logging instead of blocking - re-enable blocking later
-        tracing::warn!(
-            path = %request.uri().path(),
-            "Email not verified (allowing request temporarily)"
-        );
-        // return Err(ApiError::InvalidArgument("Email not verified".to_string()).into_response());
     }
 
     Ok(next.run(request).await)

--- a/server/src/wide_event.rs
+++ b/server/src/wide_event.rs
@@ -17,7 +17,6 @@ pub struct WideEvent {
 
     pub public_key: Option<String>,
     pub ln_address: Option<String>,
-    pub email_verified: Option<bool>,
 
     pub outcome: Option<String>,
     pub error_type: Option<String>,
@@ -53,10 +52,6 @@ impl WideEvent {
 
     pub fn set_ln_address(&mut self, ln_address: &str) {
         self.ln_address = Some(ln_address.to_string());
-    }
-
-    pub fn set_email_verified(&mut self, verified: bool) {
-        self.email_verified = Some(verified);
     }
 
     pub fn set_status(&mut self, status_code: u16) {
@@ -161,10 +156,6 @@ impl WideEventHandle {
 
     pub fn set_ln_address(&self, ln_address: &str) {
         self.with(|e| e.set_ln_address(ln_address));
-    }
-
-    pub fn set_email_verified(&self, verified: bool) {
-        self.with(|e| e.set_email_verified(verified));
     }
 
     pub fn add_context<V: Serialize>(&self, key: &str, value: V) {


### PR DESCRIPTION
## Summary

- Makes email setup optional in onboarding and removes email verification as a server-side gate for authenticated routes.
- Reframes email collection as optional emergency wallet-safety communication and adds a dismissible Home prompt plus Settings entry.
- Updates `react-native-nitro-ark` to `0.0.114` and adapts lightning send wrappers to the new `wait` flag and `LightningPayment` response type.
- Removes the post-send `checkLightningPayment` call by waiting directly on lightning send APIs.

## Validation

- `just check`
- `cargo fmt --check`
- `cargo test email_verification_tests`
- `cargo test gated_`
- pre-commit `bun --cwd client check`

Note: I did not run mobile simulators per the repo's autonomous-agent policy.