### PR TITLE
[codex] Update iOS Maestro onboarding tests

### DIFF
--- a/client/.maestro/email-verification.yml
+++ b/client/.maestro/email-verification.yml
@@ -1,0 +1,61 @@
+# email-verification.yml
+
+appId: com.noahwallet.regtest
+---
+- runScript: scripts/lightning-address.js
+
+- launchApp:
+    clearState: true
+
+- tapOn: "Create Wallet"
+- assertVisible: "Your Recovery Phrase"
+- tapOn: "I Have Saved It, Continue"
+
+# Emergency Email screen
+- extendedWaitUntil:
+    visible: "Emergency Email"
+    timeout: 10000
+- tapOn:
+    text: "your@email.com"
+    optional: true
+- inputText: "maestro@example.com"
+- tapOn: "Send Verification Code"
+
+# Verification Code screen
+- extendedWaitUntil:
+    visible: "Enter Verification Code"
+    timeout: 10000
+- inputText: "000000"
+- tapOn: "Verify Email"
+
+# Lightning Address screen
+- extendedWaitUntil:
+    visible: "Choose your Lightning Address"
+    timeout: 10000
+- tapOn:
+    point: "50%,33%"
+- eraseText: 40
+- inputText: ${output.lightningUsername}
+- assertVisible: ${output.lightningUsername}
+- tapOn: "Save"
+- extendedWaitUntil:
+    visible: "Success!"
+    timeout: 10000
+
+# Home screen
+- extendedWaitUntil:
+    visible: "History"
+    timeout: 10000
+
+# Clean up: Delete the wallet
+- tapOn: "Open settings"
+- swipe:
+    direction: UP
+- swipe:
+    direction: UP
+- tapOn: "Delete Wallet"
+- tapOn:
+    text: 'Type "delete" to confirm'
+- inputText: "delete"
+- tapOn: "Confirm"
+- assertVisible: "Welcome to Noah"

--- a/client/.maestro/scripts/lightning-address.js
+++ b/client/.maestro/scripts/lightning-address.js
@@ -1,0 +1,3 @@
+const suffix = Date.now().toString(36);
+
+output.lightningUsername = `maestro${suffix}`;

--- a/client/.maestro/setup-wallet.yml
+++ b/client/.maestro/setup-wallet.yml
@@ -9,24 +9,9 @@ appId: com.noahwallet.regtest
 - assertVisible: "Your Recovery Phrase"
 - tapOn: "I Have Saved It, Continue"
 
-# Email Verification screen
-- assertVisible: "Verify Your Email"
-- tapOn:
-    text: "your@email.com"
-    optional: true
-- inputText: "test@example.com"
-- tapOn: "Send Verification Code"
-
-# Wait for code entry screen
-- extendedWaitUntil:
-    visible: "Enter Verification Code"
-    timeout: 10000
-
-# Tap on code field to focus it, then enter test verification code
-- tapOn:
-    id: "verification-code-input"
-- inputText: "000000"
-- tapOn: "Verify Email"
+# Emergency Email screen
+- assertVisible: "Emergency Email"
+- tapOn: "Continue without email"
 
 # Lightning Address screen
 - extendedWaitUntil:
@@ -38,11 +23,11 @@ appId: com.noahwallet.regtest
 - assertVisible: "History"
 
 # Clean up: Delete the wallet
-- tapOn: "Open profile and settings"
-- scrollUntilVisible:
-    element: "Delete Wallet"
-    direction: DOWN
-    timeout: 10000
+- tapOn: "Open settings"
+- swipe:
+    direction: UP
+- swipe:
+    direction: UP
 - tapOn: "Delete Wallet"
 - tapOn:
     text: 'Type "delete" to confirm'


### PR DESCRIPTION
## What changed

- Updated the existing `setup-wallet` Maestro flow for the current onboarding screens.
- Added a separate email verification Maestro flow that uses the regtest verification code and saves a generated custom Lightning Address before continuing.
- Added a small Maestro script to generate a unique Lightning username per run, avoiding stale database uniqueness conflicts.

## Why

The old flow expected the previous email verification screen and settings selector, so the iOS Maestro test failed against the current release app. The new flow keeps the fast skip-email onboarding coverage while adding explicit coverage for the email verification path.

## Validation

- `bun --cwd client check`
- Installed the existing iOS release simulator app and ran `MAESTRO_DRIVER_STARTUP_TIMEOUT=120000 maestro test --debug-output maestro-debug-output .maestro`
- Local result: `2/2 Flows Passed in 1m 3s`