### PR TITLE
Redesign home status banners and auto-boarding flow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "react-native-gesture-handler": "~2.31.1",
         "react-native-keychain": "^10.0.0",
         "react-native-mmkv": "^4.3.1",
-        "react-native-nitro-ark": "0.0.117",
+        "react-native-nitro-ark": "0.0.118",
         "react-native-nitro-modules": "0.35.6",
         "react-native-qrcode-svg": "^6.3.21",
         "react-native-quick-base64": "^3.0.0",
@@ -1589,7 +1589,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@4.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg=="],
 
-    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.117", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-15bnTgM5IqZ83YTKwlYhIxaSxFHO8bSzO+6lkmaPZm7wx7dSnzNI0buPu2RgMBMMNIH/QQAdWpLcBTWMIJNw3A=="],
+    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.118", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-cy5HqIUaCPOjs641zxur4rxQEcpZTMdpU6Nko4bEWJ3yUOuvvDfp3xdanENt3jf6KPAQzOHo7wHwH4NHqU9UlA=="],
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.35.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g=="],
 

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -253,7 +253,7 @@ PODS:
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
   - MMKVCore (2.4.0)
-  - NitroArk (0.0.117):
+  - NitroArk (0.0.118):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -3183,7 +3183,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   hermes-engine: 7ba2a073edd246f02086a03c12186700e155b4c7
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: 5564c299837be92c84c1af6ae6595026667f6cb8
+  NitroArk: 6961eb2967fc99f705edc3772edc0ad25d0f4032
   NitroMmkv: 1ff46eceb958298b1d7c013a6314432438b77a62
   NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
   NoahTools: efecfcff1688c6e63b9acb210286badaa3eaac36

--- a/client/package.json
+++ b/client/package.json
@@ -105,7 +105,7 @@
     "react-native-gesture-handler": "~2.31.1",
     "react-native-keychain": "^10.0.0",
     "react-native-mmkv": "^4.3.1",
-    "react-native-nitro-ark": "0.0.117",
+    "react-native-nitro-ark": "0.0.118",
     "react-native-nitro-modules": "0.35.6",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-quick-base64": "^3.0.0",

--- a/client/src/AppServices.tsx
+++ b/client/src/AppServices.tsx
@@ -4,38 +4,14 @@ import { useServerRegistration } from "~/hooks/useServerRegistration";
 import { usePushNotifications } from "~/hooks/usePushNotifications";
 import { useMailboxAuthorization } from "~/hooks/useMailboxAuthorization";
 import { useAutoBackup } from "~/hooks/useAutoBackup";
-import { useTransactionStore } from "~/store/transactionStore";
-import { useAutoBoardThreshold, useBalance } from "~/hooks/useWallet";
-import { useBoardAllAmountArk } from "~/hooks/usePayments";
-import { useAlert } from "~/contexts/AlertProvider";
 import { reportLastLogin } from "~/lib/api";
 import logger from "~/lib/log";
-import { AUTO_BOARD_FLOOR_AMOUNT, formatAutoBoardThreshold } from "~/lib/autoBoarding";
+import { AutoBoardingService } from "~/components/AutoBoardingService";
 
 const log = logger("AppServices");
 
 const AppServices = memo(() => {
   const [isReady, setIsReady] = useState(false);
-  const [hasReportedAutoBoardThresholdError, setHasReportedAutoBoardThresholdError] =
-    useState(false);
-
-  const { isAutoBoardingEnabled, hasAttemptedAutoBoarding, setHasAttemptedAutoBoarding } =
-    useTransactionStore();
-  const { data: balance } = useBalance();
-  const { mutate: boardAllArk, isPending: isBoardingAll } = useBoardAllAmountArk();
-  const { showAlert } = useAlert();
-  const shouldLoadAutoBoardThreshold =
-    isReady &&
-    isAutoBoardingEnabled &&
-    !!balance &&
-    balance.onchain.confirmed >= AUTO_BOARD_FLOOR_AMOUNT &&
-    !isBoardingAll &&
-    !hasAttemptedAutoBoarding;
-  const {
-    data: autoBoardThreshold,
-    error: autoBoardThresholdError,
-    isError: isAutoBoardThresholdError,
-  } = useAutoBoardThreshold(shouldLoadAutoBoardThreshold);
 
   // Initialize all app-level services here
   useSyncManager(60_000);
@@ -58,81 +34,7 @@ const AppServices = memo(() => {
     }
   }, [isReady]);
 
-  // Auto-boarding logic
-  useEffect(() => {
-    if (
-      !isReady ||
-      !isAutoBoardingEnabled ||
-      !balance ||
-      isBoardingAll ||
-      hasAttemptedAutoBoarding
-    ) {
-      return;
-    }
-
-    const onchainConfirmedBalance = balance.onchain.confirmed;
-
-    if (onchainConfirmedBalance < AUTO_BOARD_FLOOR_AMOUNT) {
-      return;
-    }
-
-    if (isAutoBoardThresholdError) {
-      if (!hasReportedAutoBoardThresholdError) {
-        setHasReportedAutoBoardThresholdError(true);
-        log.e("Auto-boarding failed to load Ark info", [autoBoardThresholdError]);
-        showAlert({
-          title: "Auto-Boarding Failed",
-          description: "Unable to load Ark server info. Please try again later.",
-        });
-      }
-      return;
-    }
-
-    if (hasReportedAutoBoardThresholdError) {
-      setHasReportedAutoBoardThresholdError(false);
-    }
-
-    if (autoBoardThreshold === undefined || onchainConfirmedBalance < autoBoardThreshold) {
-      return;
-    }
-
-    if (onchainConfirmedBalance >= autoBoardThreshold) {
-      setHasAttemptedAutoBoarding(true);
-      log.d("Auto-boarding triggered", [
-        `Balance: ${onchainConfirmedBalance} sats`,
-        `Threshold: ${autoBoardThreshold} sats`,
-      ]);
-
-      boardAllArk(undefined, {
-        onSuccess: () => {
-          log.d("Auto-boarding successful");
-
-          showAlert({
-            title: "Auto-Boarded to Ark",
-            description: `Successfully boarded ${formatAutoBoardThreshold(onchainConfirmedBalance)} to Ark.`,
-          });
-        },
-        onError: (error) => {
-          log.e("Auto-boarding failed", [error]);
-        },
-      });
-    }
-  }, [
-    isReady,
-    isAutoBoardingEnabled,
-    hasAttemptedAutoBoarding,
-    balance,
-    autoBoardThreshold,
-    autoBoardThresholdError,
-    hasReportedAutoBoardThresholdError,
-    isAutoBoardThresholdError,
-    boardAllArk,
-    isBoardingAll,
-    setHasAttemptedAutoBoarding,
-    showAlert,
-  ]);
-
-  return null;
+  return <AutoBoardingService isReady={isReady} />;
 });
 
 AppServices.displayName = "AppServices";

--- a/client/src/components/AutoBoardingService.tsx
+++ b/client/src/components/AutoBoardingService.tsx
@@ -256,6 +256,9 @@ export const AutoBoardingService = memo(({ isReady }: AutoBoardingServiceProps) 
         onOpenChange={(open) => {
           setIsAutoBoardDialogOpen(open);
           if (!open) {
+            if (autoBoardPlan) {
+              setHasAttemptedAutoBoarding(true);
+            }
             setAutoBoardPlan(null);
           }
         }}

--- a/client/src/components/AutoBoardingService.tsx
+++ b/client/src/components/AutoBoardingService.tsx
@@ -1,0 +1,326 @@
+import { memo, useEffect, useRef, useState } from "react";
+import { View } from "react-native";
+import { ConfirmationDialog } from "~/components/ConfirmationDialog";
+import { Text } from "~/components/ui/text";
+import { useAlert } from "~/contexts/AlertProvider";
+import { useBoardArk } from "~/hooks/usePayments";
+import { useArkInfo, useBalance } from "~/hooks/useWallet";
+import {
+  AUTO_BOARD_FLOOR_AMOUNT,
+  type AutoBoardPlan,
+  buildAutoBoardPlan,
+} from "~/lib/autoBoarding";
+import logger from "~/lib/log";
+import { cn, formatBip177 } from "~/lib/utils";
+import { useTransactionStore } from "~/store/transactionStore";
+
+const log = logger("AutoBoardingService");
+
+type AutoBoardingServiceProps = {
+  isReady: boolean;
+};
+
+const AutoBoardPlanRow = ({
+  label,
+  value,
+  valueClassName,
+}: {
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) => (
+  <View className="flex-row items-center justify-between py-2.5">
+    <Text className="text-sm text-muted-foreground" numberOfLines={1}>
+      {label}
+    </Text>
+    <Text className={cn("ml-3 text-sm font-semibold text-foreground", valueClassName)}>
+      {value}
+    </Text>
+  </View>
+);
+
+export const AutoBoardingService = memo(({ isReady }: AutoBoardingServiceProps) => {
+  const [hasReportedAutoBoardPlanError, setHasReportedAutoBoardPlanError] = useState(false);
+  const [autoBoardPlan, setAutoBoardPlan] = useState<AutoBoardPlan | null>(null);
+  const [isAutoBoardDialogOpen, setIsAutoBoardDialogOpen] = useState(false);
+  const [isPlanningAutoBoard, setIsPlanningAutoBoard] = useState(false);
+  const isPlanningAutoBoardRef = useRef(false);
+
+  const {
+    isAutoBoardingEnabled,
+    hasAttemptedAutoBoarding,
+    setAutoBoardingEnabled,
+    setHasAttemptedAutoBoarding,
+    setAutoBoardSuccessBanner,
+  } = useTransactionStore();
+  const { data: balance } = useBalance();
+  const { mutate: boardArk, isPending: isBoarding } = useBoardArk();
+  const { showAlert } = useAlert();
+
+  const confirmedOnchainBalance = balance?.onchain.confirmed ?? null;
+  const shouldLoadArkInfoForAutoBoard =
+    isReady &&
+    isAutoBoardingEnabled &&
+    confirmedOnchainBalance !== null &&
+    confirmedOnchainBalance >= AUTO_BOARD_FLOOR_AMOUNT &&
+    !isBoarding &&
+    !hasAttemptedAutoBoarding;
+  const {
+    data: arkInfo,
+    error: arkInfoError,
+    isError: isArkInfoError,
+  } = useArkInfo(shouldLoadArkInfoForAutoBoard);
+
+  useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+
+    log.d("Auto-boarding check", [
+      {
+        isAutoBoardingEnabled,
+        hasAttemptedAutoBoarding,
+        confirmedOnchainBalance,
+        shouldLoadArkInfoForAutoBoard,
+        isBoarding,
+        isPlanningAutoBoard,
+        hasPlan: autoBoardPlan !== null,
+        isDialogOpen: isAutoBoardDialogOpen,
+      },
+    ]);
+  }, [
+    isReady,
+    isAutoBoardingEnabled,
+    hasAttemptedAutoBoarding,
+    confirmedOnchainBalance,
+    shouldLoadArkInfoForAutoBoard,
+    isBoarding,
+    isPlanningAutoBoard,
+    autoBoardPlan,
+    isAutoBoardDialogOpen,
+  ]);
+
+  useEffect(() => {
+    if (
+      !isReady ||
+      !isAutoBoardingEnabled ||
+      confirmedOnchainBalance === null ||
+      isBoarding ||
+      hasAttemptedAutoBoarding ||
+      autoBoardPlan ||
+      isAutoBoardDialogOpen ||
+      isPlanningAutoBoardRef.current
+    ) {
+      return;
+    }
+
+    if (confirmedOnchainBalance < AUTO_BOARD_FLOOR_AMOUNT) {
+      log.d("Auto-boarding skipped", [
+        `Confirmed onchain balance below floor: ${confirmedOnchainBalance} sats`,
+      ]);
+      return;
+    }
+
+    if (isArkInfoError) {
+      if (!hasReportedAutoBoardPlanError) {
+        setHasReportedAutoBoardPlanError(true);
+        log.e("Auto-boarding failed to load Ark info", [arkInfoError]);
+        showAlert({
+          title: "Auto-Boarding Failed",
+          description: "Unable to load Ark server info. Please try again later.",
+        });
+      }
+      return;
+    }
+
+    if (!arkInfo) {
+      log.d("Auto-boarding waiting for Ark info");
+      return;
+    }
+
+    let isActive = true;
+    isPlanningAutoBoardRef.current = true;
+    setIsPlanningAutoBoard(true);
+    log.d("Auto-boarding estimating plan", [
+      `Confirmed onchain balance: ${confirmedOnchainBalance} sats`,
+    ]);
+
+    buildAutoBoardPlan({
+      arkInfo,
+      confirmedOnchainBalanceSat: confirmedOnchainBalance,
+    })
+      .then((planResult) => {
+        if (!isActive) {
+          return;
+        }
+
+        if (planResult.isErr()) {
+          if (!hasReportedAutoBoardPlanError) {
+            setHasReportedAutoBoardPlanError(true);
+            log.e("Auto-boarding failed to estimate fees", [planResult.error]);
+            showAlert({
+              title: "Auto-Boarding Failed",
+              description: "Unable to estimate boarding fees. Please try again later.",
+            });
+          }
+          return;
+        }
+
+        if (hasReportedAutoBoardPlanError) {
+          setHasReportedAutoBoardPlanError(false);
+        }
+
+        if (!planResult.value) {
+          log.d("Auto-boarding not eligible after fee estimates", [
+            `Confirmed onchain balance: ${confirmedOnchainBalance} sats`,
+          ]);
+          return;
+        }
+
+        log.d("Auto-boarding confirmation ready", [
+          `Gross board amount: ${planResult.value.grossBoardAmountSat} sats`,
+          `Estimated Ark fee: ${planResult.value.arkFeeSat} sats`,
+          `Estimated onchain fee: ${planResult.value.estimatedOnchainFeeSat} sats`,
+        ]);
+        setAutoBoardPlan(planResult.value);
+        setIsAutoBoardDialogOpen(true);
+      })
+      .finally(() => {
+        if (isActive) {
+          isPlanningAutoBoardRef.current = false;
+          setIsPlanningAutoBoard(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+      isPlanningAutoBoardRef.current = false;
+    };
+  }, [
+    isReady,
+    isAutoBoardingEnabled,
+    hasAttemptedAutoBoarding,
+    confirmedOnchainBalance,
+    arkInfo,
+    arkInfoError,
+    autoBoardPlan,
+    hasReportedAutoBoardPlanError,
+    isArkInfoError,
+    isAutoBoardDialogOpen,
+    isBoarding,
+    showAlert,
+  ]);
+
+  const handleConfirmAutoBoard = () => {
+    if (!autoBoardPlan) {
+      return;
+    }
+
+    setHasAttemptedAutoBoarding(true);
+    setIsAutoBoardDialogOpen(false);
+    log.d("Auto-boarding triggered", [
+      `Balance: ${autoBoardPlan.confirmedOnchainBalanceSat} sats`,
+      `Gross board amount: ${autoBoardPlan.grossBoardAmountSat} sats`,
+      `Estimated Ark fee: ${autoBoardPlan.arkFeeSat} sats`,
+      `Estimated onchain fee: ${autoBoardPlan.estimatedOnchainFeeSat} sats`,
+    ]);
+
+    boardArk(autoBoardPlan.grossBoardAmountSat, {
+      onSuccess: () => {
+        log.d("Auto-boarding successful");
+        const completedPlan = autoBoardPlan;
+        setAutoBoardPlan(null);
+        setAutoBoardSuccessBanner(completedPlan.netBoardAmountSat);
+      },
+      onError: (error) => {
+        setAutoBoardPlan(null);
+        log.e("Auto-boarding failed", [error]);
+      },
+    });
+  };
+
+  const handleDisableAutoBoarding = () => {
+    setAutoBoardingEnabled(false);
+    setAutoBoardPlan(null);
+    setIsAutoBoardDialogOpen(false);
+  };
+
+  return (
+    <ConfirmationDialog
+        title="Board to Ark?"
+        description="Move available onchain funds into Ark while leaving a fee reserve in your onchain wallet."
+        confirmText="Yes, board"
+        cancelText="No, turn off"
+        confirmVariant="default"
+        open={isAutoBoardDialogOpen}
+        onOpenChange={(open) => {
+          setIsAutoBoardDialogOpen(open);
+          if (!open) {
+            setAutoBoardPlan(null);
+          }
+        }}
+        onConfirm={handleConfirmAutoBoard}
+        onCancel={handleDisableAutoBoarding}
+        isConfirmDisabled={isBoarding}
+        contentClassName="w-[92%] rounded-2xl border-border bg-background p-5"
+        headerClassName="gap-2"
+        titleClassName="text-2xl font-bold text-foreground"
+        descriptionClassName="text-base leading-6 text-muted-foreground"
+        footerClassName="mt-1 gap-3 space-x-0"
+        cancelClassName="h-12 rounded-xl border-border bg-background"
+        actionClassName="h-12 rounded-xl"
+      >
+        {autoBoardPlan ? (
+          <View className="gap-3">
+            <View className="rounded-xl border border-border/70 bg-card/80 p-4">
+              <Text className="text-sm font-medium text-muted-foreground">Amount to board</Text>
+              <Text className="mt-1 text-3xl font-bold text-foreground">
+                {formatBip177(autoBoardPlan.grossBoardAmountSat)}
+              </Text>
+              <Text className="mt-1 text-xs leading-5 text-muted-foreground">
+                {formatBip177(autoBoardPlan.netBoardAmountSat)} becomes available in Ark after the
+                boarding fee.
+              </Text>
+            </View>
+
+            <View className="rounded-xl border border-border/70 bg-card/60 px-3 py-1">
+              <AutoBoardPlanRow
+                label="Onchain balance"
+                value={formatBip177(autoBoardPlan.confirmedOnchainBalanceSat)}
+              />
+              <View className="h-px bg-border/70" />
+              <AutoBoardPlanRow
+                label="Ark boarding fee"
+                value={formatBip177(autoBoardPlan.arkFeeSat)}
+                valueClassName="text-red-500"
+              />
+              <View className="h-px bg-border/70" />
+              <AutoBoardPlanRow
+                label="Estimated onchain fee"
+                value={formatBip177(autoBoardPlan.estimatedOnchainFeeSat)}
+                valueClassName="text-red-500"
+              />
+              <View className="h-px bg-border/70" />
+              <AutoBoardPlanRow
+                label="Stays in onchain wallet"
+                value={formatBip177(autoBoardPlan.estimatedRemainingOnchainSat)}
+              />
+              <View className="h-px bg-border/70" />
+              <AutoBoardPlanRow
+                label="Ark amount after fee"
+                value={formatBip177(autoBoardPlan.netBoardAmountSat)}
+                valueClassName="text-green-500"
+              />
+            </View>
+
+            <Text className="text-xs leading-5 text-muted-foreground">
+              Onchain fee uses the regular fee rate and a {autoBoardPlan.estimatedVbytes} vB 2-in/2-out
+              SegWit estimate.
+            </Text>
+          </View>
+        ) : null}
+    </ConfirmationDialog>
+  );
+});
+
+AutoBoardingService.displayName = "AutoBoardingService";

--- a/client/src/components/AutoBoardingStatusBanner.tsx
+++ b/client/src/components/AutoBoardingStatusBanner.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { CheckCircle } from "lucide-react-native";
+import { StatusBannerStrip } from "~/components/StatusBannerStrip";
+import { formatAutoBoardThreshold } from "~/lib/autoBoarding";
+import { useTransactionStore } from "~/store/transactionStore";
+
+const AUTO_BOARD_SUCCESS_BANNER_MS = 5_000;
+
+export const AutoBoardingStatusBanner = () => {
+  const { autoBoardSuccessBanner, clearAutoBoardSuccessBanner } = useTransactionStore();
+
+  useEffect(() => {
+    if (!autoBoardSuccessBanner) {
+      return undefined;
+    }
+
+    const elapsedMs = Date.now() - autoBoardSuccessBanner.createdAt;
+    const remainingMs = AUTO_BOARD_SUCCESS_BANNER_MS - elapsedMs;
+
+    if (remainingMs <= 0) {
+      clearAutoBoardSuccessBanner();
+      return undefined;
+    }
+
+    const timeoutId = setTimeout(() => {
+      clearAutoBoardSuccessBanner();
+    }, remainingMs);
+
+    return () => clearTimeout(timeoutId);
+  }, [autoBoardSuccessBanner, clearAutoBoardSuccessBanner]);
+
+  if (!autoBoardSuccessBanner) {
+    return null;
+  }
+
+  if (Date.now() - autoBoardSuccessBanner.createdAt > AUTO_BOARD_SUCCESS_BANNER_MS) {
+    return null;
+  }
+
+  return (
+    <StatusBannerStrip
+      className="mx-4 mt-3 mb-1"
+      title="Boarding completed"
+      message={`${formatAutoBoardThreshold(autoBoardSuccessBanner.netBoardAmountSat)} available in Ark`}
+      icon={<CheckCircle size={16} color="#22c55e" />}
+      tone="success"
+    />
+  );
+};

--- a/client/src/components/BackupStatusBanner.tsx
+++ b/client/src/components/BackupStatusBanner.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { Pressable, View } from "react-native";
 import { AlertCircle, CheckCircle, CloudUpload } from "lucide-react-native";
-import { Text } from "~/components/ui/text";
 import { NoahActivityIndicator } from "~/components/ui/NoahActivityIndicator";
+import {
+  StatusBannerStrip,
+  type StatusBannerTone,
+} from "~/components/StatusBannerStrip";
 import { useBackupStore } from "~/store/backupStore";
 import { useServerStore } from "~/store/serverStore";
 import {
@@ -14,8 +16,6 @@ import logger from "~/lib/log";
 import { redactSensitiveErrorMessage } from "~/lib/errorUtils";
 
 const log = logger("BackupStatusBanner");
-
-type BannerTone = "info" | "success" | "failed";
 
 const formatBackupTime = (timestamp: number) =>
   new Date(timestamp).toLocaleTimeString([], {
@@ -78,7 +78,7 @@ export const BackupStatusBanner: React.FC = () => {
         title: "Backing up wallet",
         message: "Running in background",
         icon: <NoahActivityIndicator size="small" />,
-        tone: "info" as BannerTone,
+        tone: "info" as StatusBannerTone,
         actionLabel: null,
       };
     }
@@ -88,7 +88,7 @@ export const BackupStatusBanner: React.FC = () => {
         title: "Backup failed",
         message: lastBackupError ?? "An unknown error occurred while backing up.",
         icon: <AlertCircle size={16} color="#ef4444" />,
-        tone: "failed" as BannerTone,
+        tone: "failed" as StatusBannerTone,
         actionLabel: "Retry",
       };
     }
@@ -98,7 +98,7 @@ export const BackupStatusBanner: React.FC = () => {
         title: "Backup completed",
         message: lastBackupAt ? `Last backup ${formatBackupTime(lastBackupAt)}` : "Saved",
         icon: <CheckCircle size={16} color="#22c55e" />,
-        tone: "success" as BannerTone,
+        tone: "success" as StatusBannerTone,
         actionLabel: null,
       };
     }
@@ -112,7 +112,7 @@ export const BackupStatusBanner: React.FC = () => {
           ? `Last backup ${formatBackupTime(lastBackupAt)}`
           : "Backup is due",
       icon: <CloudUpload size={16} color="#60a5fa" />,
-      tone: "info" as BannerTone,
+      tone: "info" as StatusBannerTone,
       actionLabel: "Back up",
     };
   })();
@@ -140,56 +140,16 @@ export const BackupStatusBanner: React.FC = () => {
       });
   };
 
-  const containerClassName =
-    tone === "failed"
-      ? "border-red-500/30 bg-red-500/5"
-      : tone === "success"
-        ? "border-green-500/25 bg-green-500/5"
-        : "border-border/70 bg-card/70";
-
-  const iconContainerClassName =
-    tone === "failed"
-      ? "bg-red-500/10"
-      : tone === "success"
-        ? "bg-green-500/10"
-        : "bg-blue-500/10";
-
-  const actionTextClassName = tone === "failed" ? "text-red-500" : "text-foreground";
-
   return (
-    <View className="mx-4 mt-3 mb-1">
-      <View
-        className={`min-h-[52px] flex-row items-center rounded-xl border px-3 py-2 ${containerClassName}`}
-      >
-        <View
-          className={`mr-3 h-8 w-8 items-center justify-center rounded-full ${iconContainerClassName}`}
-        >
-          {icon}
-        </View>
-
-        <View className="min-w-0 flex-1">
-          <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
-            {title}
-          </Text>
-          <Text className="text-xs text-muted-foreground" numberOfLines={1}>
-            {message}
-          </Text>
-        </View>
-
-        {actionLabel && (
-          <Pressable
-            onPress={handleBackupNow}
-            disabled={isRetrying}
-            accessibilityRole="button"
-            accessibilityLabel={actionLabel}
-            className="ml-3 h-8 items-center justify-center rounded-full border border-border/70 bg-background/60 px-3 active:opacity-80 disabled:opacity-50"
-          >
-            <Text className={`text-xs font-semibold ${actionTextClassName}`}>
-              {isRetrying ? "Working" : actionLabel}
-            </Text>
-          </Pressable>
-        )}
-      </View>
-    </View>
+    <StatusBannerStrip
+      className="mx-4 mt-3 mb-1"
+      title={title}
+      message={message}
+      icon={icon}
+      tone={tone}
+      actionLabel={actionLabel}
+      isActionLoading={isRetrying}
+      onActionPress={actionLabel ? handleBackupNow : undefined}
+    />
   );
 };

--- a/client/src/components/ConfirmationDialog.tsx
+++ b/client/src/components/ConfirmationDialog.tsx
@@ -16,6 +16,7 @@ import { Pressable, View } from "react-native";
 import { Label } from "./ui/label";
 import Icon from "@react-native-vector-icons/ionicons";
 import { useIconColor } from "../hooks/useTheme";
+import { cn } from "~/lib/utils";
 
 type DangerZoneRowProps = {
   title: string;
@@ -60,10 +61,18 @@ type ConfirmationDialogProps = {
   onCancel?: () => void;
   children?: React.ReactNode;
   confirmText?: string;
+  cancelText?: string;
   confirmVariant?: "default" | "destructive";
   isConfirmDisabled?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  contentClassName?: string;
+  headerClassName?: string;
+  titleClassName?: string;
+  descriptionClassName?: string;
+  footerClassName?: string;
+  cancelClassName?: string;
+  actionClassName?: string;
   /** Haptic feedback type for confirm action (default: Success for default variant, Warning for destructive) */
   confirmHapticType?: Haptics.NotificationFeedbackType;
   /** Haptic feedback type for cancel action (default: Light) */
@@ -80,10 +89,18 @@ export const ConfirmationDialog = ({
   onCancel,
   children,
   confirmText = "Confirm",
+  cancelText = "Cancel",
   confirmVariant = "destructive",
   isConfirmDisabled,
   open,
   onOpenChange,
+  contentClassName,
+  headerClassName,
+  titleClassName,
+  descriptionClassName,
+  footerClassName,
+  cancelClassName,
+  actionClassName,
   confirmHapticType,
   cancelHapticType = Haptics.ImpactFeedbackStyle.Light,
   enableHaptics = true,
@@ -110,20 +127,22 @@ export const ConfirmationDialog = ({
     onCancel?.();
   };
   const content = (
-    <AlertDialogContent>
-      <AlertDialogHeader>
-        <AlertDialogTitle>{title}</AlertDialogTitle>
-        <AlertDialogDescription>{description}</AlertDialogDescription>
+    <AlertDialogContent className={contentClassName}>
+      <AlertDialogHeader className={headerClassName}>
+        <AlertDialogTitle className={titleClassName}>{title}</AlertDialogTitle>
+        <AlertDialogDescription className={descriptionClassName}>
+          {description}
+        </AlertDialogDescription>
       </AlertDialogHeader>
       {children}
-      <AlertDialogFooter className="flex-row space-x-2">
-        <AlertDialogCancel onPress={handleCancel} className="flex-1">
-          <Text>Cancel</Text>
+      <AlertDialogFooter className={cn("flex-row space-x-2", footerClassName)}>
+        <AlertDialogCancel onPress={handleCancel} className={cn("flex-1", cancelClassName)}>
+          <Text>{cancelText}</Text>
         </AlertDialogCancel>
         <AlertDialogAction
           variant={confirmVariant}
           onPress={handleConfirm}
-          className="flex-1"
+          className={cn("flex-1", actionClassName)}
           disabled={isConfirmDisabled}
         >
           <Text>{confirmText}</Text>

--- a/client/src/components/StatusBannerStrip.tsx
+++ b/client/src/components/StatusBannerStrip.tsx
@@ -1,0 +1,82 @@
+import type React from "react";
+import { Pressable, View } from "react-native";
+import { Text } from "~/components/ui/text";
+
+export type StatusBannerTone = "info" | "success" | "failed";
+
+type StatusBannerStripProps = {
+  title: string;
+  message: string;
+  icon: React.ReactNode;
+  tone: StatusBannerTone;
+  actionLabel?: string | null;
+  actionBusyLabel?: string;
+  isActionLoading?: boolean;
+  onActionPress?: () => void;
+  className?: string;
+};
+
+export const StatusBannerStrip = ({
+  title,
+  message,
+  icon,
+  tone,
+  actionLabel,
+  actionBusyLabel = "Working",
+  isActionLoading = false,
+  onActionPress,
+  className = "",
+}: StatusBannerStripProps) => {
+  const containerClassName =
+    tone === "failed"
+      ? "border-red-500/30 bg-red-500/5"
+      : tone === "success"
+        ? "border-green-500/25 bg-green-500/5"
+        : "border-border/70 bg-card/70";
+
+  const iconContainerClassName =
+    tone === "failed"
+      ? "bg-red-500/10"
+      : tone === "success"
+        ? "bg-green-500/10"
+        : "bg-blue-500/10";
+
+  const actionTextClassName = tone === "failed" ? "text-red-500" : "text-foreground";
+
+  return (
+    <View className={className}>
+      <View
+        className={`min-h-[52px] flex-row items-center rounded-xl border px-3 py-2 ${containerClassName}`}
+      >
+        <View
+          className={`mr-3 h-8 w-8 items-center justify-center rounded-full ${iconContainerClassName}`}
+        >
+          {icon}
+        </View>
+
+        <View className="min-w-0 flex-1">
+          <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
+            {title}
+          </Text>
+          <Text className="text-xs text-muted-foreground" numberOfLines={1}>
+            {message}
+          </Text>
+        </View>
+
+        {actionLabel && onActionPress ? (
+          <Pressable
+            onPress={onActionPress}
+            disabled={isActionLoading}
+            accessibilityRole="button"
+            accessibilityLabel={actionLabel}
+            className="ml-3 h-8 items-center justify-center rounded-full border border-border/70 bg-background/60 px-3 active:opacity-80 disabled:opacity-50"
+          >
+            <Text className={`text-xs font-semibold ${actionTextClassName}`}>
+              {isActionLoading ? actionBusyLabel : actionLabel}
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+    </View>
+  );
+};

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -250,6 +250,7 @@ export type BoardArkFeeEstimateUnavailable = {
   estimated_vbytes: number;
   fee_rate_sat_vb: number;
   fee_rate_tier: StandardOnchainWalletFeeEstimate["fee_rate_tier"];
+  is_max_amount: boolean;
 };
 
 export type BoardArkFeeEstimateResult =
@@ -288,6 +289,7 @@ export function useBoardArkFeeEstimate(params: BoardArkFeeEstimateParams | null)
             estimated_vbytes: onchainEstimate.estimated_vbytes,
             fee_rate_sat_vb: onchainEstimate.fee_rate_sat_vb,
             fee_rate_tier: onchainEstimate.fee_rate_tier,
+            is_max_amount: params.isMaxAmount,
           },
         };
       }

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -24,6 +24,9 @@ import {
   estimateSendOnchainFee,
   estimateOnchainWalletSendFee,
   estimateOffboardAllFee,
+  estimateBoardOffchainFee,
+  estimateStandardOnchainTxFee,
+  type StandardOnchainWalletFeeEstimate,
 } from "../lib/paymentsApi";
 import { queryClient } from "~/queryClient";
 import { DestinationTypes } from "~/lib/sendUtils";
@@ -188,7 +191,7 @@ export type SendFeeEstimateParams =
 
 export type SendFeeEstimate = BarkFeeEstimate | OnchainWalletFeeEstimate;
 
-const readEstimateResult = async <T extends SendFeeEstimate>(
+const readEstimateResult = async <T>(
   estimatePromise: Promise<Result<T, Error>>,
 ): Promise<T> => {
   const result = await estimatePromise;
@@ -224,6 +227,93 @@ export function useSendFeeEstimate(params: SendFeeEstimateParams | null) {
       }
     },
     enabled: params !== null && params.amountSat > 0,
+    staleTime: 20 * 1000,
+    retry: false,
+  });
+}
+
+export type BoardArkFeeEstimate = BarkFeeEstimate & {
+  estimated_onchain_fee_sat: number;
+  estimated_remaining_onchain_sat: number;
+  fee_rate_sat_vb: StandardOnchainWalletFeeEstimate["fee_rate_sat_vb"];
+  estimated_vbytes: StandardOnchainWalletFeeEstimate["estimated_vbytes"];
+  fee_rate_tier: StandardOnchainWalletFeeEstimate["fee_rate_tier"];
+  is_max_amount: boolean;
+};
+
+export type BoardArkFeeEstimateUnavailable = {
+  reason: "below_minimum_board_amount";
+  minimum_board_amount_sat: number;
+  boardable_amount_sat: number;
+  estimated_onchain_fee_sat: number;
+  minimum_required_balance_sat: number;
+  estimated_vbytes: number;
+  fee_rate_sat_vb: number;
+  fee_rate_tier: StandardOnchainWalletFeeEstimate["fee_rate_tier"];
+};
+
+export type BoardArkFeeEstimateResult =
+  | { kind: "estimate"; estimate: BoardArkFeeEstimate }
+  | { kind: "unavailable"; unavailable: BoardArkFeeEstimateUnavailable };
+
+type BoardArkFeeEstimateParams = {
+  amountSat: number;
+  confirmedOnchainBalanceSat: number;
+  isMaxAmount: boolean;
+  minimumBoardAmountSat: number;
+};
+
+export function useBoardArkFeeEstimate(params: BoardArkFeeEstimateParams | null) {
+  return useQuery({
+    queryKey: ["fee-estimate", "board-ark", params],
+    queryFn: async (): Promise<BoardArkFeeEstimateResult> => {
+      if (!params) {
+        throw new Error("Boarding fee estimate parameters are required");
+      }
+
+      const onchainEstimate = await readEstimateResult(estimateStandardOnchainTxFee("regular"));
+      const grossBoardAmountSat = params.isMaxAmount
+        ? Math.max(params.confirmedOnchainBalanceSat - onchainEstimate.fee_sat, 0)
+        : params.amountSat;
+
+      if (grossBoardAmountSat < params.minimumBoardAmountSat) {
+        return {
+          kind: "unavailable",
+          unavailable: {
+            reason: "below_minimum_board_amount",
+            minimum_board_amount_sat: params.minimumBoardAmountSat,
+            boardable_amount_sat: grossBoardAmountSat,
+            estimated_onchain_fee_sat: onchainEstimate.fee_sat,
+            minimum_required_balance_sat: params.minimumBoardAmountSat + onchainEstimate.fee_sat,
+            estimated_vbytes: onchainEstimate.estimated_vbytes,
+            fee_rate_sat_vb: onchainEstimate.fee_rate_sat_vb,
+            fee_rate_tier: onchainEstimate.fee_rate_tier,
+          },
+        };
+      }
+
+      const boardEstimate = await readEstimateResult(estimateBoardOffchainFee(grossBoardAmountSat));
+
+      return {
+        kind: "estimate",
+        estimate: {
+          ...boardEstimate,
+          estimated_onchain_fee_sat: onchainEstimate.fee_sat,
+          estimated_remaining_onchain_sat:
+            params.confirmedOnchainBalanceSat -
+            boardEstimate.gross_amount_sat -
+            onchainEstimate.fee_sat,
+          fee_rate_sat_vb: onchainEstimate.fee_rate_sat_vb,
+          estimated_vbytes: onchainEstimate.estimated_vbytes,
+          fee_rate_tier: onchainEstimate.fee_rate_tier,
+          is_max_amount: params.isMaxAmount,
+        },
+      };
+    },
+    enabled:
+      params !== null &&
+      params.amountSat > 0 &&
+      params.confirmedOnchainBalanceSat > 0,
     staleTime: 20 * 1000,
     retry: false,
   });

--- a/client/src/lib/autoBoarding.ts
+++ b/client/src/lib/autoBoarding.ts
@@ -1,9 +1,112 @@
 import type { BarkArkInfo } from "react-native-nitro-ark";
+import { err, ok, Result } from "neverthrow";
+import { estimateBoardOffchainFee, estimateStandardOnchainTxFee } from "~/lib/paymentsApi";
 
 export const AUTO_BOARD_FLOOR_AMOUNT = 20_000;
+export const AUTO_BOARD_ONCHAIN_BUFFER_AMOUNT = 5_000;
+const AUTO_BOARD_MAX_GROSS_ESTIMATE_ITERATIONS = 5;
 
 export const getAutoBoardThreshold = (arkInfo: Pick<BarkArkInfo, "min_board_amount">): number =>
   Math.max(arkInfo.min_board_amount, AUTO_BOARD_FLOOR_AMOUNT);
 
 export const formatAutoBoardThreshold = (amountSat: number): string =>
   `${amountSat.toLocaleString()} sats`;
+
+export type AutoBoardPlan = {
+  confirmedOnchainBalanceSat: number;
+  minimumNetBoardAmountSat: number;
+  minimumRequiredBalanceSat: number;
+  grossBoardAmountSat: number;
+  arkFeeSat: number;
+  netBoardAmountSat: number;
+  estimatedOnchainFeeSat: number;
+  onchainBufferSat: number;
+  estimatedRemainingOnchainSat: number;
+  feeRateSatVb: number;
+  estimatedVbytes: number;
+};
+
+const estimateGrossForMinimumNet = async (
+  minimumNetBoardAmountSat: number,
+): Promise<Result<{ grossAmountSat: number; arkFeeSat: number }, Error>> => {
+  let grossAmountSat = minimumNetBoardAmountSat;
+  let arkFeeSat = 0;
+
+  for (let attempt = 0; attempt < AUTO_BOARD_MAX_GROSS_ESTIMATE_ITERATIONS; attempt += 1) {
+    const estimateResult = await estimateBoardOffchainFee(grossAmountSat);
+    if (estimateResult.isErr()) {
+      return err(estimateResult.error);
+    }
+
+    const estimate = estimateResult.value;
+    arkFeeSat = estimate.fee_sat;
+
+    if (estimate.net_amount_sat >= minimumNetBoardAmountSat) {
+      return ok({ grossAmountSat, arkFeeSat });
+    }
+
+    grossAmountSat += minimumNetBoardAmountSat - estimate.net_amount_sat;
+  }
+
+  return ok({ grossAmountSat, arkFeeSat });
+};
+
+export const buildAutoBoardPlan = async ({
+  arkInfo,
+  confirmedOnchainBalanceSat,
+}: {
+  arkInfo: Pick<BarkArkInfo, "min_board_amount">;
+  confirmedOnchainBalanceSat: number;
+}): Promise<Result<AutoBoardPlan | null, Error>> => {
+  const minimumNetBoardAmountSat = getAutoBoardThreshold(arkInfo);
+  const onchainFeeResult = await estimateStandardOnchainTxFee("regular");
+  if (onchainFeeResult.isErr()) {
+    return err(onchainFeeResult.error);
+  }
+
+  const grossMinimumResult = await estimateGrossForMinimumNet(minimumNetBoardAmountSat);
+  if (grossMinimumResult.isErr()) {
+    return err(grossMinimumResult.error);
+  }
+
+  const {
+    fee_sat: estimatedOnchainFeeSat,
+    fee_rate_sat_vb: feeRateSatVb,
+    estimated_vbytes: estimatedVbytes,
+  } = onchainFeeResult.value;
+  const minimumRequiredBalanceSat =
+    grossMinimumResult.value.grossAmountSat +
+    estimatedOnchainFeeSat +
+    AUTO_BOARD_ONCHAIN_BUFFER_AMOUNT;
+
+  if (confirmedOnchainBalanceSat < minimumRequiredBalanceSat) {
+    return ok(null);
+  }
+
+  const grossBoardAmountSat =
+    confirmedOnchainBalanceSat - estimatedOnchainFeeSat - AUTO_BOARD_ONCHAIN_BUFFER_AMOUNT;
+  const finalEstimateResult = await estimateBoardOffchainFee(grossBoardAmountSat);
+  if (finalEstimateResult.isErr()) {
+    return err(finalEstimateResult.error);
+  }
+
+  const finalEstimate = finalEstimateResult.value;
+  if (finalEstimate.net_amount_sat < minimumNetBoardAmountSat) {
+    return ok(null);
+  }
+
+  return ok({
+    confirmedOnchainBalanceSat,
+    minimumNetBoardAmountSat,
+    minimumRequiredBalanceSat,
+    grossBoardAmountSat: finalEstimate.gross_amount_sat,
+    arkFeeSat: finalEstimate.fee_sat,
+    netBoardAmountSat: finalEstimate.net_amount_sat,
+    estimatedOnchainFeeSat,
+    onchainBufferSat: AUTO_BOARD_ONCHAIN_BUFFER_AMOUNT,
+    estimatedRemainingOnchainSat:
+      confirmedOnchainBalanceSat - finalEstimate.gross_amount_sat - estimatedOnchainFeeSat,
+    feeRateSatVb,
+    estimatedVbytes,
+  });
+};

--- a/client/src/lib/paymentsApi.ts
+++ b/client/src/lib/paymentsApi.ts
@@ -22,6 +22,7 @@ import {
   onchainTransactions as onchainTransactionsNitro,
   estimateArkoorPaymentFee as estimateArkoorPaymentFeeNitro,
   estimateLightningSendFee as estimateLightningSendFeeNitro,
+  estimateBoardOffchainFee as estimateBoardOffchainFeeNitro,
   estimateSendOnchain as estimateSendOnchainNitro,
   estimateOffboardAll as estimateOffboardAllNitro,
   history as historyNitro,
@@ -67,6 +68,15 @@ export type OnchainWalletFeeEstimate = BarkFeeEstimate & {
   fee_rate_sat_vb: number;
   estimated_vbytes: number;
 };
+
+export type StandardOnchainWalletFeeEstimate = {
+  fee_sat: number;
+  fee_rate_sat_vb: number;
+  estimated_vbytes: number;
+  fee_rate_tier: OnchainFeeRateTier;
+};
+
+export type OnchainFeeRateTier = keyof Pick<BarkFeeRates, "fast" | "regular" | "slow">;
 
 export const newAddress = async (): Promise<Result<NewAddressResult, Error>> => {
   return ResultAsync.fromPromise(
@@ -123,6 +133,18 @@ export const boardAllArk = async (): Promise<Result<BoardResult, Error>> => {
       `Failed to board funds: ${error instanceof Error ? error.message : String(error)}`,
     );
     return e;
+  });
+};
+
+export const estimateBoardOffchainFee = async (
+  amountSat: number,
+): Promise<Result<BarkFeeEstimate, Error>> => {
+  return ResultAsync.fromPromise(estimateBoardOffchainFeeNitro(amountSat), (error) => {
+    return new Error(
+      `Failed to estimate boarding fee: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
   });
 };
 
@@ -276,13 +298,12 @@ export const estimateOnchainWalletSendFee = async ({
 }: {
   amountSat: number;
 }): Promise<Result<OnchainWalletFeeEstimate, Error>> => {
-  const ratesResult = await onchainFeeRates();
-  if (ratesResult.isErr()) {
-    return err(ratesResult.error);
+  const standardFeeResult = await estimateStandardOnchainTxFee("regular");
+  if (standardFeeResult.isErr()) {
+    return err(standardFeeResult.error);
   }
 
-  const feeRateSatVb = ratesResult.value.regular;
-  const feeSat = Math.ceil(feeRateSatVb * ONCHAIN_WALLET_ESTIMATE_VBYTES);
+  const { fee_sat: feeSat, fee_rate_sat_vb: feeRateSatVb } = standardFeeResult.value;
 
   return ok({
     gross_amount_sat: amountSat + feeSat,
@@ -291,6 +312,27 @@ export const estimateOnchainWalletSendFee = async ({
     vtxos_spent: [],
     fee_rate_sat_vb: feeRateSatVb,
     estimated_vbytes: ONCHAIN_WALLET_ESTIMATE_VBYTES,
+  });
+};
+
+export const estimateStandardOnchainTxFee = async (
+  feeRateTier: OnchainFeeRateTier,
+): Promise<
+  Result<StandardOnchainWalletFeeEstimate, Error>
+> => {
+  const ratesResult = await onchainFeeRates();
+  if (ratesResult.isErr()) {
+    return err(ratesResult.error);
+  }
+
+  const feeRateSatVb = ratesResult.value[feeRateTier];
+  const feeSat = Math.ceil(feeRateSatVb * ONCHAIN_WALLET_ESTIMATE_VBYTES);
+
+  return ok({
+    fee_sat: feeSat,
+    fee_rate_sat_vb: feeRateSatVb,
+    estimated_vbytes: ONCHAIN_WALLET_ESTIMATE_VBYTES,
+    fee_rate_tier: feeRateTier,
   });
 };
 

--- a/client/src/screens/BoardArkScreen.tsx
+++ b/client/src/screens/BoardArkScreen.tsx
@@ -18,12 +18,14 @@ import { validateBitcoinAddress } from "bip-321";
 import { APP_VARIANT } from "../config";
 import { NoahButton } from "../components/ui/NoahButton";
 import { NoahActivityIndicator } from "../components/ui/NoahActivityIndicator";
-import { useBalance } from "../hooks/useWallet";
+import { useArkInfo, useBalance } from "../hooks/useWallet";
 import {
   useBoardAllAmountArk,
   useBoardArk,
+  useBoardArkFeeEstimate,
   useOffboardAllArk,
   useOffboardAllFeeEstimate,
+  type BoardArkFeeEstimateResult,
 } from "../hooks/usePayments";
 import { copyToClipboard } from "../lib/clipboardUtils";
 import { cn, formatBip177, isNetworkMatch } from "../lib/utils";
@@ -201,6 +203,127 @@ const OnboardForm = ({
   </View>
 );
 
+const BoardFeeEstimateSummary = ({
+  result,
+  isLoading,
+  error,
+  isWaitingForDebounce,
+}: {
+  result?: BoardArkFeeEstimateResult;
+  isLoading: boolean;
+  error: Error | null;
+  isWaitingForDebounce: boolean;
+}) => {
+  if (!result && !isLoading && !error && !isWaitingForDebounce) {
+    return null;
+  }
+
+  const estimate = result?.kind === "estimate" ? result.estimate : null;
+  const unavailable = result?.kind === "unavailable" ? result.unavailable : null;
+
+  return (
+    <View className="mt-3 rounded-[18px] border border-border/70 bg-card/70 px-3 py-3">
+      <View className="mb-1 flex-row items-center justify-between">
+        <Text className="text-xs font-semibold uppercase tracking-[2px] text-muted-foreground">
+          Rough fee estimate
+        </Text>
+        {isLoading || isWaitingForDebounce ? <NoahActivityIndicator size="small" /> : null}
+      </View>
+
+      {estimate ? (
+        <>
+          {estimate.is_max_amount ? (
+            <Text className="mb-2 text-xs leading-5 text-muted-foreground">
+              Max estimate leaves room for the onchain transaction fee.
+            </Text>
+          ) : null}
+          <View className="flex-row items-center justify-between py-1">
+            <Text className="text-sm text-muted-foreground">Amount to board</Text>
+            <Text className="text-sm font-semibold text-foreground">
+              {formatBip177(estimate.gross_amount_sat)}
+            </Text>
+          </View>
+          <View className="h-px bg-border/70" />
+          <View className="flex-row items-center justify-between py-1">
+            <Text className="text-sm text-muted-foreground">Ark boarding fee</Text>
+            <Text className="text-sm font-semibold text-red-500">
+              {formatBip177(estimate.fee_sat)}
+            </Text>
+          </View>
+          <View className="h-px bg-border/70" />
+          <View className="flex-row items-center justify-between py-1">
+            <Text className="text-sm text-muted-foreground">Estimated onchain fee</Text>
+            <Text className="text-sm font-semibold text-red-500">
+              {formatBip177(estimate.estimated_onchain_fee_sat)}
+            </Text>
+          </View>
+          <View className="h-px bg-border/70" />
+          <View className="flex-row items-center justify-between py-1">
+            <Text className="text-sm text-muted-foreground">Stays in onchain wallet</Text>
+            <Text
+              className={cn(
+                "text-sm font-semibold",
+                estimate.estimated_remaining_onchain_sat < 0 ? "text-red-500" : "text-foreground",
+              )}
+            >
+              {formatBip177(estimate.estimated_remaining_onchain_sat)}
+            </Text>
+          </View>
+          <View className="h-px bg-border/70" />
+          <View className="flex-row items-center justify-between py-1">
+            <Text className="text-sm text-muted-foreground">Ark amount after fee</Text>
+            <Text className="text-sm font-semibold text-green-500">
+              {formatBip177(estimate.net_amount_sat)}
+            </Text>
+          </View>
+          <Text className="mt-2 text-xs leading-5 text-muted-foreground">
+            Onchain fee uses the regular fee rate and a {estimate.estimated_vbytes} vB 2-in/2-out
+            SegWit estimate.
+          </Text>
+        </>
+      ) : unavailable ? (
+        <>
+          <Text className="text-sm leading-5 text-muted-foreground">
+            Max leaves {formatBip177(unavailable.boardable_amount_sat)} after the estimated onchain
+            fee, which is below Ark&apos;s minimum board amount.
+          </Text>
+          <View className="mt-2 h-px bg-border/70" />
+          <View className="flex-row items-center justify-between py-1">
+            <Text className="text-sm text-muted-foreground">Minimum board amount</Text>
+            <Text className="text-sm font-semibold text-foreground">
+              {formatBip177(unavailable.minimum_board_amount_sat)}
+            </Text>
+          </View>
+          <View className="h-px bg-border/70" />
+          <View className="flex-row items-center justify-between py-1">
+            <Text className="text-sm text-muted-foreground">Estimated onchain fee</Text>
+            <Text className="text-sm font-semibold text-red-500">
+              {formatBip177(unavailable.estimated_onchain_fee_sat)}
+            </Text>
+          </View>
+          <View className="h-px bg-border/70" />
+          <View className="flex-row items-center justify-between py-1">
+            <Text className="text-sm text-muted-foreground">Minimum balance needed</Text>
+            <Text className="text-sm font-semibold text-foreground">
+              {formatBip177(unavailable.minimum_required_balance_sat)}
+            </Text>
+          </View>
+          <Text className="mt-2 text-xs leading-5 text-muted-foreground">
+            Onchain fee uses the regular fee rate and a {unavailable.estimated_vbytes} vB 2-in/2-out
+            SegWit estimate.
+          </Text>
+        </>
+      ) : error ? (
+        <Text className="text-sm leading-5 text-muted-foreground">
+          Fee estimate unavailable. The final fee will be calculated when you board.
+        </Text>
+      ) : (
+        <Text className="text-sm text-muted-foreground">Estimating fees...</Text>
+      )}
+    </View>
+  );
+};
+
 // Transaction result component
 const TransactionResult = ({
   parsedData,
@@ -304,6 +427,29 @@ const BoardArkScreen = () => {
   const [amount, setAmount] = useState("");
   const [isMaxAmount, setIsMaxAmount] = useState(false);
   const [address, setAddress] = useState("");
+  const { data: arkInfo } = useArkInfo(flow === "onboard");
+
+  const onchainBalance = balance?.onchain.confirmed ?? 0;
+  const onchainPendingBalance =
+    (balance?.onchain.immature ?? 0) +
+    (balance?.onchain.trusted_pending ?? 0) +
+    (balance?.onchain.untrusted_pending ?? 0);
+
+  const offchainBalance = balance?.offchain.spendable ?? 0;
+  const offchainPendingBalance =
+    (balance?.offchain.pending_lightning_send ?? 0) +
+    (balance?.offchain.pending_in_round ?? 0) +
+    (balance?.offchain.pending_exit ?? 0);
+
+  const boardAmountSat = useMemo(() => {
+    const trimmedAmount = amount.trim();
+    if (!/^\d+$/.test(trimmedAmount)) {
+      return null;
+    }
+
+    const parsedAmount = Number(trimmedAmount);
+    return Number.isSafeInteger(parsedAmount) && parsedAmount > 0 ? parsedAmount : null;
+  }, [amount]);
 
   const validOffboardEstimateAddress = useMemo(() => {
     if (flow !== "offboard") {
@@ -326,6 +472,45 @@ const BoardArkScreen = () => {
   const [debouncedOffboardEstimateAddress, setDebouncedOffboardEstimateAddress] = useState<
     string | null
   >(null);
+  const [debouncedBoardEstimateParams, setDebouncedBoardEstimateParams] = useState<{
+    amountSat: number;
+    confirmedOnchainBalanceSat: number;
+    isMaxAmount: boolean;
+    minimumBoardAmountSat: number;
+  } | null>(null);
+
+  const boardEstimateParams = useMemo(() => {
+    if (
+      flow !== "onboard" ||
+      boardAmountSat === null ||
+      onchainBalance <= 0 ||
+      !arkInfo
+    ) {
+      return null;
+    }
+
+    return {
+      amountSat: boardAmountSat,
+      confirmedOnchainBalanceSat: onchainBalance,
+      isMaxAmount,
+      minimumBoardAmountSat: arkInfo.min_board_amount,
+    };
+  }, [arkInfo, boardAmountSat, flow, isMaxAmount, onchainBalance]);
+
+  useEffect(() => {
+    if (!boardEstimateParams) {
+      setDebouncedBoardEstimateParams(null);
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      setDebouncedBoardEstimateParams(boardEstimateParams);
+    }, 350);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [boardEstimateParams]);
 
   useEffect(() => {
     if (!validOffboardEstimateAddress) {
@@ -342,7 +527,16 @@ const BoardArkScreen = () => {
     };
   }, [validOffboardEstimateAddress]);
 
+  const boardFeeEstimateQuery = useBoardArkFeeEstimate(debouncedBoardEstimateParams);
   const offboardFeeEstimateQuery = useOffboardAllFeeEstimate(debouncedOffboardEstimateAddress);
+
+  useEffect(() => {
+    if (!boardFeeEstimateQuery.error) {
+      return;
+    }
+
+    log.w("Failed to estimate boarding fee", [boardFeeEstimateQuery.error]);
+  }, [boardFeeEstimateQuery.error]);
 
   useEffect(() => {
     if (!offboardFeeEstimateQuery.error) {
@@ -354,18 +548,6 @@ const BoardArkScreen = () => {
 
   // Use custom hook for parsing results
   const { parsedData, setParsedData } = useParsedBoardingResult(boardResult, boardAllResult);
-
-  const onchainBalance = balance?.onchain.confirmed ?? 0;
-  const onchainPendingBalance =
-    (balance?.onchain.immature ?? 0) +
-    (balance?.onchain.trusted_pending ?? 0) +
-    (balance?.onchain.untrusted_pending ?? 0);
-
-  const offchainBalance = balance?.offchain.spendable ?? 0;
-  const offchainPendingBalance =
-    (balance?.offchain.pending_lightning_send ?? 0) +
-    (balance?.offchain.pending_in_round ?? 0) +
-    (balance?.offchain.pending_exit ?? 0);
 
   const handlePress = () => {
     Keyboard.dismiss();
@@ -485,6 +667,14 @@ const BoardArkScreen = () => {
                   onchainBalance={onchainBalance}
                   setIsMaxAmount={setIsMaxAmount}
                 />
+                {boardEstimateParams ? (
+                  <BoardFeeEstimateSummary
+                    result={boardFeeEstimateQuery.data}
+                    isLoading={boardFeeEstimateQuery.isFetching}
+                    error={boardFeeEstimateQuery.error}
+                    isWaitingForDebounce={debouncedBoardEstimateParams !== boardEstimateParams}
+                  />
+                ) : null}
               </>
             ) : (
               <>

--- a/client/src/screens/BoardArkScreen.tsx
+++ b/client/src/screens/BoardArkScreen.tsx
@@ -284,8 +284,9 @@ const BoardFeeEstimateSummary = ({
       ) : unavailable ? (
         <>
           <Text className="text-sm leading-5 text-muted-foreground">
-            Max leaves {formatBip177(unavailable.boardable_amount_sat)} after the estimated onchain
-            fee, which is below Ark&apos;s minimum board amount.
+            {unavailable.is_max_amount
+              ? `Max leaves ${formatBip177(unavailable.boardable_amount_sat)} after the estimated onchain fee, which is below Ark's minimum board amount.`
+              : `Enter at least ${formatBip177(unavailable.minimum_board_amount_sat)} to meet Ark's minimum board amount.`}
           </Text>
           <View className="mt-2 h-px bg-border/70" />
           <View className="flex-row items-center justify-between py-1">
@@ -529,6 +530,17 @@ const BoardArkScreen = () => {
 
   const boardFeeEstimateQuery = useBoardArkFeeEstimate(debouncedBoardEstimateParams);
   const offboardFeeEstimateQuery = useOffboardAllFeeEstimate(debouncedOffboardEstimateAddress);
+  const isCurrentBoardEstimate =
+    !!boardEstimateParams && debouncedBoardEstimateParams === boardEstimateParams;
+  const currentBoardEstimateResult = isCurrentBoardEstimate ? boardFeeEstimateQuery.data : undefined;
+  const isBoardEstimatePending =
+    flow === "onboard" &&
+    !!boardEstimateParams &&
+    (!isCurrentBoardEstimate || boardFeeEstimateQuery.isFetching);
+  const isBoardEstimateBlocked =
+    currentBoardEstimateResult?.kind === "unavailable" ||
+    (currentBoardEstimateResult?.kind === "estimate" &&
+      currentBoardEstimateResult.estimate.estimated_remaining_onchain_sat < 0);
 
   useEffect(() => {
     if (!boardFeeEstimateQuery.error) {
@@ -581,6 +593,36 @@ const BoardArkScreen = () => {
   };
 
   const handleBoard = () => {
+    if (isBoardEstimatePending) {
+      showAlert({
+        title: "Estimating Fees",
+        description: "Please wait for the boarding fee estimate to finish.",
+      });
+      return;
+    }
+
+    if (currentBoardEstimateResult?.kind === "unavailable") {
+      const { unavailable } = currentBoardEstimateResult;
+      showAlert({
+        title: unavailable.is_max_amount ? "Insufficient Funds" : "Amount Too Low",
+        description: unavailable.is_max_amount
+          ? `Your balance needs to cover ${formatBip177(unavailable.minimum_board_amount_sat)} plus the estimated onchain fee.`
+          : `Enter at least ${formatBip177(unavailable.minimum_board_amount_sat)} to board to Ark.`,
+      });
+      return;
+    }
+
+    if (
+      currentBoardEstimateResult?.kind === "estimate" &&
+      currentBoardEstimateResult.estimate.estimated_remaining_onchain_sat < 0
+    ) {
+      showAlert({
+        title: "Insufficient Funds",
+        description: "The amount plus estimated onchain fee exceeds your confirmed on-chain balance.",
+      });
+      return;
+    }
+
     if (isMaxAmount) {
       setParsedData(null);
       boardAllArk();
@@ -669,7 +711,7 @@ const BoardArkScreen = () => {
                 />
                 {boardEstimateParams ? (
                   <BoardFeeEstimateSummary
-                    result={boardFeeEstimateQuery.data}
+                    result={currentBoardEstimateResult}
                     isLoading={boardFeeEstimateQuery.isFetching}
                     error={boardFeeEstimateQuery.error}
                     isWaitingForDebounce={debouncedBoardEstimateParams !== boardEstimateParams}
@@ -748,6 +790,8 @@ const BoardArkScreen = () => {
                 isBoarding ||
                 isBoardingAll ||
                 isOffboarding ||
+                isBoardEstimatePending ||
+                isBoardEstimateBlocked ||
                 (flow === "onboard" && (!amount || onchainBalance === 0)) ||
                 (flow === "offboard" && (offchainBalance === 0 || !address))
               }

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -18,6 +18,7 @@ import { useAppVersionCheck } from "~/hooks/useAppVersionCheck";
 import { UpdateWarningBanner } from "~/components/UpdateWarningBanner";
 import { EmailVerificationBanner } from "~/components/EmailVerificationBanner";
 import { BackupStatusBanner } from "~/components/BackupStatusBanner";
+import { AutoBoardingStatusBanner } from "~/components/AutoBoardingStatusBanner";
 import { useBackgroundJobCoordination } from "~/hooks/useBackgroundJobCoordination";
 import { useServerStore } from "~/store/serverStore";
 
@@ -235,6 +236,7 @@ const HomeScreen = () => {
           />
         )}
         <BackupStatusBanner />
+        <AutoBoardingStatusBanner />
         {isBackgroundJobRunning && (
           <View className="px-4 py-2 bg-blue-500/20 border-b border-blue-500/40">
             <View className="flex-row items-center justify-center space-x-2">

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -29,7 +29,10 @@ import { resetAndReRegisterWithServer } from "../lib/server";
 import { useBottomTabBarHeight } from "react-native-bottom-tabs";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { revokeMailboxAuthorization } from "~/lib/api";
-import { formatAutoBoardThreshold } from "~/lib/autoBoarding";
+import {
+  AUTO_BOARD_ONCHAIN_BUFFER_AMOUNT,
+  formatAutoBoardThreshold,
+} from "~/lib/autoBoarding";
 
 type Setting = {
   id:
@@ -98,7 +101,7 @@ const SettingsScreen = () => {
     ? "Auto-board threshold unavailable"
     : isAutoBoardThresholdLoading || autoBoardThreshold === undefined
       ? "Loading auto-board threshold..."
-      : `Automatically board to Ark when onchain balance reaches ${formatAutoBoardThreshold(autoBoardThreshold)}`;
+      : `Ask to board to Ark when onchain balance can cover ${formatAutoBoardThreshold(autoBoardThreshold)}, estimated fees, and a ${formatAutoBoardThreshold(AUTO_BOARD_ONCHAIN_BUFFER_AMOUNT)} reserve.`;
 
   useEffect(() => {
     const check = async () => {

--- a/client/src/store/transactionStore.ts
+++ b/client/src/store/transactionStore.ts
@@ -36,28 +36,65 @@ const zustandStorage: StateStorage = {
 interface TransactionState {
   isAutoBoardingEnabled: boolean;
   hasAttemptedAutoBoarding: boolean;
+  autoBoardSuccessBanner: {
+    netBoardAmountSat: number;
+    createdAt: number;
+  } | null;
   setAutoBoardingEnabled: (enabled: boolean) => void;
   setHasAttemptedAutoBoarding: (attempted: boolean) => void;
+  setAutoBoardSuccessBanner: (netBoardAmountSat: number) => void;
+  clearAutoBoardSuccessBanner: () => void;
   reset: () => void;
 }
+
+type PersistedTransactionState = Pick<
+  TransactionState,
+  "isAutoBoardingEnabled" | "hasAttemptedAutoBoarding"
+>;
 
 export const useTransactionStore = create<TransactionState>()(
   persist(
     (set) => ({
       isAutoBoardingEnabled: true,
       hasAttemptedAutoBoarding: false,
-      setAutoBoardingEnabled: (enabled: boolean) => set({ isAutoBoardingEnabled: enabled }),
+      autoBoardSuccessBanner: null,
+      setAutoBoardingEnabled: (enabled: boolean) =>
+        set({
+          isAutoBoardingEnabled: enabled,
+          ...(enabled ? { hasAttemptedAutoBoarding: false } : {}),
+        }),
       setHasAttemptedAutoBoarding: (attempted: boolean) =>
         set({ hasAttemptedAutoBoarding: attempted }),
+      setAutoBoardSuccessBanner: (netBoardAmountSat: number) =>
+        set({ autoBoardSuccessBanner: { netBoardAmountSat, createdAt: Date.now() } }),
+      clearAutoBoardSuccessBanner: () => set({ autoBoardSuccessBanner: null }),
       reset: () =>
         set({
           isAutoBoardingEnabled: true,
           hasAttemptedAutoBoarding: false,
+          autoBoardSuccessBanner: null,
         }),
     }),
     {
       name: "transaction-storage",
       storage: createJSONStorage(() => zustandStorage),
+      version: 1,
+      partialize: (state): PersistedTransactionState => ({
+        isAutoBoardingEnabled: state.isAutoBoardingEnabled,
+        hasAttemptedAutoBoarding: state.hasAttemptedAutoBoarding,
+      }),
+      migrate: (persistedState, version) => {
+        const state = persistedState as Partial<PersistedTransactionState>;
+
+        if (version < 1) {
+          return {
+            ...state,
+            hasAttemptedAutoBoarding: false,
+          };
+        }
+
+        return state;
+      },
     },
   ),
 );


### PR DESCRIPTION
## Summary
- Extract the shared compact status strip used for backup and auto-boarding success states
- Move auto-boarding success into the home banner stack above the balance section
- Polish the auto-boarding confirmation dialog with clearer fee/reserve breakdown and theme-safe colors
- Keep auto-boarding logic in its own service and update the fee estimation path for the new nitro-ark release

## Testing
- `bun client check`
- Manual UI verification of the home banner placement and auto-boarding dialog behavior