### PR TITLE
[codex] Polish send, receive, and notification flows

### DIFF
--- a/client/src/components/SendConfirmation.tsx
+++ b/client/src/components/SendConfirmation.tsx
@@ -35,6 +35,7 @@ interface SendConfirmationProps {
   feeEstimateUnavailableText?: string | null;
   feeEstimateNote?: string | null;
   feeEstimateWarning?: string | null;
+  sendError?: string | null;
 }
 
 const truncateValue = (value: string) => {
@@ -69,6 +70,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
   feeEstimateUnavailableText = null,
   feeEstimateNote = null,
   feeEstimateWarning = null,
+  sendError = null,
 }) => {
   const colors = useThemeColors();
   const isOnchainDestination =
@@ -136,13 +138,19 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
 
   const usdAmount = btcPrice ? satsToUsd(amount, btcPrice) : 0;
   const resolvedDestination = getDestinationDisplay();
+  const title = isLoading ? "Sending payment" : sendError ? "Send failed" : "Confirm send";
+  const description = isLoading
+    ? "Keep Noah open while this completes."
+    : sendError
+      ? "Review the error, then retry or cancel."
+      : "Review the route and fee before sending.";
 
   return (
     <View>
       <View className="items-center">
-        <Text className="text-center text-2xl font-bold text-foreground">Confirm send</Text>
+        <Text className="text-center text-2xl font-bold text-foreground">{title}</Text>
         <Text className="mt-1 max-w-[280px] text-center text-sm text-muted-foreground">
-          Review the route and fee before sending.
+          {description}
         </Text>
       </View>
 
@@ -182,7 +190,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
           <Bip321Picker
             bip321Data={bip321Data}
             selectedPaymentMethod={selectedPaymentMethod}
-            onSelect={onSelectPaymentMethod}
+            onSelect={isLoading ? () => undefined : onSelectPaymentMethod}
             showSectionHeader={false}
             showSelectedDestination={false}
           />
@@ -205,6 +213,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
                       <Pressable
                         key={source}
                         onPress={() => onSelectOnchainSource(source)}
+                        disabled={isLoading}
                         className="flex-1 rounded-2xl border px-3 py-3"
                         style={{
                           borderColor: isSelected
@@ -213,6 +222,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
                           backgroundColor: isSelected
                             ? "rgba(201, 138, 60, 0.14)"
                             : `${colors.card}99`,
+                          opacity: isLoading ? 0.65 : 1,
                         }}
                       >
                         <Text
@@ -278,6 +288,13 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
           <Text className="text-sm leading-5 text-amber-700 dark:text-amber-200">
             {feeEstimateWarning}
           </Text>
+        </View>
+      ) : null}
+
+      {sendError ? (
+        <View className="mt-3 rounded-2xl border border-destructive/35 bg-destructive/10 px-4 py-3">
+          <Text className="text-sm font-semibold text-destructive">Payment did not send</Text>
+          <Text className="mt-1 text-sm leading-5 text-destructive/90">{sendError}</Text>
         </View>
       ) : null}
 

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -351,8 +351,6 @@ const readLightningPayment = async (
 };
 
 export function useSend(destinationType: DestinationTypes) {
-  const { showAlert } = useAlert();
-
   return useMutation<SendResult, Error, SendVariables>({
     mutationFn: async (variables) => {
       const { destination, amountSat, comment, onchainSource } = variables;
@@ -416,9 +414,6 @@ export function useSend(destinationType: DestinationTypes) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["balance"] });
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
-    },
-    onError: (error: Error) => {
-      showAlert({ title: "Send Failed", description: error.message });
     },
   });
 }

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -405,6 +405,7 @@ export const useSendScreen = () => {
 
     if (displayResult) {
       if (displayResult.success) {
+        setShowConfirmation(false);
         setShowSuccess(true);
       }
       setParsedResult(displayResult);
@@ -449,6 +450,10 @@ export const useSendScreen = () => {
 
   const handleConfirmSend = () => {
     setIsDestinationFocused(false);
+    reset();
+    setParsedResult(null);
+    setShowSuccess(false);
+
     if (destinationType === "bip321" && bip321Data) {
       let destinationToSend = null;
       let newDestinationType: DestinationTypes = "onchain";
@@ -516,11 +521,14 @@ export const useSendScreen = () => {
         btcPrice,
       });
     }
-
-    setShowConfirmation(false);
   };
 
   const handleCancelConfirmation = () => {
+    if (isSending) {
+      return;
+    }
+
+    reset();
     setShowConfirmation(false);
   };
 
@@ -541,6 +549,7 @@ export const useSendScreen = () => {
   };
 
   const handleClear = () => {
+    reset();
     setDestination("");
     setComment("");
     setAmount("");
@@ -586,6 +595,7 @@ export const useSendScreen = () => {
     isSending,
     error,
     errorMessage,
+    confirmationError: showConfirmation && error ? errorMessage : null,
     showCamera,
     setShowCamera,
     handleScanPress,

--- a/client/src/lib/pushNotifications.ts
+++ b/client/src/lib/pushNotifications.ts
@@ -54,16 +54,13 @@ async function ensureDefaultNotificationChannel() {
   });
 }
 
-async function scheduleLightningPaymentNotification(amountSat: number | null): Promise<string> {
+async function scheduleLightningPaymentNotification(amountSat: number): Promise<string> {
   await ensureDefaultNotificationChannel();
 
   return Notifications.scheduleNotificationAsync({
     content: {
       title: "Lightning Payment Received! ⚡",
-      body:
-        amountSat === null
-          ? "You received a Lightning payment."
-          : `You received ${formatBip177(amountSat)}`,
+      body: `You received ${formatBip177(amountSat)}`,
       sound: "default",
       priority: Notifications.AndroidNotificationPriority.MAX,
       data: {

--- a/client/src/screens/BoardingTransactionsScreen.tsx
+++ b/client/src/screens/BoardingTransactionsScreen.tsx
@@ -7,7 +7,6 @@ import { Text } from "../components/ui/text";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import Icon from "@react-native-vector-icons/ionicons";
 import { useIconColor } from "../hooks/useTheme";
-import { Label } from "~/components/ui/label";
 import { useNavigation } from "@react-navigation/native";
 import { HomeStackParamList } from "~/Navigators";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -212,36 +211,37 @@ const BoardingTransactionsScreen = () => {
 
                 return (
                   <View style={{ marginBottom: 8 }}>
-                    <Pressable onPress={() => openTransaction(item)}>
-                      <View className="flex-row items-center p-4 bg-card rounded-lg">
-                        <View className="mr-4">
-                          <Icon
-                            name={getIconForType(item.type)}
-                            size={24}
-                            color={item.type === "onboarding" ? "green" : "orange"}
-                          />
-                        </View>
-                        <View className="flex-1">
-                          <View className="flex-row justify-between items-center">
-                            <Label className="text-foreground text-base">
-                              {formatBoardingType(item.type)}
-                            </Label>
-                            <Text className={`text-sm font-medium ${getStatusColor(item.status)}`}>
-                              {statusLabel}
-                            </Text>
-                          </View>
-                          <Text className="text-foreground text-sm mt-1">
-                            {formatBip177(item.amountSat)}
+                    <Pressable
+                      onPress={() => openTransaction(item)}
+                      className="w-full flex-row items-center rounded-lg bg-card p-4"
+                    >
+                      <View pointerEvents="none" className="mr-4">
+                        <Icon
+                          name={getIconForType(item.type)}
+                          size={24}
+                          color={item.type === "onboarding" ? "green" : "orange"}
+                        />
+                      </View>
+                      <View pointerEvents="none" className="flex-1">
+                        <View className="flex-row justify-between items-center">
+                          <Text className="text-foreground text-base font-medium">
+                            {formatBoardingType(item.type)}
                           </Text>
-                          <Text className="text-muted-foreground text-sm mt-1">
-                            {new Date(item.date).toLocaleString()}
+                          <Text className={`text-sm font-medium ${getStatusColor(item.status)}`}>
+                            {statusLabel}
                           </Text>
-                          {item.txid && (
-                            <Text className="text-muted-foreground text-xs mt-1" numberOfLines={1}>
-                              TXID: {item.txid}
-                            </Text>
-                          )}
                         </View>
+                        <Text className="text-foreground text-sm mt-1">
+                          {formatBip177(item.amountSat)}
+                        </Text>
+                        <Text className="text-muted-foreground text-sm mt-1">
+                          {new Date(item.date).toLocaleString()}
+                        </Text>
+                        {item.txid && (
+                          <Text className="text-muted-foreground text-xs mt-1" numberOfLines={1}>
+                            TXID: {item.txid}
+                          </Text>
+                        )}
                       </View>
                     </Pressable>
                   </View>

--- a/client/src/screens/ReceiveScreen.tsx
+++ b/client/src/screens/ReceiveScreen.tsx
@@ -4,6 +4,7 @@ import {
   Pressable,
   TouchableWithoutFeedback,
   Keyboard,
+  InteractionManager,
   TextInput,
   ScrollView,
 } from "react-native";
@@ -192,8 +193,13 @@ const ReceiveScreen = () => {
   const lightningSubscriptionRef = useRef<BarkNotificationSubscription | null>(null);
   const arkSubscriptionRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lightningSubscriptionRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingReceiveGenerationTaskRef = useRef<ReturnType<
+    typeof InteractionManager.runAfterInteractions
+  > | null>(null);
+  const receiveGenerationRequestIdRef = useRef(0);
   const isCompletingReceiveRef = useRef(false);
   const amountInputRef = useRef<TextInput>(null);
+  const [isSchedulingGeneration, setIsSchedulingGeneration] = useState(false);
   const [arkSubscriptionRetryTick, setArkSubscriptionRetryTick] = useState(0);
   const [lightningSubscriptionRetryTick, setLightningSubscriptionRetryTick] = useState(0);
 
@@ -206,7 +212,8 @@ const ReceiveScreen = () => {
   const { mutateAsync: generateLightningInvoice, isPending: isGeneratingLightning } =
     useGenerateLightningInvoice();
 
-  const isLoading = isGeneratingVtxo || isGeneratingOnchain || isGeneratingLightning;
+  const isLoading =
+    isSchedulingGeneration || isGeneratingVtxo || isGeneratingOnchain || isGeneratingLightning;
   const generatedAmountSat = generatedRequest?.amountSat ?? null;
   const arkAddress = generatedRequest?.arkAddress;
   const generatedOnchainAddress = generatedRequest?.onchainAddress;
@@ -290,6 +297,13 @@ const ReceiveScreen = () => {
     lightningSubscriptionRetryTimeoutRef.current = null;
   }, []);
 
+  const cancelPendingReceiveGeneration = useCallback(() => {
+    receiveGenerationRequestIdRef.current += 1;
+    pendingReceiveGenerationTaskRef.current?.cancel();
+    pendingReceiveGenerationTaskRef.current = null;
+    setIsSchedulingGeneration(false);
+  }, []);
+
   const scheduleArkSubscriptionRetry = useCallback((sessionId: number) => {
     if (arkSubscriptionRetryTimeoutRef.current) {
       return;
@@ -335,6 +349,7 @@ const ReceiveScreen = () => {
   const cancelReceiveSession = useCallback(
     ({ resetAmount }: { resetAmount: boolean }) => {
       receiveSessionIdRef.current += 1;
+      cancelPendingReceiveGeneration();
       activeReceiveSessionRef.current = null;
       isCompletingReceiveRef.current = false;
       clearArkSubscriptionRetry();
@@ -347,6 +362,7 @@ const ReceiveScreen = () => {
       clearArkSubscriptionRetry,
       clearGeneratedReceiveData,
       clearLightningSubscriptionRetry,
+      cancelPendingReceiveGeneration,
       releaseArkSubscription,
       releaseLightningSubscription,
     ],
@@ -514,9 +530,7 @@ const ReceiveScreen = () => {
     }, [cancelReceiveSession]),
   );
 
-  const handleGenerate = () => {
-    Keyboard.dismiss();
-
+  const generateReceiveRequest = useCallback(() => {
     if (hasEnteredAmount && amountSat < minAmount) {
       showAlert({
         title: "Invalid Amount",
@@ -588,6 +602,33 @@ const ReceiveScreen = () => {
         });
       },
     );
+  }, [
+    amountSat,
+    cancelReceiveSession,
+    generateLightningInvoice,
+    generateOffchainAddress,
+    generateOnchainAddress,
+    hasEnteredAmount,
+    showAlert,
+  ]);
+
+  const handleGenerate = () => {
+    Keyboard.dismiss();
+    cancelPendingReceiveGeneration();
+
+    const requestId = receiveGenerationRequestIdRef.current + 1;
+    receiveGenerationRequestIdRef.current = requestId;
+    setIsSchedulingGeneration(true);
+
+    pendingReceiveGenerationTaskRef.current = InteractionManager.runAfterInteractions(() => {
+      if (receiveGenerationRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      pendingReceiveGenerationTaskRef.current = null;
+      setIsSchedulingGeneration(false);
+      generateReceiveRequest();
+    });
   };
 
   const handleClear = () => {
@@ -623,6 +664,7 @@ const ReceiveScreen = () => {
         <ScrollView
           className="flex-1"
           showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
           contentContainerStyle={{ paddingBottom: 32 }}
         >
           <View className="px-5 pb-8">

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -84,6 +84,7 @@ const SendScreen = () => {
     feeEstimateUnavailableText,
     feeEstimateNote,
     feeEstimateWarning,
+    confirmationError,
   } = useSendScreen();
   const displayAmount = amount === "" ? (currency === "USD" ? "0.00" : "0") : amount;
 
@@ -381,6 +382,7 @@ const SendScreen = () => {
           feeEstimateUnavailableText={feeEstimateUnavailableText}
           feeEstimateNote={feeEstimateNote}
           feeEstimateWarning={feeEstimateWarning}
+          sendError={confirmationError}
         />
       </AppBottomSheet>
 

--- a/client/src/screens/TransactionsScreen.tsx
+++ b/client/src/screens/TransactionsScreen.tsx
@@ -8,7 +8,6 @@ import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import Icon from "@react-native-vector-icons/ionicons";
 import { useIconColor } from "../hooks/useTheme";
 import { type Transaction, type PaymentTypes } from "../types/transaction";
-import { Label } from "~/components/ui/label";
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { TabParamList, TransactionsStackParamList } from "~/Navigators";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -208,38 +207,39 @@ const TransactionsScreen = () => {
               renderItem={({ item }: { item: Transaction }) => {
                 return (
                   <View style={{ marginBottom: 8 }}>
-                    <Pressable onPress={() => openTransaction(item)}>
-                      <View className="flex-row items-center p-4 bg-card rounded-lg">
-                        <View className="mr-4">
-                          <Icon
-                            name={getIconForType(item.type)}
-                            size={24}
-                            color={item.direction === "outgoing" ? "red" : "green"}
-                          />
-                        </View>
-                        <View className="flex-1">
-                          <View className="flex-row justify-between gap-4">
-                            <View className="flex-1">
-                              <Label className="text-foreground text-base">
-                                {item.type === "Bolt11" || item.type === "Lnurl"
-                                  ? "Lightning"
-                                  : item.type}
-                              </Label>
-                            </View>
-                            <View className="items-end">
-                              <Text
-                                className={`text-base font-bold ${
-                                  item.direction === "outgoing" ? "text-red-500" : "text-green-500"
-                                }`}
-                              >
-                                {`${item.direction === "outgoing" ? "-" : "+"}${formatBip177(item.amount)}`}
-                              </Text>
-                            </View>
+                    <Pressable
+                      onPress={() => openTransaction(item)}
+                      className="w-full flex-row items-center rounded-lg bg-card p-4"
+                    >
+                      <View pointerEvents="none" className="mr-4">
+                        <Icon
+                          name={getIconForType(item.type)}
+                          size={24}
+                          color={item.direction === "outgoing" ? "red" : "green"}
+                        />
+                      </View>
+                      <View pointerEvents="none" className="flex-1">
+                        <View className="flex-row justify-between gap-4">
+                          <View className="flex-1">
+                            <Text className="text-foreground text-base font-medium">
+                              {item.type === "Bolt11" || item.type === "Lnurl"
+                                ? "Lightning"
+                                : item.type}
+                            </Text>
                           </View>
-                          <Text className="text-muted-foreground text-sm mt-1">
-                            {item.dateLabel ?? new Date(item.date).toLocaleString()}
-                          </Text>
+                          <View className="items-end">
+                            <Text
+                              className={`text-base font-bold ${
+                                item.direction === "outgoing" ? "text-red-500" : "text-green-500"
+                              }`}
+                            >
+                              {`${item.direction === "outgoing" ? "-" : "+"}${formatBip177(item.amount)}`}
+                            </Text>
+                          </View>
                         </View>
+                        <Text className="text-muted-foreground text-sm mt-1">
+                          {item.dateLabel ?? new Date(item.date).toLocaleString()}
+                        </Text>
                       </View>
                     </Pressable>
                   </View>

--- a/client/src/types/serverTypes.ts
+++ b/client/src/types/serverTypes.ts
@@ -101,7 +101,7 @@ export type LightningAddressSuggestionsResponse = {
  */
 suggestions: Array<string>, };
 
-export type LightningClaimRequestNotification = { payment_hash: string | null, amount_sat: number | null, };
+export type LightningClaimRequestNotification = { payment_hash: string, amount_sat: number, };
 
 export type LightningInvoiceRequestNotification = { transaction_id: string, amount: number, };
 

--- a/server/src/mailbox_worker.rs
+++ b/server/src/mailbox_worker.rs
@@ -518,7 +518,7 @@ async fn process_mailbox_message(
         Some(Message::IncomingLightningPayment(lightning_payment)) if send_notifications => {
             let payment_hash = hex::encode(&lightning_payment.payment_hash);
             let amount_sat = lightning_payment.amount_msat / 1000;
-            let notification = build_lightning_claim_notification(payment_hash, Some(amount_sat))?;
+            let notification = build_lightning_claim_notification(payment_hash, amount_sat)?;
 
             tracing::info!(
                 service = "mailbox_worker",
@@ -598,11 +598,11 @@ fn should_suppress_catchup_notifications(last_checkpoint: i64) -> bool {
 
 fn build_lightning_claim_notification(
     payment_hash: String,
-    amount_sat: Option<u64>,
+    amount_sat: u64,
 ) -> Result<PushNotificationData, ApiError> {
     let data = serde_json::to_string(&NotificationData::LightningClaimRequest(
         LightningClaimRequestNotification {
-            payment_hash: Some(payment_hash),
+            payment_hash,
             amount_sat,
         },
     ))
@@ -737,9 +737,8 @@ mod tests {
         let payment_hash = "00".repeat(32);
         let amount_sat = 42_000;
 
-        let notification =
-            build_lightning_claim_notification(payment_hash.clone(), Some(amount_sat))
-                .expect("lightning claim notification should build");
+        let notification = build_lightning_claim_notification(payment_hash.clone(), amount_sat)
+            .expect("lightning claim notification should build");
 
         assert_eq!(notification.title, None);
         assert_eq!(notification.body, None);
@@ -751,8 +750,8 @@ mod tests {
         assert!(matches!(
             data,
             NotificationData::LightningClaimRequest(LightningClaimRequestNotification {
-                payment_hash: Some(hash),
-                amount_sat: Some(amount),
+                payment_hash: hash,
+                amount_sat: amount,
             }) if hash == payment_hash && amount == amount_sat
         ));
     }

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -367,9 +367,9 @@ pub struct LightningInvoiceRequestNotification {
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]
 #[ts(export, export_to = "../../client/src/types/serverTypes.ts")]
 pub struct LightningClaimRequestNotification {
-    pub payment_hash: Option<String>,
-    #[ts(type = "number | null")]
-    pub amount_sat: Option<u64>,
+    pub payment_hash: String,
+    #[ts(type = "number")]
+    pub amount_sat: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]


### PR DESCRIPTION
## Summary

- Keep the send confirmation sheet open while a payment is in flight, show an in-sheet sending state, and surface send failures inline for retry/cancel.
- Make Receive request generation more robust when the amount input keyboard/focus is active by letting taps persist and running generation after current interactions.
- Make transaction and boarding history rows fully tappable by moving the visual card onto the press target and preventing child views from taking touch handling.
- Use server-provided incoming Lightning amounts/payment hashes directly in push notifications and tighten the shared notification type contract.

## Why

The prior send flow dismissed the confirmation sheet immediately after confirmation, leaving the user on the main send screen while wallet work was still running. The receive screen also had a plausible keyboard/touch timing issue where generation could appear delayed until another tap on some devices. History rows had dead zones because nested row content could take touch handling instead of the full card.

## Validation

- `bun client check`
- `cargo fmt --check`
- `cargo test mailbox_worker`
- `cargo test export_bindings`