### PR TITLE
Allow verified users to change emergency email

### DIFF
--- a/client/src/screens/EmailVerificationScreen.tsx
+++ b/client/src/screens/EmailVerificationScreen.tsx
@@ -51,8 +51,15 @@ const EmailVerificationScreen = () => {
   const [isVerifying, setIsVerifying] = useState(false);
   const [codeSent, setCodeSent] = useState(false);
 
-  const { isRegisteredWithServer, setEmailAddress, setEmailVerified } = useServerStore();
+  const {
+    emailAddress: currentEmailAddress,
+    isEmailVerified,
+    isRegisteredWithServer,
+    setEmailAddress,
+    setEmailVerified,
+  } = useServerStore();
   const registerMutation = useServerRegistrationMutation();
+  const isChangingEmail = Boolean(fromSettings && isEmailVerified);
 
   useEffect(() => {
     if (fromSettings || isRegisteredWithServer) {
@@ -88,7 +95,8 @@ const EmailVerificationScreen = () => {
   };
 
   const handleSendCode = async () => {
-    if (!isValidEmail(email)) {
+    const trimmedEmail = email.trim();
+    if (!isValidEmail(trimmedEmail)) {
       showAlert({
         title: "Invalid Email",
         description: "Please enter a valid email address.",
@@ -98,18 +106,19 @@ const EmailVerificationScreen = () => {
 
     Keyboard.dismiss();
     setIsSendingCode(true);
+    setEmail(trimmedEmail);
 
-    const result = await sendVerificationEmail({ email });
+    const result = await sendVerificationEmail({ email: trimmedEmail });
 
     if (result.isOk()) {
       if (result.value.message === "Email already verified") {
         log.i("Email is already verified on server, syncing local state");
-        setEmailAddress(result.value.email);
+        setEmailAddress(result.value.email ?? trimmedEmail);
         setEmailVerified(true);
         if (fromSettings) {
           showAlert({
             title: "Already Verified",
-            description: "Your email is already verified.",
+            description: "This email is already verified.",
           });
           navigation.goBack();
         } else {
@@ -152,8 +161,10 @@ const EmailVerificationScreen = () => {
 
       if (fromSettings) {
         showAlert({
-          title: "Email Verified",
-          description: "Your email has been verified successfully.",
+          title: isChangingEmail ? "Email Updated" : "Email Verified",
+          description: isChangingEmail
+            ? "Your emergency email has been updated."
+            : "Your email has been verified successfully.",
         });
         navigation.goBack();
       } else {
@@ -197,14 +208,19 @@ const EmailVerificationScreen = () => {
           <Pressable onPress={() => navigation.goBack()} className="mr-4">
             <Icon name="arrow-back-outline" size={24} color={iconColor} />
           </Pressable>
-          <Text className="text-2xl font-bold text-foreground">Emergency Email</Text>
+          <Text className="text-2xl font-bold text-foreground">
+            {isChangingEmail ? "Change Emergency Email" : "Emergency Email"}
+          </Text>
         </View>
 
         {!codeSent ? (
           <>
             <Text className="text-muted-foreground mb-6">
-              Email is optional. Noah uses it only for urgent wallet safety messages, such as when
-              your VTXOs are close to expiring and you need to come online to refresh them.
+              {isChangingEmail
+                ? `Your current email${
+                    currentEmailAddress ? `, ${currentEmailAddress},` : ""
+                  } will stay active until the new email is verified.`
+                : "Email is optional. Noah uses it only for urgent wallet safety messages, such as when your VTXOs are close to expiring and you need to come online to refresh them."}
             </Text>
 
             <View className="bg-card rounded-2xl border border-border p-5 space-y-5">
@@ -216,7 +232,7 @@ const EmailVerificationScreen = () => {
                   value={email}
                   onChangeText={setEmail}
                   className="h-16 rounded-2xl border border-border bg-background/90 px-4 text-lg leading-6 text-foreground"
-                  placeholder="your@email.com"
+                  placeholder={isChangingEmail ? "new@email.com" : "your@email.com"}
                   autoCapitalize="none"
                   autoCorrect={false}
                   keyboardType="email-address"
@@ -231,7 +247,7 @@ const EmailVerificationScreen = () => {
               isLoading={isSendingCode}
               disabled={!email || isSendingCode}
             >
-              Send Verification Code
+              {isChangingEmail ? "Send Code to New Email" : "Send Verification Code"}
             </NoahButton>
             {!fromSettings && (
               <Pressable onPress={handleSkip} className="mt-5 items-center">
@@ -242,7 +258,9 @@ const EmailVerificationScreen = () => {
         ) : (
           <>
             <Text className="text-muted-foreground mb-2">
-              We sent a 6-digit verification code to:
+              {isChangingEmail
+                ? "We sent a 6-digit verification code to your new email:"
+                : "We sent a 6-digit verification code to:"}
             </Text>
             <Text className="text-foreground font-semibold mb-6">{email}</Text>
 
@@ -284,7 +302,7 @@ const EmailVerificationScreen = () => {
               isLoading={isVerifying}
               disabled={code.length !== CELL_COUNT || isVerifying}
             >
-              Verify Email
+              {isChangingEmail ? "Update Email" : "Verify Email"}
             </NoahButton>
 
             <View className="mt-6 items-center">

--- a/client/src/screens/ProfileScreen.tsx
+++ b/client/src/screens/ProfileScreen.tsx
@@ -269,20 +269,16 @@ const ProfileScreen = () => {
                   </Text>
                 </View>
               )}
-              {!isEmailVerified ? (
-                <>
-                  <View className="h-px bg-border" />
-                  <Pressable
-                    onPress={() => navigation.navigate("EmailVerification", { fromSettings: true })}
-                    className="flex-row items-center justify-between px-4 py-4"
-                  >
-                    <Text className="text-base font-semibold text-foreground">
-                      Add Emergency Email
-                    </Text>
-                    <Icon name="chevron-forward-outline" size={22} color={iconColor} />
-                  </Pressable>
-                </>
-              ) : null}
+              <View className="h-px bg-border" />
+              <Pressable
+                onPress={() => navigation.navigate("EmailVerification", { fromSettings: true })}
+                className="flex-row items-center justify-between px-4 py-4"
+              >
+                <Text className="text-base font-semibold text-foreground">
+                  {isEmailVerified ? "Change Emergency Email" : "Add Emergency Email"}
+                </Text>
+                <Icon name="chevron-forward-outline" size={22} color={iconColor} />
+              </Pressable>
             </View>
           </View>
 

--- a/server/src/routes/public_api_v0.rs
+++ b/server/src/routes/public_api_v0.rs
@@ -527,7 +527,13 @@ pub async fn send_verification_email(
         .await?
         .ok_or_else(|| ApiError::UserNotFound)?;
 
-    if user.is_email_verified {
+    let requested_email = payload.email.trim();
+    if user.is_email_verified
+        && user
+            .email
+            .as_deref()
+            .is_some_and(|email| email.eq_ignore_ascii_case(requested_email))
+    {
         return Ok(Json(EmailVerificationResponse {
             success: true,
             message: Some("Email already verified".to_string()),
@@ -539,7 +545,7 @@ pub async fn send_verification_email(
 
     state
         .email_verification_store
-        .store(&auth_payload.key, &payload.email, &code)
+        .store(&auth_payload.key, requested_email, &code)
         .await
         .map_err(|e| {
             tracing::error!("Failed to store verification code: {}", e);
@@ -548,7 +554,7 @@ pub async fn send_verification_email(
 
     state
         .email_client
-        .send_verification_email(&payload.email, &code)
+        .send_verification_email(requested_email, &code)
         .await
         .map_err(|e| {
             tracing::error!("Failed to send verification email: {}", e);
@@ -557,7 +563,7 @@ pub async fn send_verification_email(
 
     tracing::info!(
         "Verification email sent to {} for user {}",
-        payload.email,
+        requested_email,
         auth_payload.key
     );
 
@@ -577,21 +583,10 @@ pub async fn verify_email(
 ) -> anyhow::Result<Json<EmailVerificationResponse>, ApiError> {
     let user_repo = UserRepository::new(&state.db_pool);
 
-    let user = user_repo
+    user_repo
         .find_by_pubkey(&auth_payload.key)
         .await?
         .ok_or_else(|| ApiError::UserNotFound)?;
-
-    if user.is_email_verified {
-        if let Some(Extension(event)) = &event {
-            event.add_context("verification_result", "already_verified");
-        }
-        return Ok(Json(EmailVerificationResponse {
-            success: true,
-            message: Some("Email already verified".to_string()),
-            email: user.email,
-        }));
-    }
 
     let email = state
         .email_verification_store

--- a/server/src/tests/email_verification_tests.rs
+++ b/server/src/tests/email_verification_tests.rs
@@ -112,7 +112,7 @@ async fn test_send_verification_email_already_verified() {
                 )
                 .body(Body::from(
                     serde_json::to_vec(&json!({
-                        "email": "another@example.com"
+                        "email": "verified@example.com"
                     }))
                     .unwrap(),
                 ))
@@ -128,6 +128,76 @@ async fn test_send_verification_email_already_verified() {
 
     assert!(res.success);
     assert_eq!(res.message, Some("Email already verified".to_string()));
+    assert_eq!(res.email, Some("verified@example.com".to_string()));
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_send_verification_email_verified_user_can_request_new_email() {
+    let (app, app_state, _guard) = setup_test_app().await;
+
+    let user = TestUser::new();
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, lightning_address, email, is_email_verified) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(user.pubkey().to_string())
+    .bind("test@localhost")
+    .bind("old@example.com")
+    .bind(true)
+    .execute(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    let access_token = user.access_token(&app_state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/email/send_verification")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "email": "new@example.com"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let res: EmailVerificationResponse = serde_json::from_slice(&body).unwrap();
+
+    assert!(res.success);
+    assert_eq!(res.message, Some("Verification code sent".to_string()));
+    assert_eq!(res.email, None);
+
+    let user_record = sqlx::query_as::<_, (Option<String>, bool)>(
+        "SELECT email, is_email_verified FROM users WHERE pubkey = $1",
+    )
+    .bind(user.pubkey().to_string())
+    .fetch_one(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    assert_eq!(user_record.0, Some("old@example.com".to_string()));
+    assert!(user_record.1);
+
+    let pending_email = app_state
+        .email_verification_store
+        .get_email(&user.pubkey().to_string())
+        .await
+        .unwrap();
+    assert_eq!(pending_email, Some("new@example.com".to_string()));
 }
 
 #[tracing_test::traced_test]
@@ -320,7 +390,7 @@ async fn test_verify_email_no_pending_verification() {
 
 #[tracing_test::traced_test]
 #[tokio::test]
-async fn test_verify_email_already_verified() {
+async fn test_verify_email_verified_user_without_pending_code_fails() {
     let (app, app_state, _guard) = setup_test_app().await;
 
     let user = TestUser::new();
@@ -360,13 +430,146 @@ async fn test_verify_email_already_verified() {
         .await
         .unwrap();
 
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let user_record = sqlx::query_as::<_, (Option<String>, bool)>(
+        "SELECT email, is_email_verified FROM users WHERE pubkey = $1",
+    )
+    .bind(user.pubkey().to_string())
+    .fetch_one(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    assert_eq!(user_record.0, Some("verified@example.com".to_string()));
+    assert!(user_record.1);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_verify_email_verified_user_can_update_email() {
+    let (app, app_state, _guard) = setup_test_app().await;
+
+    let user = TestUser::new();
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, lightning_address, email, is_email_verified) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(user.pubkey().to_string())
+    .bind("test@localhost")
+    .bind("old@example.com")
+    .bind(true)
+    .execute(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    let access_token = user.access_token(&app_state);
+    let code = "123456";
+    app_state
+        .email_verification_store
+        .store(&user.pubkey().to_string(), "new@example.com", code)
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/email/verify")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "code": code
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
     assert_eq!(response.status(), StatusCode::OK);
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let res: EmailVerificationResponse = serde_json::from_slice(&body).unwrap();
 
     assert!(res.success);
-    assert_eq!(res.message, Some("Email already verified".to_string()));
+    assert_eq!(res.message, Some("Email verified successfully".to_string()));
+    assert_eq!(res.email, Some("new@example.com".to_string()));
+
+    let user_record = sqlx::query_as::<_, (Option<String>, bool)>(
+        "SELECT email, is_email_verified FROM users WHERE pubkey = $1",
+    )
+    .bind(user.pubkey().to_string())
+    .fetch_one(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    assert_eq!(user_record.0, Some("new@example.com".to_string()));
+    assert!(user_record.1);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_verify_email_verified_user_invalid_code_keeps_old_email() {
+    let (app, app_state, _guard) = setup_test_app().await;
+
+    let user = TestUser::new();
+
+    sqlx::query(
+        "INSERT INTO users (pubkey, lightning_address, email, is_email_verified) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(user.pubkey().to_string())
+    .bind("test@localhost")
+    .bind("old@example.com")
+    .bind(true)
+    .execute(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    let access_token = user.access_token(&app_state);
+    app_state
+        .email_verification_store
+        .store(&user.pubkey().to_string(), "new@example.com", "123456")
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/email/verify")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "code": "999999"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let user_record = sqlx::query_as::<_, (Option<String>, bool)>(
+        "SELECT email, is_email_verified FROM users WHERE pubkey = $1",
+    )
+    .bind(user.pubkey().to_string())
+    .fetch_one(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    assert_eq!(user_record.0, Some("old@example.com".to_string()));
+    assert!(user_record.1);
 }
 
 #[tracing_test::traced_test]


### PR DESCRIPTION
## Summary
- Let already verified users request a new emergency email from Settings and keep the current email active until the new one is verified.
- Reuse the existing verification flow with updated copy and controls for change-email mode.
- Update server behavior so `send_verification_email` accepts a new address for verified users, while `verify_email` applies the replacement only after a valid code is confirmed.
- Add coverage for verified-email update, no-pending-code, and invalid-code paths.

## Testing
- `bun client check`
- `cargo test email_verification`
- `git diff --check`