### PR TITLE
Add beta warning onboarding gate and Telegram support link

### DIFF
--- a/client/.maestro/email-verification.yml
+++ b/client/.maestro/email-verification.yml
@@ -8,6 +8,8 @@ appId: com.noahwallet.regtest
     clearState: true
 
 - tapOn: "Create Wallet"
+- assertVisible: "Noah is in beta"
+- tapOn: "I accept"
 - assertVisible: "Your Recovery Phrase"
 - tapOn: "I Have Saved It, Continue"
 

--- a/client/.maestro/setup-wallet.yml
+++ b/client/.maestro/setup-wallet.yml
@@ -6,6 +6,8 @@ appId: com.noahwallet.regtest
     clearState: true
 
 - tapOn: "Create Wallet"
+- assertVisible: "Noah is in beta"
+- tapOn: "I accept"
 - assertVisible: "Your Recovery Phrase"
 - tapOn: "I Have Saved It, Continue"
 

--- a/client/src/Navigators.tsx
+++ b/client/src/Navigators.tsx
@@ -15,6 +15,7 @@ import { NoahActivityIndicator } from "~/components/ui/NoahActivityIndicator";
 
 import HomeScreen from "~/screens/HomeScreen";
 import OnboardingScreen from "~/screens/OnboardingScreen";
+import BetaWarningScreen from "~/screens/BetaWarningScreen";
 import ReceiveScreen from "~/screens/ReceiveScreen";
 import ReceiveSuccessScreen from "~/screens/ReceiveSuccessScreen";
 import SendScreen from "~/screens/SendScreen";
@@ -84,6 +85,7 @@ export type SettingsStackParamList = {
 
 export type OnboardingStackParamList = {
   Onboarding: undefined;
+  BetaWarning: undefined;
   Configuration: undefined;
   Mnemonic: { fromOnboarding: boolean };
   RestoreWallet: undefined;
@@ -225,6 +227,11 @@ const OnboardingStackScreen = () => (
     <OnboardingStack.Screen
       name="Onboarding"
       component={OnboardingScreen}
+      options={{ animation: "default" }}
+    />
+    <OnboardingStack.Screen
+      name="BetaWarning"
+      component={BetaWarningScreen}
       options={{ animation: "default" }}
     />
     <OnboardingStack.Screen

--- a/client/src/screens/BetaWarningScreen.tsx
+++ b/client/src/screens/BetaWarningScreen.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from "react";
+import { View } from "react-native";
+import { AlertTriangle } from "lucide-react-native";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { OnboardingStackParamList } from "../Navigators";
+import { NoahButton } from "../components/ui/NoahButton";
+import { Button } from "../components/ui/button";
+import { Text } from "../components/ui/text";
+import { NoahActivityIndicator } from "../components/ui/NoahActivityIndicator";
+import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
+import { useCreateWallet } from "../hooks/useWallet";
+
+const BetaWarningScreen = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<OnboardingStackParamList>>();
+  const { mutate: createWallet, isPending, isSuccess } = useCreateWallet();
+
+  useEffect(() => {
+    if (isSuccess) {
+      navigation.navigate("Mnemonic", { fromOnboarding: true });
+    }
+  }, [isSuccess, navigation]);
+
+  const handleDecline = () => {
+    navigation.goBack();
+  };
+
+  return (
+    <NoahSafeAreaView className="flex-1 bg-background">
+      <View className="flex-1 justify-center px-6 py-10">
+        <View className="items-center">
+          <View className="h-20 w-20 items-center justify-center rounded-3xl border border-border bg-card">
+            <AlertTriangle size={40} color="#f97316" />
+          </View>
+          <Text className="mt-6 text-center text-3xl font-bold text-foreground">
+            Noah is in beta
+          </Text>
+          <Text className="mt-4 text-center text-lg leading-7 text-muted-foreground">
+            Noah is still in beta. There is a possibility you could lose money. Only deposit funds
+            you are willing to lose.
+          </Text>
+        </View>
+
+        <View className="mt-10">
+          {isPending ? (
+            <View className="items-center">
+              <NoahActivityIndicator size="large" />
+              <Text className="mt-4 text-muted-foreground">Creating your wallet...</Text>
+            </View>
+          ) : (
+            <View className="space-y-3">
+              <NoahButton onPress={() => createWallet()} size="lg">
+                I accept
+              </NoahButton>
+              <Button onPress={handleDecline} variant="outline" size="lg" className="mt-3">
+                <Text>I decline</Text>
+              </Button>
+            </View>
+          )}
+        </View>
+      </View>
+    </NoahSafeAreaView>
+  );
+};
+
+export default BetaWarningScreen;

--- a/client/src/screens/OnboardingScreen.tsx
+++ b/client/src/screens/OnboardingScreen.tsx
@@ -1,25 +1,16 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { View } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { OnboardingStackParamList } from "../Navigators";
 import { NoahButton } from "../components/ui/NoahButton";
 import { Text } from "../components/ui/text";
-import { useCreateWallet } from "../hooks/useWallet";
-import { NoahActivityIndicator } from "../components/ui/NoahActivityIndicator";
 
 const OnboardingScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<OnboardingStackParamList>>();
-  const { mutate: createWallet, isPending, isSuccess } = useCreateWallet();
-
-  useEffect(() => {
-    if (isSuccess) {
-      navigation.navigate("Mnemonic", { fromOnboarding: true });
-    }
-  }, [isSuccess, navigation]);
 
   const handleCreateWallet = () => {
-    createWallet();
+    navigation.navigate("BetaWarning");
   };
 
   return (
@@ -28,24 +19,17 @@ const OnboardingScreen = () => {
       <Text className="text-lg text-muted-foreground mb-10 text-center">
         Create a new wallet or restore an existing one.
       </Text>
-      {isPending ? (
-        <View className="items-center">
-          <NoahActivityIndicator size="large" />
-          <Text className="mt-4 text-muted-foreground">Creating your wallet...</Text>
+      <View>
+        <View className="flex-row justify-center">
+          <NoahButton onPress={handleCreateWallet} size="lg">
+            Create Wallet
+          </NoahButton>
+          <View style={{ width: 20 }} />
+          <NoahButton onPress={() => navigation.navigate("RestoreWallet")} size="lg">
+            Restore Wallet
+          </NoahButton>
         </View>
-      ) : (
-        <View>
-          <View className="flex-row justify-center">
-            <NoahButton onPress={handleCreateWallet} size="lg">
-              Create Wallet
-            </NoahButton>
-            <View style={{ width: 20 }} />
-            <NoahButton onPress={() => navigation.navigate("RestoreWallet")} size="lg">
-              Restore Wallet
-            </NoahButton>
-          </View>
-        </View>
-      )}
+      </View>
     </View>
   );
 };

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { Pressable, ScrollView, View, Switch, Image } from "react-native";
+import { Linking, Pressable, ScrollView, View, Switch, Image } from "react-native";
 import Constants from "expo-constants";
 import { useWalletStore } from "../store/walletStore";
 import { useBiometrics } from "../hooks/useBiometrics";
@@ -126,6 +126,10 @@ const SettingsScreen = () => {
         setVersionTapCount(0);
       }, 2000);
     }
+  };
+
+  const handleSupportPress = () => {
+    Linking.openURL("https://t.me/blixtwallet/605026");
   };
 
   const handleBiometricsToggle = async (value: boolean) => {
@@ -564,6 +568,11 @@ const SettingsScreen = () => {
                 versionTapCount < 5 &&
                 ` (${5 - versionTapCount} taps to unlock debug)`}
               {isDebugModeEnabled && " 🔧"}
+            </Text>
+          </Pressable>
+          <Pressable onPress={handleSupportPress} className="mb-1">
+            <Text className="text-muted-foreground text-sm text-center">
+              For support, reach us on Telegram
             </Text>
           </Pressable>
           <Text className="text-muted-foreground text-sm">Made with ❤️ from Noah team</Text>

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -572,7 +572,10 @@ const SettingsScreen = () => {
           </Pressable>
           <Pressable onPress={handleSupportPress} className="mb-1">
             <Text className="text-muted-foreground text-sm text-center">
-              For support, reach us on Telegram
+              For support, reach us on{" "}
+              <Text className="text-sm font-semibold" style={{ color: COLORS.BITCOIN_ORANGE }}>
+                Telegram
+              </Text>
             </Text>
           </Pressable>
           <Text className="text-muted-foreground text-sm">Made with ❤️ from Noah team</Text>


### PR DESCRIPTION
## Summary
- Add a new onboarding beta warning screen before wallet creation.
- Require `I accept` before creating a wallet; `I decline` returns to onboarding.
- Update Maestro onboarding flows to accept the warning before expecting the recovery phrase.
- Add a tappable Telegram support link to the bottom of Settings and highlight `Telegram` with the app accent color.

## Testing
- `bun client check` passed.
- Updated Maestro flows for the new onboarding step.