### PR TITLE
Add multi-currency support across wallet screens and settings

### DIFF
--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -2791,16 +2791,16 @@ DEPENDENCIES:
   - ExpoClipboard (from `../../node_modules/expo-clipboard/ios`)
   - ExpoDevice (from `../../node_modules/expo-device/ios`)
   - "ExpoDomWebView (from `../../node_modules/@expo/dom-webview/ios`)"
-  - ExpoFileSystem (from `../../node_modules/expo-file-system/ios/ExpoFileSystem.podspec`)
-  - ExpoFont (from `../../node_modules/expo-font/ios/ExpoFont.podspec`)
+  - ExpoFileSystem (from `../../node_modules/expo-file-system/ios`)
+  - ExpoFont (from `../../node_modules/expo-font/ios`)
   - ExpoHaptics (from `../../node_modules/expo-haptics/ios`)
   - ExpoImagePicker (from `../../node_modules/expo-image-picker/ios`)
   - ExpoKeepAwake (from `../../node_modules/expo-keep-awake/ios`)
   - ExpoLocalAuthentication (from `../../node_modules/expo-local-authentication/ios`)
   - "ExpoLogBox (from `../../node_modules/@expo/log-box`)"
-  - ExpoModulesCore (from `../../node_modules/expo-modules-core/ExpoModulesCore.podspec`)
+  - ExpoModulesCore (from `../../node_modules/expo-modules-core`)
   - ExpoModulesJSI (from `../../node_modules/expo-modules-jsi/apple`)
-  - ExpoModulesWorklets (from `../../node_modules/expo-modules-core/ExpoModulesWorklets.podspec`)
+  - ExpoModulesWorklets (from `../../node_modules/expo-modules-core`)
   - ExpoModulesWorkletsAdapter (from `../../node_modules/expo-modules-core`)
   - ExpoNotifications (from `../../node_modules/expo-notifications/ios`)
   - ExpoSplashScreen (from `../../node_modules/expo-splash-screen/ios`)
@@ -2946,9 +2946,9 @@ EXTERNAL SOURCES:
   ExpoDomWebView:
     :path: "../../node_modules/@expo/dom-webview/ios"
   ExpoFileSystem:
-    :podspec: "../../node_modules/expo-file-system/ios/ExpoFileSystem.podspec"
+    :path: "../../node_modules/expo-file-system/ios"
   ExpoFont:
-    :podspec: "../../node_modules/expo-font/ios/ExpoFont.podspec"
+    :path: "../../node_modules/expo-font/ios"
   ExpoHaptics:
     :path: "../../node_modules/expo-haptics/ios"
   ExpoImagePicker:
@@ -2960,11 +2960,11 @@ EXTERNAL SOURCES:
   ExpoLogBox:
     :path: "../../node_modules/@expo/log-box"
   ExpoModulesCore:
-    :podspec: "../../node_modules/expo-modules-core/ExpoModulesCore.podspec"
+    :path: "../../node_modules/expo-modules-core"
   ExpoModulesJSI:
     :path: "../../node_modules/expo-modules-jsi/apple"
   ExpoModulesWorklets:
-    :podspec: "../../node_modules/expo-modules-core/ExpoModulesWorklets.podspec"
+    :path: "../../node_modules/expo-modules-core"
   ExpoModulesWorkletsAdapter:
     :path: "../../node_modules/expo-modules-core"
   ExpoNotifications:
@@ -3176,137 +3176,137 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EXApplication: e6040c92edc5522accd62852342e6b14742d42c0
-  EXConstants: 1c400bb9969f4c9e5ab324553138b74ae47b9efe
+  EXApplication: 8e64f7ce47f6c8b86daa2c72da0a4bae427de022
+  EXConstants: 5388ff782cff8df2578c313d5473d0eea9d4bbf4
   EXJSONUtils: dba2755f4e24009eaf87a876b2d615ea06c16e42
-  EXManifests: 7e19be8df665a338493060a419847dae76ffcd43
-  Expo: c82930e1c8b6f2e26308e364499773d3de12d55d
-  expo-dev-client: 754a615fe4d63fdffb9bd41ea45092daa7fdfc33
-  expo-dev-launcher: e3f91a500b71c6fd5c2764364d2920ea4116ed21
-  expo-dev-menu: 1c851977caf77bb9ba81298ea03270d2b1f96bc8
+  EXManifests: 9548f57656823662ca8f2708d76b986abd417273
+  Expo: ed59ed237e929bb3c2b504308141d52bdc72e1f5
+  expo-dev-client: 00a65d7e81e558ee629264f9494749175119e466
+  expo-dev-launcher: 0d92583f44e1f10eaed91220f22cdbb0d33f2b81
+  expo-dev-menu: 65963fc78bcae505c0e2665074ae71e11bbc3b18
   expo-dev-menu-interface: 65402d4affb8b418aa6cec29b3abb0e313c8f443
-  ExpoAsset: c2e7b5ba1fe75be683282d6264e38fd7cd8defbb
-  ExpoClipboard: eee843698341fd26d571fd2807800f98abb6123c
-  ExpoDevice: f527f8bbefa6efa12f8ef63e9038dd1d5d903697
-  ExpoDomWebView: 27205be8754f9992913b8a9a08e65019f2207075
-  ExpoFileSystem: d730a1cb33f2c91dec01561f0d710054fda32ae9
-  ExpoFont: 6fe496f2be617ed4367f159f215dcc4ba27d37d6
-  ExpoHaptics: 89364cf3c3ca2cfd54cafed42f3be3169bab6d42
-  ExpoImagePicker: 808f5ed1553dca885ed5b05a8d6c67bf1d379da3
-  ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
-  ExpoLocalAuthentication: 93f29833d2a8b957f996eddc05a632eb2bdeaa7d
-  ExpoLogBox: 7aa03244fe5eeced5129e4ec7ad5bd9a3994378e
-  ExpoModulesCore: 79ff1d99cc88bf895f0a5c6055fdbe64e5dcbc63
-  ExpoModulesJSI: f25a013ea9a79904bdd535e4bea0872e155cde09
-  ExpoModulesWorklets: 3f847eb6ba544bd4b55d585f89b3b18f8cd73a72
-  ExpoModulesWorkletsAdapter: 340d7d5a885ae812b6e810e2da1aa7ad72919e3a
-  ExpoNotifications: 22f9caefdb674598ee2d11dfe06eebab7a7cc155
-  ExpoSplashScreen: 3fe3a57d56d7242a9109d9714a6f9fa1e256538b
-  ExpoSystemUI: 8f4fb641c6a6ebe2a01dda0fbd3fdd952ab5823a
-  ExpoTaskManager: f9511a17a4528adb8da94efb639ad592eef8bc53
-  EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
+  ExpoAsset: 9f0e1f1b3f721162184314e9d9ef5d0ce15a0427
+  ExpoClipboard: 99404c4d18defef14c97b17c740d76de43a3cac2
+  ExpoDevice: 14b86df89a95ac59fce049600590e4e1924b0a9a
+  ExpoDomWebView: 1d046ffae836cdb4221a46bc72a93df7b994ab8e
+  ExpoFileSystem: 866c675f75c2e3f61b4db6bd8f1da1e686a08cec
+  ExpoFont: 1ef53003394eeb9ec65eb8e0b4ca22b2ef39db99
+  ExpoHaptics: 4f104baed863f132c390b802ea2f59ecc55b99a5
+  ExpoImagePicker: 776ad879c4ad1bed44398e8344d76578a9e1040e
+  ExpoKeepAwake: edf05a0a5cdeddbb9fe705b49243ec6aef9cfded
+  ExpoLocalAuthentication: 4f0076a81e64d0ed3b041b8eb6c5d0077184457e
+  ExpoLogBox: ae61965ef8e88b08b1496a65ce6cf98e82190574
+  ExpoModulesCore: 7b876c8391370fb71d987130dcfd84e2ea1213fe
+  ExpoModulesJSI: 3dc06d022a7745e465622a210083fa07a36c98cb
+  ExpoModulesWorklets: 3268242d88c2ada46fc5ee0e075c994efffb1a52
+  ExpoModulesWorkletsAdapter: 32230fc448370d3a0aaff5772c1d669eb018cbfd
+  ExpoNotifications: 88940a180e1264346f8f7371dccded26e6f9483a
+  ExpoSplashScreen: 6deba2c0000d89a38dc192ebbee1656a0fbb0b70
+  ExpoSystemUI: 5b9bfd2ccc7933ee41711b8cddabecd1eed697e2
+  ExpoTaskManager: 7c9ab45ff145cece3f713b15eec6352130f5bdf0
+  EXUpdatesInterface: 211042a76ef49beec0de793aa4439de3164c4fd4
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: a4b58d93049110cff97dba74394902b3c6cdd233
+  hermes-engine: 7ba2a073edd246f02086a03c12186700e155b4c7
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: d11f92dd1a1ee6ae53acaba14810f35d982e3333
-  NitroMmkv: 4b4f95387a15161b346a6a93b9c7072c179e0e88
-  NitroModules: c41b7b778d6557f1e517a80ec681a670321fa001
-  NoahTools: 690d5d90593c5634d2a9ab514a6c243d8212ef20
+  NitroArk: c0f3027c8ed52556eaa2741ddfe6793dd49cadbf
+  NitroMmkv: 1ff46eceb958298b1d7c013a6314432438b77a62
+  NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
+  NoahTools: efecfcff1688c6e63b9acb210286badaa3eaac36
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc
   RCTSwiftUI: 239ed2eb9e73de5a6f518810630f0c95e01c8702
-  RCTSwiftUIWrapper: 966ca7f5f22ac0b2b2255fb09cffc381f5440b03
+  RCTSwiftUIWrapper: 7b8a1ffba8994a8f955c563511bffb74b4681317
   RCTTypeSafety: 2a6403ba3492c04510e7c15bd635461646c43bb2
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
-  React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 35e06ee2bbe398196a1b85afd554cbb4da29bfb0
-  React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
-  React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
+  React-Core: f90d375d3bab515ad00df30605ce1bf02e6db12f
+  React-Core-prebuilt: 737f198a81373b645d6799713a990f951de0d2c9
+  React-CoreModules: da4f80202ef954bdfb926ca4c9ac5f685900aa5c
+  React-cxxreact: 1d1d2a28a5f10e4e2e7cf2bfd54dc9c92c68c672
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
-  React-defaultsnativemodule: cd64bc09d7ca24112bbaf1b91edbbcf3d81ea7dc
-  React-domnativemodule: dacf5bc055ae041039574f38b73a20b91e368774
-  React-Fabric: bb0baa33d91839631d315800eb23e9aaa4338a44
-  React-FabricComponents: c504d0b0e2f3054b2ba19af839f175cb361153c0
-  React-FabricImage: 91eaea1cc58d25ae2596a9277bcfe028f92374c3
-  React-featureflags: 5ac0455da0af12ca79b40402e2f42c5c7556b638
-  React-featureflagsnativemodule: df7da181b064f10f5959a7cd529b5aab3686ecb2
-  React-graphics: d25b1195baf24c7918543f4aff9be89cc080906f
-  React-hermes: 663286153a8ad6bf752b742654c766ff5e8991e7
-  React-idlecallbacksnativemodule: 0bd5392cb67f1ab25df736814b7c05213b1d3c68
-  React-ImageManager: a03eed3e3d4222130dc0ad503a1a5f3aa89de746
-  React-intersectionobservernativemodule: 5d0f1c3c7b30031b0f6f730ee52dd9d607e2c966
-  React-jserrorhandler: d5d6e7e20c5a2d6e8607e18d31d8712d7de676f6
-  React-jsi: eb7cc4cffcf24796cc302d5b2bca0e92544139a9
-  React-jsiexecutor: 65006f60e64c72c6b82f62ef6bd17c84846e73f8
-  React-jsinspector: 01e32e2247b2486117fbb143db7f7717ef462c6d
-  React-jsinspectorcdp: f1cbb34ca41d188ba22efd9b663cf258a911f6cd
-  React-jsinspectornetwork: f61acc94c881c41451f508abfe6efa748b956c21
-  React-jsinspectortracing: 9395894d9bd4d17931b9afcf230c0e7f4cb3d674
-  React-jsitooling: 03ead841daa12a93b18479f5e400ceab3732d36d
-  React-jsitracing: 4ae61c79e14360d1c6ab566031c62c490da78439
-  React-logger: bf149dea4343a9037b74bade36cced8b63f03f46
-  React-Mapbuffer: fec3e025f0ffba6b32cd2a1d7bbdee3e269aae90
-  React-microtasksnativemodule: ab33a818d339f5a1da308893c11b487be66121a8
-  React-mutationobservernativemodule: a42d1626651ccd7d0dc02a56e69d4ec77c248893
-  react-native-bottom-tabs: dd7e07f249fc4d532e4fa71b72bfd11113d2c290
-  react-native-quick-base64: 53393ee5ea472a7486e6652ad3d7a640ebf6ebda
-  react-native-safe-area-context: fb5c8ee9f6dd62ef710611b3d370c501f42a4ac0
-  react-native-slider: 08ecfc4e9cc16cc388a56dd9caeca51b55cd9bb7
-  react-native-vector-icons: fa90a3e51f7174137fa0836808ad5166efbf22dc
+  React-defaultsnativemodule: 172d2ef7d11c531c40ee74f3be1ac98d258a817f
+  React-domnativemodule: 5a60a88075a35e20fa5879c94e7aa24e5f4071d0
+  React-Fabric: 5c1954e06c094623e46d51da2dc2c926621c03a5
+  React-FabricComponents: f32494150868073accd5d52d46b30a0496626813
+  React-FabricImage: dfcd2826b10f05c19e5bfa68d4937c4401c129db
+  React-featureflags: 84bcfcb8f91f9475e437f3dd579399085a4af51e
+  React-featureflagsnativemodule: 83111c4ee188b8859aaa8643c1be640442098fef
+  React-graphics: e0441bc695f5c682a3fb1b0fd317e10765700f12
+  React-hermes: da795ff5d5816d8940fca927c46dcdd81d7e9ad6
+  React-idlecallbacksnativemodule: b6d79e1c9e335564e17d18e2649fe7524c4e74e4
+  React-ImageManager: 0e137d7231092ddaa236f3520b67b4aa833e7079
+  React-intersectionobservernativemodule: 160b3c85bb5a3df2bf50e60619c0db50aadbef8c
+  React-jserrorhandler: 619d382632f5ed166541c03f7ba7deee76fb1b16
+  React-jsi: eac528e72d25146faa922ef1aad82d338addbb75
+  React-jsiexecutor: 2d3000fdde95d0da451f8976cdf9018448756023
+  React-jsinspector: 0377987f9635c64c5aaf72ec73aaf2b0b0da7744
+  React-jsinspectorcdp: 9db641a9cd0dd5b693df27d2e665ac2540ddc336
+  React-jsinspectornetwork: 61b00d0adfe6f175830660f1b98da576bc74eb0a
+  React-jsinspectortracing: 0f8d4f2ebd7523aece78cbc926cd4b6f2fc227dc
+  React-jsitooling: 36f3854063d507bc4d4a01227ebf1b63d9e24592
+  React-jsitracing: cddf044c0c2847d3f5822a984018fd5596c1d448
+  React-logger: 57001aefabd79d885589d2f31a8be05ccc393eaa
+  React-Mapbuffer: 1aa9126122d4247ffc24bf9d28d50ce923499a71
+  React-microtasksnativemodule: d86581169e9bb5bb6f5fc3c5052f890016c1bf21
+  React-mutationobservernativemodule: 9a0c4e866f1ef2a57acebc902ebacbdf469ae741
+  react-native-bottom-tabs: af48d1bc2bdfbf8c0ac1462ea9fa9db6eb1970e8
+  react-native-quick-base64: f5840b9dd6ea8f5814fee7a11376d709d08cab3a
+  react-native-safe-area-context: c1eb308f4b36372a4de4b3bdaa8ed695ec3dd461
+  react-native-slider: 8824cf332b11bf5149f6576c8c8b32b4f93f82ac
+  react-native-vector-icons: 96005b208c80c31220245b202468887afab1fddc
   react-native-vector-icons-ionicons: 7e633927db6ab96e0255b5920c053777cacca505
-  react-native-worklets-core: 89a42b9bbce25698c6fb3f36fa61181377655e6c
-  React-NativeModulesApple: deba264b03bd79c6bd61014fa30e40321b5e443a
-  React-networking: 35e6070b084f435429f85c5db40b4d5b38652fe9
+  react-native-worklets-core: ac6ca44cc93388211aa7da8977227f9ef8bb1faf
+  React-NativeModulesApple: cc6ec4767844d610e92cc358bd3ea34937438d56
+  React-networking: a8ce15641ed7775d5b54a9d0d32defc367c2216e
   React-oscompat: 64a0c7ef5441855dc6e2a6afe8ba8f92aa05075e
-  React-perflogger: ca04287f205086a1edb5c95882be7b6068458889
-  React-performancecdpmetrics: cf1d0a3178ccd59353cedcacbda421f40100a889
-  React-performancetimeline: c9771212e7a43032d6f8d5edfb58280d46a7ce1f
+  React-perflogger: b2b0144e4ba8dd157c1e90f8ebb02d22edbd040d
+  React-performancecdpmetrics: 5a715ec33f2dea48a93a70db37a78b4f51f9fd5a
+  React-performancetimeline: c292077a6fbc7f423269b01aab0fb7cc48efe3c0
   React-RCTActionSheet: ab545c1e7b5f1ce4f8b40b6fa06afe2869095884
-  React-RCTAnimation: 343147a9cd68c93d0ca280799fedfc7102d76ce4
-  React-RCTAppDelegate: 5054754e92aaa9f8bfabe0f1022b84e46f3dcb57
-  React-RCTBlob: 8c7ae3422ca4e72bc64b7a0142fd730efc5d4dfb
-  React-RCTFabric: be458db054b206c4d8e4f20f666e75d5f2c2d420
-  React-RCTFBReactNativeSpec: 06db2e8d0f352d9fa23321aed1dd2cde25a3e83c
-  React-RCTImage: 481457bca63e039eb997f7d16c7560472f49657e
-  React-RCTLinking: 76cbb871240cec2dc5e7aa26c60f59e0ebbcf5a2
-  React-RCTNetwork: e23a778225b7672e38545d3c5c24e1f4aad6d15f
-  React-RCTRuntime: 93c830b3ab3f7b494bbe7ae7289784f8b07b3947
-  React-RCTSettings: 96196b535bef147381f96cc60ce9bda85d8be848
-  React-RCTText: 749ebbd1a999fd84d80f37002ea3bf597fcea6df
-  React-RCTVibration: 5b41a7f274757c2928845981d970916ef9e4ca14
+  React-RCTAnimation: 1f9a58c7b74c25ea4ca6e6fbd05f37cc4919097a
+  React-RCTAppDelegate: 856f82c57b47c1795009af585cfb7b87fe2d3b5a
+  React-RCTBlob: 1cb18861a19be0b4d7e44bed9315e791413399f9
+  React-RCTFabric: 081853d9efb9b38fa868c1ff3d60e48106fe2a24
+  React-RCTFBReactNativeSpec: cbc760c7a889bfce20746ca0037b97c10ea58665
+  React-RCTImage: 0d94b22644ca87fcb778a8fa3ffbf990bc9028df
+  React-RCTLinking: 881a0c6772dd05a14ab0edfea05dadb698ec8090
+  React-RCTNetwork: feb412861e3fff3426eb0961c2acdd96bee8dce1
+  React-RCTRuntime: c61b848ffadc0209fe643406370d58021bd3585d
+  React-RCTSettings: b6e14b8764f807ebe9be2e7f0d72be83b359ac26
+  React-RCTText: 1ecd4f85ff609183ebec858cf94c0f27a9dec163
+  React-RCTVibration: 3611aa5cb59094632b3141d72c50cbb8ce3d5b08
   React-rendererconsistency: 6708acd4bc39c1c5b00164370d0010d93b324c1f
-  React-renderercss: 80eb778756fed511d6128fc005188ac9008b0baf
-  React-rendererdebug: b46f338fb9d3f0bea6cf0621016c6c5a7a18e72e
-  React-RuntimeApple: c494b2089fad4a0c553cf63c2bb265f7eca2285d
-  React-RuntimeCore: b0bb151c3e2b26c6309d45d05c54aa65a6e0c094
-  React-runtimeexecutor: 00b18635b6216a1708f6eb35dbadfd993ec91c7b
-  React-RuntimeHermes: bb44c4c574ce1b9507cad2e6be015344d18b94a9
-  React-runtimescheduler: e1631e57209cb94b3efc29002b6a049cac3f6599
-  React-timing: 356b88317ca60d373b0d94b6e7a71b0a572899f5
-  React-utils: ccc01da318979af773259c4f6cdb1876f6f86f1a
-  React-webperformancenativemodule: f8b97c2cb6cfa94e92a503c09ad6d491c50a1390
-  ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
-  ReactCodegen: e5d55b301414d3cb48738d6630b434e59cf5cc57
-  ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeBottomSheet: 63aa348b5cc4cd101613c8ffa70163056043c0a5
-  ReactNativeDependencies: d811a43abebfffa71a8925aed9a630e95c115bcc
-  RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
-  RNFSTurbo: 2ba3f628bad433250a545a8c156529866f01d4da
-  RNGestureHandler: 2ff61eac036eaf89f6818bf4ed9c39771a17d134
-  RNKeychain: 6778b35b5bd067c322f8479526ac09b1d61f31d0
-  RNReanimated: 7aa4766a8c7caf521a582cfc2932180332d00128
-  RNScreens: 991cc417cd396602a6cf59a42139e5a9d91462a9
-  RNSentry: c2b739c5dbdd77f439fbd197d1d45724b22a0437
-  RNShare: 7344a3a7d4e5df58c356ad0f79e4a3ef1325c635
-  RNSVG: 0e52210d4d43165e7e2cf9c890a9848b27e513ac
-  RNWorklets: c9d31be8d2b0f73d73c573489c885a8534a9f53e
+  React-renderercss: d4a70898381431dcc07d6deba94a7eaef0cc9058
+  React-rendererdebug: ad92235a960983f69183e2e59e2bce21e72c80a0
+  React-RuntimeApple: 53a5b8fe60b044ec6fd4d254d66b7da69314a295
+  React-RuntimeCore: 97e125471c0b8313db2bbeb1e9dc001a5503e979
+  React-runtimeexecutor: 0ff42dcf1cc4bc7a89d29532a16a7d2d3849fb2f
+  React-RuntimeHermes: da5a1b7e39f3db1a7b3303d75d4c5bb6cd7c0d49
+  React-runtimescheduler: 0e24c80f0c8b6e822a33e4ad89e0ab555704eedb
+  React-timing: f23e82ad46673716e34a786048414ab80f237594
+  React-utils: 2851415c698da4b18331f9a445825d260fffa32c
+  React-webperformancenativemodule: 9f29ed34f6f6c01dac688b95fd2dfcbccf3aed7a
+  ReactAppDependencyProvider: a54c0c9b976766e1b6d5e2bb4d1ad0d15913e9e1
+  ReactCodegen: 7862b98c16d5497b7c56c4821a64446a9dacddf2
+  ReactCommon: 3ec2a55999d296af90c24beb66c8a77dc660d3ef
+  ReactNativeBottomSheet: ad86e071a3993700fec5d394314cdaf5445f00c9
+  ReactNativeDependencies: 3adcce65198f83890ec4b900248ab39f2f803027
+  RNCClipboard: c1cdf3cdd72df606520114f42e61c6898a488dd8
+  RNFSTurbo: d00626ccbeb66c229d14fa1ba33adc3d2f12caab
+  RNGestureHandler: acf7db8499c11193d9b4b6b1cc1439ff4f01a693
+  RNKeychain: 1b055a0ec36d058cb0a075e965d8c9d335e0c828
+  RNReanimated: 7592876addbe7a2c043491465a16043f0b276777
+  RNScreens: 032083414633a4d94cbcf08f8ab5019d72d1ba36
+  RNSentry: 859c1702fe09e25c24747a5feedecab1d5138074
+  RNShare: 43cee010ada075019148c7a6bac1ca71b074e1d7
+  RNSVG: a37350c7bc37452fd2b209efa0806f1de0f847ae
+  RNWorklets: 2b89b4088f75d3f99a9268060273301c229d9648
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageSVGCoder: 8e10c8f6cc879c7dfb317b284e13dd589379f01c
   Sentry: d587a8fe91ca13503ecd69a1905f3e8a0fcf61be
   SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
-  UMAppLoader: b7d22886a244871c20b5a8f2fcea13c18534e677
-  VisionCamera: 0044a94f7489f19e19d5938e97dfc36f4784af3c
+  UMAppLoader: 0fef21c4b19a111eb2912c46fbc7c6a04c242513
+  VisionCamera: 47f10351a1b6a8d251b90986ae72ca5f52331954
   Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
   ZIPFoundation: dfd3d681c4053ff7e2f7350bc4e53b5dba3f5351
 

--- a/client/ios/noah/PrivacyInfo.xcprivacy
+++ b/client/ios/noah/PrivacyInfo.xcprivacy
@@ -36,8 +36,8 @@
 			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>85F4.1</string>
 				<string>E174.1</string>
+				<string>85F4.1</string>
 			</array>
 		</dict>
 	</array>

--- a/client/src/Navigators.tsx
+++ b/client/src/Navigators.tsx
@@ -34,6 +34,7 @@ import NoahStoryScreen from "~/screens/NoahStoryScreen";
 import DebugScreen from "~/screens/DebugScreen";
 import QRHubScreen from "~/screens/QRHubScreen";
 import ProfileScreen from "~/screens/ProfileScreen";
+import CurrencySettingsScreen from "~/screens/CurrencySettingsScreen";
 import WalletLoader from "~/components/WalletLoader";
 import { useWalletStore } from "~/store/walletStore";
 import { useServerStore } from "~/store/serverStore";
@@ -68,6 +69,7 @@ export type TabParamList = {
 export type SettingsStackParamList = {
   SettingsList: undefined;
   Profile: undefined;
+  Currency: undefined;
   Mnemonic: { fromOnboarding: boolean };
   Logs: undefined;
   EmailVerification: { fromSettings?: boolean } | undefined;
@@ -123,6 +125,11 @@ const SettingsStackNav = () => (
       options={{ animation: "default" }}
     />
     <Stack.Screen name="Profile" component={ProfileScreen} options={{ animation: "default" }} />
+    <Stack.Screen
+      name="Currency"
+      component={CurrencySettingsScreen}
+      options={{ animation: "default" }}
+    />
     <Stack.Screen name="Mnemonic" component={MnemonicScreen} options={{ animation: "default" }} />
     <Stack.Screen name="Logs" component={LogScreen} options={{ animation: "default" }} />
     <Stack.Screen

--- a/client/src/components/ReceiveSuccess.tsx
+++ b/client/src/components/ReceiveSuccess.tsx
@@ -5,7 +5,9 @@ import { Text } from "./ui/text";
 import { NoahButton } from "./ui/NoahButton";
 import ReceiveAnimation from "./ReceiveAnimation";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
-import { formatNumber, satsToUsd, formatBip177 } from "~/lib/utils";
+import { formatBip177 } from "~/lib/utils";
+import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
+import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
 import * as Haptics from "expo-haptics";
 import { useThemeColors } from "~/hooks/useTheme";
 import { COLORS } from "~/lib/styleConstants";
@@ -14,6 +16,7 @@ import { useBottomTabBarHeight } from "react-native-bottom-tabs";
 type ReceiveSuccessProps = {
   amountSat: number;
   btcPrice?: number;
+  fiatCurrency: FiatCurrencyCode;
   totalWalletBalanceSat?: number;
   handleDone: () => void;
 };
@@ -21,10 +24,11 @@ type ReceiveSuccessProps = {
 export const ReceiveSuccess: React.FC<ReceiveSuccessProps> = ({
   amountSat,
   btcPrice,
+  fiatCurrency,
   totalWalletBalanceSat,
   handleDone,
 }) => {
-  const usdAmount = btcPrice ? satsToUsd(amountSat, btcPrice) : 0;
+  const fiatAmount = btcPrice ? satsToFiat(amountSat, btcPrice, fiatCurrency) : null;
   const colors = useThemeColors();
   const bottomTabBarHeight = useBottomTabBarHeight();
 
@@ -52,7 +56,7 @@ export const ReceiveSuccess: React.FC<ReceiveSuccessProps> = ({
             </Text>
             {btcPrice && (
               <Text className="mt-3 text-base font-medium text-muted-foreground">
-                ≈ ${formatNumber(usdAmount)}
+                ≈ {fiatAmount ? formatFiatAmount(fiatAmount, fiatCurrency) : null}
               </Text>
             )}
             <Text className="mt-6 text-center text-2xl font-bold text-foreground">

--- a/client/src/components/SendConfirmation.tsx
+++ b/client/src/components/SendConfirmation.tsx
@@ -3,7 +3,9 @@ import { Pressable, View } from "react-native";
 import { Text } from "./ui/text";
 import { NoahButton } from "./ui/NoahButton";
 import { Button } from "./ui/button";
-import { formatNumber, satsToUsd, formatBip177 } from "~/lib/utils";
+import { formatBip177 } from "~/lib/utils";
+import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
+import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
 import { DestinationTypes, ParsedBip321 } from "~/lib/sendUtils";
 import { useThemeColors } from "~/hooks/useTheme";
 import { COLORS } from "~/lib/styleConstants";
@@ -17,6 +19,7 @@ interface SendConfirmationProps {
   destinationType: DestinationTypes;
   comment?: string;
   btcPrice?: number;
+  fiatCurrency: FiatCurrencyCode;
   bip321Data?: ParsedBip321 | null;
   selectedPaymentMethod?: "ark" | "lightning" | "onchain" | "offer";
   onSelectPaymentMethod?: (type: "ark" | "lightning" | "onchain" | "offer") => void;
@@ -52,6 +55,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
   destinationType,
   comment,
   btcPrice,
+  fiatCurrency,
   bip321Data,
   selectedPaymentMethod,
   onSelectPaymentMethod,
@@ -136,7 +140,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
     return destination;
   };
 
-  const usdAmount = btcPrice ? satsToUsd(amount, btcPrice) : 0;
+  const fiatAmount = btcPrice ? satsToFiat(amount, btcPrice, fiatCurrency) : null;
   const resolvedDestination = getDestinationDisplay();
   const title = isLoading ? "Sending payment" : sendError ? "Send failed" : "Confirm send";
   const description = isLoading
@@ -160,7 +164,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
         </Text>
         {btcPrice ? (
           <Text className="mt-1 text-sm font-medium text-muted-foreground">
-            ≈ ${formatNumber(usdAmount)}
+            ≈ {fiatAmount ? formatFiatAmount(fiatAmount, fiatCurrency) : null}
           </Text>
         ) : null}
       </View>

--- a/client/src/components/SendSuccessBottomSheet.tsx
+++ b/client/src/components/SendSuccessBottomSheet.tsx
@@ -3,7 +3,9 @@ import { Pressable, View } from "react-native";
 import { Text } from "./ui/text";
 import { NoahButton } from "./ui/NoahButton";
 import SuccessAnimation from "./SuccessAnimation";
-import { formatNumber, satsToUsd, formatBip177 } from "~/lib/utils";
+import { formatBip177 } from "~/lib/utils";
+import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
+import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
 import { useCopyToClipboard } from "~/lib/clipboardUtils";
 import { COLORS } from "~/lib/styleConstants";
 import { useThemeColors } from "~/hooks/useTheme";
@@ -21,6 +23,7 @@ type SendSuccessBottomSheetProps = {
   parsedResult: ParsedResult;
   handleDone: () => void;
   btcPrice?: number;
+  fiatCurrency: FiatCurrencyCode;
 };
 
 const truncateValue = (value: string) => {
@@ -59,8 +62,11 @@ export const SendSuccessBottomSheet: React.FC<SendSuccessBottomSheetProps> = ({
   parsedResult,
   handleDone,
   btcPrice,
+  fiatCurrency,
 }) => {
-  const usdAmount = btcPrice ? satsToUsd(parsedResult.amount_sat, btcPrice) : 0;
+  const fiatAmount = btcPrice
+    ? satsToFiat(parsedResult.amount_sat, btcPrice, fiatCurrency)
+    : null;
   const colors = useThemeColors();
 
   return (
@@ -76,7 +82,7 @@ export const SendSuccessBottomSheet: React.FC<SendSuccessBottomSheetProps> = ({
         </Text>
         {btcPrice && (
           <Text className="mt-3 text-lg font-medium text-muted-foreground">
-            ≈ ${formatNumber(usdAmount)}
+            ≈ {fiatAmount ? formatFiatAmount(fiatAmount, fiatCurrency) : null}
           </Text>
         )}
       </View>

--- a/client/src/hooks/useMarketData.ts
+++ b/client/src/hooks/useMarketData.ts
@@ -12,12 +12,15 @@ const log = logger("useMarketData");
 
 import { err, ok, Result, ResultAsync } from "neverthrow";
 import { APP_VARIANT } from "~/config";
-export const getBtcToUsdRate = (): ResultAsync<number, Error> => {
+import type { FiatCurrencyCode, FiatRates } from "~/lib/fiatCurrency";
+import { useProfileStore } from "~/store/profileStore";
+
+export const getBtcToFiatRate = (currency: FiatCurrencyCode): ResultAsync<number, Error> => {
   return ResultAsync.fromPromise(
-    ky.get(mempoolPriceEndpoint).json<{ USD?: number }>(),
-    (e) => new Error(`Failed to fetch BTC to USD rate: ${e}`),
+    ky.get(mempoolPriceEndpoint).json<FiatRates>(),
+    (e) => new Error(`Failed to fetch BTC to ${currency} rate: ${e}`),
   ).andThen((data) => {
-    const rate = data.USD;
+    const rate = data[currency];
     if (rate) {
       return ok(rate);
     }
@@ -25,11 +28,13 @@ export const getBtcToUsdRate = (): ResultAsync<number, Error> => {
   });
 };
 
-export function useBtcToUsdRate() {
+export function useBtcToFiatRate() {
+  const preferredCurrency = useProfileStore((state) => state.preferredCurrency);
+
   return useQuery({
-    queryKey: ["btcToUsdRate"],
+    queryKey: ["btcToFiatRate", preferredCurrency],
     queryFn: async () => {
-      const result = await getBtcToUsdRate();
+      const result = await getBtcToFiatRate(preferredCurrency);
       if (result.isErr()) {
         throw result.error;
       }
@@ -95,30 +100,34 @@ export function useGetBlockHeight() {
   });
 }
 
-export const getHistoricalBtcToUsdRate = (date: string): ResultAsync<number, Error> => {
+export const getHistoricalBtcToFiatRate = (
+  date: string,
+  currency: FiatCurrencyCode,
+): ResultAsync<number, Error> => {
   const timestamp = Math.floor(new Date(date).getTime() / 1000);
   return ResultAsync.fromPromise(
     ky
       .get(mempoolHistoricalPriceEndpoint, {
         searchParams: {
-          currency: "USD",
+          currency,
           timestamp: timestamp.toString(),
         },
       })
-      .json<{ prices?: { USD?: number }[] }>(),
-    (e) => new Error(`Failed to fetch historical BTC to USD rate: ${e}`),
+      .json<{ prices?: FiatRates[] }>(),
+    (e) => new Error(`Failed to fetch historical BTC to ${currency} rate: ${e}`),
   )
     .andThen((data) => {
       const prices = data.prices;
-      if (prices && prices.length > 0 && prices[0].USD) {
-        return ok(prices[0].USD);
+      const rate = prices?.[0]?.[currency];
+      if (rate) {
+        return ok(rate);
       }
       // If no price is available for that day, fetch the current price as a fallback.
-      return getBtcToUsdRate();
+      return getBtcToFiatRate(currency);
     })
     .orElse((error) => {
-      log.e("Failed to fetch historical BTC to USD rate:", [error]);
+      log.e(`Failed to fetch historical BTC to ${currency} rate:`, [error]);
       // Fallback to current price on error
-      return getBtcToUsdRate();
+      return getBtcToFiatRate(currency);
     });
 };

--- a/client/src/hooks/useReceiveScreen.ts
+++ b/client/src/hooks/useReceiveScreen.ts
@@ -1,25 +1,28 @@
 import { useState, useMemo } from "react";
-import { useBtcToUsdRate } from "./useMarketData";
+import { useBtcToFiatRate } from "./useMarketData";
+import { fiatToSats, satsToFiat } from "~/lib/fiatCurrency";
+import { useProfileStore } from "~/store/profileStore";
 
 export const useReceiveScreen = () => {
   const [amount, setAmount] = useState("");
-  const [currency, setCurrency] = useState<"SATS" | "USD">("SATS");
-  const { data: btcPrice } = useBtcToUsdRate();
+  const [currency, setCurrency] = useState<"SATS" | "FIAT">("SATS");
+  const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
+  const { data: btcPrice } = useBtcToFiatRate();
 
   const toggleCurrency = () => {
     if (currency === "SATS") {
       if (btcPrice && amount) {
         const sats = parseInt(amount, 10);
         if (!isNaN(sats)) {
-          setAmount(((sats * btcPrice) / 100000000).toFixed(2));
+          setAmount(satsToFiat(sats, btcPrice, fiatCurrency));
         }
       }
-      setCurrency("USD");
+      setCurrency("FIAT");
     } else {
       if (btcPrice && amount) {
-        const usd = parseFloat(amount);
-        if (!isNaN(usd)) {
-          setAmount(Math.round((usd / btcPrice) * 100000000).toString());
+        const fiatAmount = parseFloat(amount);
+        if (!isNaN(fiatAmount)) {
+          setAmount(fiatToSats(fiatAmount, btcPrice).toString());
         }
       }
       setCurrency("SATS");
@@ -36,8 +39,8 @@ export const useReceiveScreen = () => {
 
     if (!btcPrice) return 0;
 
-    return Math.round((amountFloat / btcPrice) * 100000000);
-  }, [amount, currency, btcPrice]);
+    return fiatToSats(amountFloat, btcPrice);
+  }, [amount, currency, btcPrice, fiatCurrency]);
 
   return {
     amount,
@@ -46,5 +49,6 @@ export const useReceiveScreen = () => {
     toggleCurrency,
     amountSat,
     btcPrice,
+    fiatCurrency,
   };
 };

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -15,10 +15,12 @@ import {
   type PaymentResult,
 } from "../lib/paymentsApi";
 import { useQRCodeScanner } from "~/hooks/useQRCodeScanner";
-import { useBtcToUsdRate } from "./useMarketData";
+import { useBtcToFiatRate } from "./useMarketData";
 import { useBalance } from "./useWallet";
 import { useLightningAddressSuggestions } from "./useLightningAddressSuggestions";
-import { formatBip177, satsToUsd, usdToSats } from "../lib/utils";
+import { formatBip177 } from "../lib/utils";
+import { fiatToSats, satsToFiat } from "~/lib/fiatCurrency";
+import { useProfileStore } from "~/store/profileStore";
 import logger from "~/lib/log";
 
 const log = logger("useSendScreen");
@@ -57,7 +59,8 @@ const isOnchainWalletFeeEstimate = (estimate: unknown): estimate is OnchainWalle
 export const useSendScreen = () => {
   const route = useRoute<SendScreenRouteProp>();
   const { showAlert } = useAlert();
-  const { data: btcPrice } = useBtcToUsdRate();
+  const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
+  const { data: btcPrice } = useBtcToFiatRate();
   const { data: balance } = useBalance();
   const [destination, setDestination] = useState("");
   const [amount, setAmount] = useState("");
@@ -65,7 +68,7 @@ export const useSendScreen = () => {
   const [comment, setComment] = useState("");
   const [parsedResult, setParsedResult] = useState<DisplayResult | null>(null);
   const [destinationType, setDestinationType] = useState<DestinationTypes | null>(null);
-  const [currency, setCurrency] = useState<"USD" | "SATS">("SATS");
+  const [currency, setCurrency] = useState<"FIAT" | "SATS">("SATS");
   const [parsedAmount, setParsedAmount] = useState<number | null>(null);
   const [bip321Data, setBip321Data] = useState<ParsedBip321 | null>(null);
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
@@ -153,7 +156,7 @@ export const useSendScreen = () => {
       return parseInt(amount, 10) || 0;
     }
     if (btcPrice) {
-      return usdToSats(parseFloat(amount), btcPrice);
+      return fiatToSats(parseFloat(amount), btcPrice);
     }
     return 0;
   }, [amount, currency, btcPrice]);
@@ -322,16 +325,16 @@ export const useSendScreen = () => {
   const toggleCurrency = useCallback(() => {
     if (currency === "SATS") {
       if (btcPrice && amount) {
-        setAmount(satsToUsd(parseInt(amount, 10), btcPrice));
+        setAmount(satsToFiat(parseInt(amount, 10), btcPrice, fiatCurrency));
       }
-      setCurrency("USD");
+      setCurrency("FIAT");
     } else {
       if (btcPrice && amount) {
-        setAmount(usdToSats(parseFloat(amount), btcPrice).toString());
+        setAmount(fiatToSats(parseFloat(amount), btcPrice).toString());
       }
       setCurrency("SATS");
     }
-  }, [currency, btcPrice, amount]);
+  }, [currency, btcPrice, amount, fiatCurrency]);
 
   useEffect(() => {
     if (!result) {
@@ -601,6 +604,7 @@ export const useSendScreen = () => {
     handleScanPress,
     codeScanner,
     currency,
+    fiatCurrency,
     toggleCurrency,
     amountSat,
     btcPrice,

--- a/client/src/hooks/useTransactions.ts
+++ b/client/src/hooks/useTransactions.ts
@@ -9,8 +9,10 @@ import type { Transaction, PaymentTypes } from "~/types/transaction";
 import type { BarkMovement, MovementStatus, OnchainTransactionInfo } from "react-native-nitro-ark";
 import type { MovementKind } from "~/types/movement";
 import { INCOMING_MOVEMENT_KINDS } from "~/types/movement";
-import { getHistoricalBtcToUsdRate } from "~/hooks/useMarketData";
+import { getHistoricalBtcToFiatRate } from "~/hooks/useMarketData";
 import logger from "~/lib/log";
+import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
+import { useProfileStore } from "~/store/profileStore";
 import {
   BARK_SUBSYSTEM,
   type BarkSubsystemId,
@@ -199,7 +201,10 @@ const determineTransactionType = (
   return "Onchain";
 };
 
-const transformMovementToTransaction = async (movement: BarkMovement): Promise<Transaction> => {
+const transformMovementToTransaction = async (
+  movement: BarkMovement,
+  currency: FiatCurrencyCode,
+): Promise<Transaction> => {
   const movementKind = determineMovementKind(movement);
   const isOutgoing = isOutgoingMovement(movement);
   const direction = isOutgoing ? "outgoing" : "incoming";
@@ -212,7 +217,7 @@ const transformMovementToTransaction = async (movement: BarkMovement): Promise<T
   const transactionType = determineTransactionType(movement, movementKind, isOutgoing);
 
   let btcPrice: number | undefined;
-  const btcPriceResult = await getHistoricalBtcToUsdRate(dateIso);
+  const btcPriceResult = await getHistoricalBtcToFiatRate(dateIso, currency);
   if (btcPriceResult.isOk()) {
     btcPrice = btcPriceResult.value;
   }
@@ -299,6 +304,7 @@ const getOnchainTransactionBlockTime = async (
 
 const transformOnchainTransaction = async (
   transaction: OnchainTransactionInfo,
+  currency: FiatCurrencyCode,
 ): Promise<Transaction> => {
   const isOutgoing = transaction.balance_change_sat < 0;
   const blockTime = await getOnchainTransactionBlockTime(transaction);
@@ -306,7 +312,7 @@ const transformOnchainTransaction = async (
 
   let btcPrice: number | undefined;
   if (blockTime) {
-    const btcPriceResult = await getHistoricalBtcToUsdRate(date);
+    const btcPriceResult = await getHistoricalBtcToFiatRate(date, currency);
     if (btcPriceResult.isOk()) {
       btcPrice = btcPriceResult.value;
     }
@@ -380,7 +386,9 @@ const shouldIncludeMovement = (movement: BarkMovement): boolean => {
   return hasAmount;
 };
 
-const fetchAndTransformTransactions = async (): Promise<Transaction[]> => {
+const fetchAndTransformTransactions = async (
+  currency: FiatCurrencyCode,
+): Promise<Transaction[]> => {
   const loadWalletResult = await loadWalletIfNeeded();
   if (loadWalletResult.isErr()) {
     throw loadWalletResult.error;
@@ -414,9 +422,11 @@ const fetchAndTransformTransactions = async (): Promise<Transaction[]> => {
     return [];
   }
 
-  const movementTransactions = await Promise.all(movements.map(transformMovementToTransaction));
+  const movementTransactions = await Promise.all(
+    movements.map((movement) => transformMovementToTransaction(movement, currency)),
+  );
   const onchainWalletTransactions = await Promise.all(
-    walletTransactions.map(transformOnchainTransaction),
+    walletTransactions.map((transaction) => transformOnchainTransaction(transaction, currency)),
   );
 
   return [...movementTransactions, ...onchainWalletTransactions].sort(compareTransactions);
@@ -424,12 +434,13 @@ const fetchAndTransformTransactions = async (): Promise<Transaction[]> => {
 
 export const useTransactions = (options?: { enabled?: boolean }) => {
   const { isInitialized, isWalletLoaded, isWalletSuspended } = useWalletStore();
+  const preferredCurrency = useProfileStore((state) => state.preferredCurrency);
   const enabled =
     (options?.enabled ?? true) && isInitialized && isWalletLoaded && !isWalletSuspended;
 
   return useQuery({
-    queryKey: ["transactions"],
-    queryFn: fetchAndTransformTransactions,
+    queryKey: ["transactions", preferredCurrency],
+    queryFn: () => fetchAndTransformTransactions(preferredCurrency),
     enabled,
     staleTime: 30 * 1000,
     refetchOnWindowFocus: true,

--- a/client/src/lib/fiatCurrency.ts
+++ b/client/src/lib/fiatCurrency.ts
@@ -1,0 +1,53 @@
+import { formatNumber } from "~/lib/utils";
+
+export const SUPPORTED_FIAT_CURRENCIES = ["USD", "EUR", "GBP", "CAD", "CHF", "AUD", "JPY"] as const;
+
+export type FiatCurrencyCode = (typeof SUPPORTED_FIAT_CURRENCIES)[number];
+
+export type FiatCurrencyInfo = {
+  code: FiatCurrencyCode;
+  name: string;
+  symbol: string;
+  decimals: number;
+};
+
+export const FIAT_CURRENCY_INFO: Record<FiatCurrencyCode, FiatCurrencyInfo> = {
+  USD: { code: "USD", name: "U.S. Dollar", symbol: "$", decimals: 2 },
+  EUR: { code: "EUR", name: "Euro", symbol: "€", decimals: 2 },
+  GBP: { code: "GBP", name: "British Pound", symbol: "£", decimals: 2 },
+  CAD: { code: "CAD", name: "Canadian Dollar", symbol: "CA$", decimals: 2 },
+  CHF: { code: "CHF", name: "Swiss Franc", symbol: "CHF", decimals: 2 },
+  AUD: { code: "AUD", name: "Australian Dollar", symbol: "A$", decimals: 2 },
+  JPY: { code: "JPY", name: "Japanese Yen", symbol: "¥", decimals: 0 },
+};
+
+export type FiatRates = Partial<Record<FiatCurrencyCode, number>>;
+
+export const isFiatCurrencyCode = (value: unknown): value is FiatCurrencyCode =>
+  typeof value === "string" &&
+  SUPPORTED_FIAT_CURRENCIES.includes(value as FiatCurrencyCode);
+
+export const getFiatCurrencyInfo = (currency: FiatCurrencyCode): FiatCurrencyInfo =>
+  FIAT_CURRENCY_INFO[currency];
+
+export const satsToFiat = (sats: number, btcPrice: number, currency: FiatCurrencyCode): string => {
+  const { decimals } = getFiatCurrencyInfo(currency);
+  return ((sats * btcPrice) / 100_000_000).toFixed(decimals);
+};
+
+export const fiatToSats = (amount: number, btcPrice: number): number => {
+  return Math.round((amount / btcPrice) * 100_000_000);
+};
+
+export const formatFiatAmount = (
+  amount: number | string,
+  currency: FiatCurrencyCode,
+): string => {
+  const { decimals, symbol } = getFiatCurrencyInfo(currency);
+  const numericAmount = typeof amount === "number" ? amount : Number(amount);
+  const formattedAmount = Number.isFinite(numericAmount)
+    ? numericAmount.toFixed(decimals)
+    : amount.toString();
+  const separator = /^[A-Z]+$/.test(symbol) ? " " : "";
+  return `${symbol}${separator}${formatNumber(formattedAmount)}`;
+};

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -28,14 +28,6 @@ export const satsToBtc = (sats: number) => {
   return (sats / 100_000_000).toFixed(8);
 };
 
-export const satsToUsd = (sats: number, btcPrice: number): string => {
-  return ((sats * btcPrice) / 100_000_000).toFixed(2);
-};
-
-export const usdToSats = (usd: number, btcPrice: number): number => {
-  return Math.round((usd / btcPrice) * 100_000_000);
-};
-
 export const formatBip177 = (sats: number): string => {
   return `₿\u00A0${sats.toLocaleString()}`;
 };

--- a/client/src/screens/CurrencySettingsScreen.tsx
+++ b/client/src/screens/CurrencySettingsScreen.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { Pressable, ScrollView, View } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import Icon from "@react-native-vector-icons/ionicons";
+import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
+import { Text } from "~/components/ui/text";
+import type { SettingsStackParamList } from "~/Navigators";
+import {
+  getFiatCurrencyInfo,
+  SUPPORTED_FIAT_CURRENCIES,
+  type FiatCurrencyCode,
+} from "~/lib/fiatCurrency";
+import { COLORS } from "~/lib/styleConstants";
+import { useIconColor, useThemeColors } from "~/hooks/useTheme";
+import { useProfileStore } from "~/store/profileStore";
+
+type CurrencyNavigationProp = NativeStackNavigationProp<SettingsStackParamList, "Currency">;
+
+const CurrencySettingsScreen = () => {
+  const navigation = useNavigation<CurrencyNavigationProp>();
+  const iconColor = useIconColor();
+  const colors = useThemeColors();
+  const preferredCurrency = useProfileStore((state) => state.preferredCurrency);
+  const setPreferredCurrency = useProfileStore((state) => state.setPreferredCurrency);
+
+  const handleSelectCurrency = (currency: FiatCurrencyCode) => {
+    setPreferredCurrency(currency);
+    navigation.goBack();
+  };
+
+  return (
+    <NoahSafeAreaView className="flex-1 bg-background">
+      <ScrollView
+        className="flex-1"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 32 }}
+      >
+        <View className="px-5 pb-8 pt-4">
+          <View className="flex-row items-center">
+            <Pressable onPress={() => navigation.goBack()} className="mr-4">
+              <Icon name="arrow-back-outline" size={24} color={iconColor} />
+            </Pressable>
+            <Text className="text-2xl font-bold text-foreground">Currency</Text>
+          </View>
+
+          <View
+            className="mt-8 overflow-hidden rounded-[18px] border"
+            style={{
+              borderColor: `${colors.mutedForeground}24`,
+              backgroundColor: `${colors.card}CC`,
+            }}
+          >
+            {SUPPORTED_FIAT_CURRENCIES.map((currency, index) => {
+              const info = getFiatCurrencyInfo(currency);
+              const isSelected = currency === preferredCurrency;
+
+              return (
+                <Pressable
+                  key={currency}
+                  onPress={() => handleSelectCurrency(currency)}
+                  className={`flex-row items-center justify-between px-4 py-4 ${
+                    index < SUPPORTED_FIAT_CURRENCIES.length - 1 ? "border-b border-border" : ""
+                  }`}
+                >
+                  <View className="min-w-0 flex-1">
+                    <Text className="text-base font-semibold text-foreground">
+                      {info.code} · {info.name}
+                    </Text>
+                    <Text className="mt-1 text-sm text-muted-foreground">{info.symbol}</Text>
+                  </View>
+                  {isSelected ? (
+                    <Icon name="checkmark-circle" size={24} color={COLORS.BITCOIN_ORANGE} />
+                  ) : (
+                    <Icon name="ellipse-outline" size={24} color={iconColor} />
+                  )}
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+      </ScrollView>
+    </NoahSafeAreaView>
+  );
+};
+
+export default CurrencySettingsScreen;

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -30,10 +30,11 @@ import Animated, {
 } from "react-native-reanimated";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import { useBottomTabBarHeight } from "react-native-bottom-tabs";
-import { useBtcToUsdRate } from "~/hooks/useMarketData";
+import { useBtcToFiatRate } from "~/hooks/useMarketData";
 import { useWalletStore } from "~/store/walletStore";
 import { updateWidget, useWidget } from "~/hooks/useWidget";
 import { formatBip177 } from "~/lib/utils";
+import { formatFiatAmount, getFiatCurrencyInfo, satsToFiat } from "~/lib/fiatCurrency";
 import { calculateBalances } from "~/lib/balanceUtils";
 import { onchainSync, sync } from "~/lib/walletApi";
 import { useTransactions } from "~/hooks/useTransactions";
@@ -41,6 +42,7 @@ import { Transaction } from "~/types/transaction";
 import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
 import { TransactionDetailContent } from "~/screens/TransactionDetailScreen";
 import { usePrivacyStore } from "~/store/privacyStore";
+import { useProfileStore } from "~/store/profileStore";
 
 const getTransactionIcon = (type: Transaction["type"]) => {
   switch (type) {
@@ -77,7 +79,9 @@ const HomeScreen = () => {
   const { data: balance, refetch, error, isLoading: isBalanceLoading } = useBalance();
   const { isPending: isSyncPending } = useWalletSync();
   const { mutateAsync: loadWallet } = useLoadWallet();
-  const { data: btcToUsdRate, isLoading: isRateLoading } = useBtcToUsdRate();
+  const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
+  const fiatCurrencyInfo = getFiatCurrencyInfo(fiatCurrency);
+  const { data: btcToFiatRate, isLoading: isRateLoading } = useBtcToFiatRate();
   const [isOpen, setIsOpen] = useState(false);
   const [fact, setFact] = useState("");
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
@@ -129,7 +133,9 @@ const HomeScreen = () => {
   const onchainBalance = balances?.onchainBalance ?? 0;
   const offchainBalance = balances?.offchainBalance ?? 0;
   const totalPendingBalance = balances?.pendingBalance ?? 0;
-  const totalBalanceInUsd = btcToUsdRate ? (totalBalance / 100_000_000) * btcToUsdRate : 0;
+  const totalBalanceInFiat = btcToFiatRate
+    ? satsToFiat(totalBalance, btcToFiatRate, fiatCurrency)
+    : null;
   const errorMessage = error instanceof Error ? error.message : String(error);
   const maskedBalance = "••••";
   const formatHomeBalance = (amount: number) =>
@@ -271,14 +277,12 @@ const HomeScreen = () => {
               <Collapsible open={isOpen} onOpenChange={setIsOpen} className="items-center pb-10">
                 <View className="items-center">
                   {isHomeBalanceHidden ? (
-                    <Text className="mb-2 text-2xl text-muted-foreground">$ {maskedBalance}</Text>
-                  ) : btcToUsdRate ? (
                     <Text className="mb-2 text-2xl text-muted-foreground">
-                      $
-                      {totalBalanceInUsd.toLocaleString(undefined, {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
+                      {fiatCurrencyInfo.symbol} {maskedBalance}
+                    </Text>
+                  ) : totalBalanceInFiat ? (
+                    <Text className="mb-2 text-2xl text-muted-foreground">
+                      {formatFiatAmount(totalBalanceInFiat, fiatCurrency)}
                     </Text>
                   ) : (
                     <View className="h-[32px] mb-2 justify-center">
@@ -473,6 +477,7 @@ const HomeScreen = () => {
         >
           <TransactionDetailContent
             transaction={selectedTransaction}
+            fiatCurrency={fiatCurrency}
             onClose={() => setIsTransactionSheetOpen(false)}
             closeIconName="close-outline"
           />

--- a/client/src/screens/ReceiveScreen.tsx
+++ b/client/src/screens/ReceiveScreen.tsx
@@ -26,7 +26,8 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { TabParamList } from "~/Navigators";
 import Icon from "@react-native-vector-icons/ionicons";
 import { useIconColor, useThemeColors } from "../hooks/useTheme";
-import { satsToBtc, formatNumber, formatBip177 } from "~/lib/utils";
+import { satsToBtc, formatBip177 } from "~/lib/utils";
+import { formatFiatAmount, getFiatCurrencyInfo, satsToFiat } from "~/lib/fiatCurrency";
 import { useReceiveScreen } from "../hooks/useReceiveScreen";
 import { COLORS } from "~/lib/styleConstants";
 import { CurrencyToggle } from "~/components/CurrencyToggle";
@@ -182,7 +183,9 @@ const ReceiveScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<TabParamList>>();
   const iconColor = useIconColor();
   const colors = useThemeColors();
-  const { amount, setAmount, currency, toggleCurrency, amountSat, btcPrice } = useReceiveScreen();
+  const { amount, setAmount, currency, toggleCurrency, amountSat, btcPrice, fiatCurrency } =
+    useReceiveScreen();
+  const fiatCurrencyInfo = getFiatCurrencyInfo(fiatCurrency);
   const { copyWithState, isCopied } = useCopyToClipboard();
   const [generatedRequest, setGeneratedRequest] = useState<GeneratedReceiveRequest | null>(null);
   const { showAlert } = useAlert();
@@ -232,7 +235,7 @@ const ReceiveScreen = () => {
   const isAmountLocked = isLoading || isGenerated;
   const hasEnteredAmount = amount.trim().length > 0;
   const isEnteredAmountInvalid = hasEnteredAmount && amountSat < minAmount;
-  const displayAmount = amount === "" ? (currency === "USD" ? "0.00" : "0") : amount;
+  const displayAmount = amount === "" ? (currency === "FIAT" ? "0.00" : "0") : amount;
   const [isAmountFocused, setIsAmountFocused] = useState(false);
 
   const stopSubscription = useCallback(
@@ -701,7 +704,7 @@ const ReceiveScreen = () => {
                     <Pressable onPress={focusAmountInput} disabled={isAmountLocked}>
                       <View className="flex-row items-center justify-center">
                         <Text className="mr-3 text-[46px] font-bold leading-[52px] text-foreground">
-                          {currency === "USD" ? "$" : "₿"}
+                          {currency === "FIAT" ? fiatCurrencyInfo.symbol : "₿"}
                         </Text>
                         <Text className="text-[46px] font-bold leading-[52px] text-foreground">
                           {displayAmount}
@@ -738,10 +741,13 @@ const ReceiveScreen = () => {
 
                 <Text className="mt-3 text-lg font-medium text-muted-foreground">
                   {currency === "SATS"
-                    ? `≈ $${
+                    ? `≈ ${
                         btcPrice && amountSat && !isNaN(amountSat)
-                          ? formatNumber(((amountSat * btcPrice) / 100000000).toFixed(2))
-                          : "0.00"
+                          ? formatFiatAmount(
+                              satsToFiat(amountSat, btcPrice, fiatCurrency),
+                              fiatCurrency,
+                            )
+                          : formatFiatAmount("0.00", fiatCurrency)
                       }`
                     : `≈ ${!isNaN(amountSat) && amount ? formatBip177(amountSat) : formatBip177(0)}`}
                 </Text>

--- a/client/src/screens/ReceiveSuccessScreen.tsx
+++ b/client/src/screens/ReceiveSuccessScreen.tsx
@@ -4,9 +4,10 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { RouteProp } from "@react-navigation/native";
 import type { HomeStackParamList } from "../Navigators";
 import { ReceiveSuccess } from "../components/ReceiveSuccess";
-import { useBtcToUsdRate } from "../hooks/useMarketData";
+import { useBtcToFiatRate } from "../hooks/useMarketData";
 import { useBalance } from "~/hooks/useWallet";
 import { calculateBalances } from "~/lib/balanceUtils";
+import { useProfileStore } from "~/store/profileStore";
 
 type NavigationProp = NativeStackNavigationProp<HomeStackParamList, "ReceiveSuccess">;
 type ReceiveSuccessRouteProp = RouteProp<HomeStackParamList, "ReceiveSuccess">;
@@ -15,7 +16,8 @@ const ReceiveSuccessScreen = () => {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<ReceiveSuccessRouteProp>();
   const { amountSat } = route.params;
-  const { data: btcPrice } = useBtcToUsdRate();
+  const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
+  const { data: btcPrice } = useBtcToFiatRate();
   const { data: balance } = useBalance();
   const balances = balance ? calculateBalances(balance) : null;
 
@@ -27,6 +29,7 @@ const ReceiveSuccessScreen = () => {
     <ReceiveSuccess
       amountSat={amountSat}
       btcPrice={btcPrice}
+      fiatCurrency={fiatCurrency}
       totalWalletBalanceSat={balances?.totalBalance}
       handleDone={handleDone}
     />

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -16,7 +16,8 @@ import {
 import Icon from "@react-native-vector-icons/ionicons";
 import { useIconColor, useThemeColors } from "../hooks/useTheme";
 import * as Clipboard from "expo-clipboard";
-import { formatNumber, satsToUsd, formatBip177 } from "~/lib/utils";
+import { formatBip177 } from "~/lib/utils";
+import { formatFiatAmount, getFiatCurrencyInfo, satsToFiat } from "~/lib/fiatCurrency";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
 import { Button } from "~/components/ui/button";
 import { NoahButton } from "~/components/ui/NoahButton";
@@ -60,6 +61,7 @@ const SendScreen = () => {
     handleScanPress,
     codeScanner,
     currency,
+    fiatCurrency,
     toggleCurrency,
     amountSat,
     btcPrice,
@@ -86,7 +88,8 @@ const SendScreen = () => {
     feeEstimateWarning,
     confirmationError,
   } = useSendScreen();
-  const displayAmount = amount === "" ? (currency === "USD" ? "0.00" : "0") : amount;
+  const fiatCurrencyInfo = getFiatCurrencyInfo(fiatCurrency);
+  const displayAmount = amount === "" ? (currency === "FIAT" ? "0.00" : "0") : amount;
 
   const handlePaste = async () => {
     const text = await Clipboard.getStringAsync();
@@ -176,7 +179,7 @@ const SendScreen = () => {
                       <Pressable onPress={focusAmountInput} disabled={!isAmountEditable}>
                         <View className="flex-row items-center justify-center">
                           <Text className="mr-3 text-[46px] font-bold leading-[52px] text-foreground">
-                            {currency === "USD" ? "$" : "₿"}
+                            {currency === "FIAT" ? fiatCurrencyInfo.symbol : "₿"}
                           </Text>
                           <Text
                             className={`text-[46px] font-bold leading-[52px] ${
@@ -217,12 +220,22 @@ const SendScreen = () => {
 
                   <Text className="mt-3 text-lg font-medium text-muted-foreground">
                     {parsedAmount
-                      ? `≈ $${btcPrice ? formatNumber(satsToUsd(parsedAmount, btcPrice)) : "0.00"}`
+                      ? `≈ ${
+                          btcPrice
+                            ? formatFiatAmount(
+                                satsToFiat(parsedAmount, btcPrice, fiatCurrency),
+                                fiatCurrency,
+                              )
+                            : formatFiatAmount("0.00", fiatCurrency)
+                        }`
                       : currency === "SATS"
-                        ? `≈ $${
+                        ? `≈ ${
                             btcPrice && amountSat && !isNaN(amountSat)
-                              ? formatNumber(satsToUsd(amountSat, btcPrice))
-                              : "0.00"
+                              ? formatFiatAmount(
+                                  satsToFiat(amountSat, btcPrice, fiatCurrency),
+                                  fiatCurrency,
+                                )
+                              : formatFiatAmount("0.00", fiatCurrency)
                           }`
                         : `≈ ${!isNaN(amountSat) && amount ? formatBip177(amountSat) : formatBip177(0)}`}
                   </Text>
@@ -364,6 +377,7 @@ const SendScreen = () => {
           destinationType={destinationType}
           comment={comment}
           btcPrice={btcPrice}
+          fiatCurrency={fiatCurrency}
           bip321Data={bip321Data}
           selectedPaymentMethod={selectedPaymentMethod}
           onSelectPaymentMethod={setSelectedPaymentMethod}
@@ -392,6 +406,7 @@ const SendScreen = () => {
             parsedResult={parsedResult}
             handleDone={handleDone}
             btcPrice={btcPrice}
+            fiatCurrency={fiatCurrency}
           />
         )}
       </AppBottomSheet>

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -30,10 +30,13 @@ import { useBottomTabBarHeight } from "react-native-bottom-tabs";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { revokeMailboxAuthorization } from "~/lib/api";
 import { AUTO_BOARD_ONCHAIN_BUFFER_AMOUNT, formatAutoBoardThreshold } from "~/lib/autoBoarding";
+import { useProfileStore } from "~/store/profileStore";
+import { getFiatCurrencyInfo } from "~/lib/fiatCurrency";
 
 type Setting = {
   id:
     | "profile"
+    | "currency"
     | "showMnemonic"
     | "showLogs"
     | "resetRegistration"
@@ -72,6 +75,8 @@ const SettingsScreen = () => {
     setMailboxAuthorizationEnabled,
   } = useServerStore();
   const { isAutoBoardingEnabled, setAutoBoardingEnabled } = useTransactionStore();
+  const preferredCurrency = useProfileStore((state) => state.preferredCurrency);
+  const preferredCurrencyInfo = getFiatCurrencyInfo(preferredCurrency);
   const {
     data: autoBoardThreshold,
     isError: isAutoBoardThresholdError,
@@ -178,6 +183,8 @@ const SettingsScreen = () => {
 
     if (item.id === "profile") {
       navigation.navigate("Profile");
+    } else if (item.id === "currency") {
+      navigation.navigate("Currency");
     } else if (item.id === "showMnemonic") {
       navigation.navigate("Mnemonic", { fromOnboarding: false });
     } else if (item.id === "showLogs") {
@@ -211,6 +218,13 @@ const SettingsScreen = () => {
       id: "profile",
       title: "Profile",
       description: "Manage your name, Lightning address, emergency email, and public key.",
+      isPressable: true,
+    });
+    profileData.push({
+      id: "currency",
+      title: "Currency",
+      value: `${preferredCurrencyInfo.code} · ${preferredCurrencyInfo.name}`,
+      description: "Choose the fiat currency used for balances and payment amounts.",
       isPressable: true,
     });
 

--- a/client/src/screens/TransactionDetailScreen.tsx
+++ b/client/src/screens/TransactionDetailScreen.tsx
@@ -9,8 +9,11 @@ import { type Transaction } from "../types/transaction";
 import { type ComponentProps, useState } from "react";
 import { COLORS } from "~/lib/styleConstants";
 import { formatBip177 } from "~/lib/utils";
+import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
+import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
 import { formatMovementKindLabel, formatMovementStatusLabel } from "~/types/movement";
 import { getMempoolTxUrl } from "~/constants";
+import { useProfileStore } from "~/store/profileStore";
 
 const TransactionDetailRow = ({
   label,
@@ -108,19 +111,25 @@ const MovementDestinationList = ({
 
 export const TransactionDetailContent = ({
   transaction,
+  fiatCurrency,
   onClose,
   closeIconName = "arrow-back-outline",
 }: {
   transaction: Transaction;
+  fiatCurrency: FiatCurrencyCode;
   onClose?: () => void;
   closeIconName?: ComponentProps<typeof Icon>["name"];
 }) => {
   const iconColor = useIconColor();
 
   const fiatAmount = transaction.btcPrice
-    ? (transaction.amount * 0.00000001 * transaction.btcPrice).toFixed(2)
+    ? satsToFiat(transaction.amount, transaction.btcPrice, fiatCurrency)
     : "N/A";
-  const bitcoinPrice = transaction.btcPrice ? transaction.btcPrice.toLocaleString() : "N/A";
+  const bitcoinPrice = transaction.btcPrice
+    ? formatFiatAmount(transaction.btcPrice, fiatCurrency)
+    : "N/A";
+  const formattedFiatAmount =
+    fiatAmount === "N/A" ? fiatAmount : formatFiatAmount(fiatAmount, fiatCurrency);
   const transactionDateLabel = transaction.dateLabel ?? new Date(transaction.date).toLocaleString();
   const movementStatusLabel = formatMovementStatusLabel(transaction.movementStatus);
   const movementKindLabel = formatMovementKindLabel(transaction.movementKind);
@@ -161,14 +170,14 @@ export const TransactionDetailContent = ({
         <Text className="text-4xl font-bold text-foreground">
           {formatBip177(transaction.amount)}
         </Text>
-        <Text className="text-xl text-muted-foreground">${fiatAmount}</Text>
+        <Text className="text-xl text-muted-foreground">{formattedFiatAmount}</Text>
       </View>
 
       <View className="bg-card p-4 rounded-lg mb-4">
-        <TransactionDetailRow label="Bitcoin Price" value={`$${bitcoinPrice}`} />
+        <TransactionDetailRow label={`Bitcoin Price (${fiatCurrency})`} value={bitcoinPrice} />
         <TransactionDetailRow
           label="Amount"
-          value={`${formatBip177(transaction.amount)} ($${fiatAmount})`}
+          value={`${formatBip177(transaction.amount)} (${formattedFiatAmount})`}
         />
       </View>
 
@@ -307,11 +316,13 @@ const TransactionDetailScreen = () => {
   const route = useRoute();
   const navigation = useNavigation();
   const { transaction } = route.params as { transaction: Transaction };
+  const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
 
   return (
     <NoahSafeAreaView className="flex-1 bg-background">
       <TransactionDetailContent
         transaction={transaction}
+        fiatCurrency={fiatCurrency}
         onClose={() => navigation.goBack()}
       />
     </NoahSafeAreaView>

--- a/client/src/screens/TransactionsScreen.tsx
+++ b/client/src/screens/TransactionsScreen.tsx
@@ -20,6 +20,7 @@ import { useTransactions } from "~/hooks/useTransactions";
 import { HistoryRefreshButton } from "~/components/HistoryRefreshButton";
 import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
 import { TransactionDetailContent } from "~/screens/TransactionDetailScreen";
+import { useProfileStore } from "~/store/profileStore";
 
 const log = logger("TransactionsScreen");
 
@@ -28,6 +29,7 @@ const TransactionsScreen = () => {
   const parentNavigation = navigation.getParent<NavigationProp<TabParamList>>();
   const iconColor = useIconColor();
   const { data: transactions = [], isLoading, isError, isRefetching, refetch } = useTransactions();
+  const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
   const [filter, setFilter] = useState<PaymentTypes | "all" | "Lightning">("all");
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
   const [isTransactionSheetOpen, setIsTransactionSheetOpen] = useState(false);
@@ -64,7 +66,7 @@ const TransactionsScreen = () => {
 
   const exportToCSV = async () => {
     const csvHeader =
-      "Payment ID,Date,Type,Direction,Amount (₿),BTC Price,Transaction ID,Destination\n";
+      `Payment ID,Date,Type,Direction,Amount (₿),BTC Price (${fiatCurrency}),Transaction ID,Destination\n`;
     const csvRows = filteredTransactions
       .map((transaction) => {
         const date =
@@ -259,6 +261,7 @@ const TransactionsScreen = () => {
           >
             <TransactionDetailContent
               transaction={selectedTransaction}
+              fiatCurrency={fiatCurrency}
               onClose={() => setIsTransactionSheetOpen(false)}
               closeIconName="close-outline"
             />

--- a/client/src/store/profileStore.ts
+++ b/client/src/store/profileStore.ts
@@ -2,6 +2,8 @@ import { create } from "zustand";
 import { persist, createJSONStorage, StateStorage } from "zustand/middleware";
 import { mmkv } from "~/lib/mmkv";
 import logger from "~/lib/log";
+import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
+import { isFiatCurrencyCode } from "~/lib/fiatCurrency";
 
 const log = logger("profileStore");
 
@@ -35,18 +37,32 @@ const zustandStorage: StateStorage = {
 
 interface ProfileState {
   displayName: string;
+  preferredCurrency: FiatCurrencyCode;
   setDisplayName: (displayName: string) => void;
+  setPreferredCurrency: (preferredCurrency: FiatCurrencyCode) => void;
 }
 
 export const useProfileStore = create<ProfileState>()(
   persist(
     (set) => ({
       displayName: "",
+      preferredCurrency: "USD",
       setDisplayName: (displayName) => set({ displayName }),
+      setPreferredCurrency: (preferredCurrency) => set({ preferredCurrency }),
     }),
     {
       name: "profile-storage",
       storage: createJSONStorage(() => zustandStorage),
+      merge: (persistedState, currentState) => {
+        const state = persistedState as Partial<ProfileState> | null;
+        return {
+          ...currentState,
+          ...state,
+          preferredCurrency: isFiatCurrencyCode(state?.preferredCurrency)
+            ? state.preferredCurrency
+            : "USD",
+        };
+      },
     },
   ),
 );

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -73,7 +73,7 @@ services:
         condition: service_healthy
 
   captaind:
-    image: niteshbalusu/captaind:nightly-2026-06-04
+    image: niteshbalusu/captaind:nightly-2026-06-11
     volumes:
       - captaind:/data/captaind
       - ./captaind.toml:/data/captaind/captaind.toml
@@ -92,7 +92,7 @@ services:
         condition: service_healthy
 
   bark:
-    image: niteshbalusu/bark:nightly-2026-06-04
+    image: niteshbalusu/bark:nightly-2026-06-11
     volumes:
       - bark:/root
     depends_on:


### PR DESCRIPTION
## Summary
- Add multi-currency display and selection support throughout send, receive, home, transactions, and detail flows.
- Introduce currency settings and shared fiat/market-data helpers to keep amounts consistent across the app.
- Update success and confirmation components to reflect the active currency context.
- Refresh iOS privacy metadata and supporting lockfile/config changes.

## Testing
- Not run (not requested)
- Covered by updates to screen, hook, and store logic across the affected wallet flows.