### PR TITLE
Surface pending Ark rounds on the home screen

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
     },
     "client": {
       "name": "noah",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
         "@bottom-tabs/react-navigation": "^1.2.0",
         "@react-native-clipboard/clipboard": "^1.16.3",
@@ -66,7 +66,7 @@
         "react-native-gesture-handler": "~2.31.1",
         "react-native-keychain": "^10.0.0",
         "react-native-mmkv": "^4.3.1",
-        "react-native-nitro-ark": "0.0.122",
+        "react-native-nitro-ark": "0.0.124",
         "react-native-nitro-modules": "0.35.6",
         "react-native-qrcode-svg": "^6.3.21",
         "react-native-quick-base64": "^3.0.0",
@@ -1592,7 +1592,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@4.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg=="],
 
-    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.122", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-h7gVcE3BkmDsv9cCr7YQOdMTGrryAFtXhRr/v90ZYEpgJs050YJXd0Br3c3WhbGTyPDE250mkrq3h2q4id9jMA=="],
+    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.124", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-0VC4vfpkbQ+hLKi+GUXxK58zJSJl+Jd9o5j48H3ZdIlRmmerOHpm4itVAp6heqKYU4vZiUSlUGnKTxU6t6SrLg=="],
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.35.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g=="],
 

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -253,7 +253,7 @@ PODS:
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
   - MMKVCore (2.4.0)
-  - NitroArk (0.0.122):
+  - NitroArk (0.0.124):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -3208,7 +3208,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   hermes-engine: 7ba2a073edd246f02086a03c12186700e155b4c7
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: c0f3027c8ed52556eaa2741ddfe6793dd49cadbf
+  NitroArk: a9454d9334b47a6afeb40d5689e162689ffee7fa
   NitroMmkv: 1ff46eceb958298b1d7c013a6314432438b77a62
   NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
   NoahTools: efecfcff1688c6e63b9acb210286badaa3eaac36

--- a/client/package.json
+++ b/client/package.json
@@ -107,7 +107,7 @@
     "react-native-gesture-handler": "~2.31.1",
     "react-native-keychain": "^10.0.0",
     "react-native-mmkv": "^4.3.1",
-    "react-native-nitro-ark": "0.0.122",
+    "react-native-nitro-ark": "0.0.124",
     "react-native-nitro-modules": "0.35.6",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-quick-base64": "^3.0.0",

--- a/client/src/components/PendingRoundStatusBanner.tsx
+++ b/client/src/components/PendingRoundStatusBanner.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useState } from "react";
+import { Linking, Pressable, View } from "react-native";
+import { Clock3 } from "lucide-react-native";
+import Icon from "@react-native-vector-icons/ionicons";
+import type { PendingRoundStatus } from "react-native-nitro-ark";
+import { StatusBannerStrip } from "~/components/StatusBannerStrip";
+import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
+import { Text } from "~/components/ui/text";
+import { usePendingRounds } from "~/hooks/useWallet";
+import { COLORS } from "~/lib/styleConstants";
+import { getMempoolTxUrl } from "~/constants";
+import { truncateMiddle } from "~/lib/exitTimeline";
+
+const PENDING_ROUNDS_REFETCH_MS = 30_000;
+
+const isRoundActive = (round: PendingRoundStatus) =>
+  !round.is_final || round.status === "pending" || round.status === "unconfirmed";
+
+const formatRoundStatus = (status: PendingRoundStatus["status"]) =>
+  status.charAt(0).toUpperCase() + status.slice(1);
+
+const RoundDetailRow = ({
+  label,
+  value,
+  explorerUrl,
+}: {
+  label: string;
+  value: string;
+  explorerUrl?: string | null;
+}) => (
+  <View className="flex-row items-center justify-between border-b border-border/10 py-3 last:border-b-0">
+    <Text className="mr-3 text-sm text-muted-foreground">{label}</Text>
+    {explorerUrl ? (
+      <Pressable
+        onPress={() => Linking.openURL(explorerUrl)}
+        className="min-w-0 flex-1 flex-row items-center justify-end gap-x-2"
+        accessibilityRole="button"
+        accessibilityLabel={`Open ${label} in browser`}
+      >
+        <Text className="min-w-0 text-right text-sm text-foreground" numberOfLines={1}>
+          {truncateMiddle(value, 10, 10)}
+        </Text>
+        <Icon name="open-outline" size={17} color={COLORS.BITCOIN_ORANGE} />
+      </Pressable>
+    ) : (
+      <Text
+        className="min-w-0 flex-1 text-right text-sm text-foreground"
+        numberOfLines={2}
+        ellipsizeMode="middle"
+      >
+        {value}
+      </Text>
+    )}
+  </View>
+);
+
+const PendingRoundDetail = ({ round }: { round: PendingRoundStatus }) => {
+  const fundingTxUrl = round.funding_txid ? getMempoolTxUrl(round.funding_txid) : null;
+
+  return (
+    <View className="mb-4 rounded-lg bg-card p-4">
+      <Text className="mb-3 text-base font-semibold text-foreground">
+        Round #{round.round_id}
+      </Text>
+      <RoundDetailRow label="Status" value={formatRoundStatus(round.status)} />
+      <RoundDetailRow label="Final" value={round.is_final ? "Yes" : "No"} />
+      <RoundDetailRow label="Successful" value={round.is_success ? "Yes" : "No"} />
+      {round.funding_txid ? (
+        <RoundDetailRow label="Funding tx" value={round.funding_txid} explorerUrl={fundingTxUrl} />
+      ) : null}
+      {round.unsigned_funding_txids.map((txid, index) => (
+        <RoundDetailRow
+          key={`${round.round_id}-${txid}`}
+          label={`Unsigned tx ${index + 1}`}
+          value={txid}
+          explorerUrl={getMempoolTxUrl(txid)}
+        />
+      ))}
+      {round.error ? <RoundDetailRow label="Error" value={round.error} /> : null}
+    </View>
+  );
+};
+
+export const PendingRoundStatusBanner = () => {
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [shouldPoll, setShouldPoll] = useState(false);
+  const { data: rounds = [] } = usePendingRounds(shouldPoll ? PENDING_ROUNDS_REFETCH_MS : false);
+
+  const activeRounds = useMemo(() => rounds.filter(isRoundActive), [rounds]);
+
+  useEffect(() => {
+    setShouldPoll(activeRounds.length > 0);
+  }, [activeRounds.length]);
+
+  if (activeRounds.length === 0) {
+    return null;
+  }
+
+  const primaryRound = activeRounds[0];
+  const title = activeRounds.length === 1 ? "Round in progress" : "Rounds in progress";
+  const message =
+    activeRounds.length === 1
+      ? `Round #${primaryRound.round_id} ${primaryRound.status}`
+      : `${activeRounds.length} rounds pending`;
+
+  return (
+    <>
+      <StatusBannerStrip
+        className="mx-4 mt-3 mb-1"
+        title={title}
+        message={message}
+        icon={<Clock3 size={16} color="#60a5fa" />}
+        tone="info"
+        onPress={() => setIsSheetOpen(true)}
+      />
+      <AppBottomSheet
+        isOpen={isSheetOpen}
+        onClose={() => setIsSheetOpen(false)}
+        scrollable
+      >
+        <View className="px-1 pb-2">
+          <View className="mb-5 flex-row items-center">
+            <Pressable onPress={() => setIsSheetOpen(false)} className="mr-4">
+              <Icon name="close-outline" size={24} color={COLORS.BITCOIN_ORANGE} />
+            </Pressable>
+            <Text className="text-2xl font-bold text-foreground">Pending Rounds</Text>
+          </View>
+          {activeRounds.map((round) => (
+            <PendingRoundDetail key={round.round_id} round={round} />
+          ))}
+        </View>
+      </AppBottomSheet>
+    </>
+  );
+};

--- a/client/src/components/PendingRoundStatusBanner.tsx
+++ b/client/src/components/PendingRoundStatusBanner.tsx
@@ -10,6 +10,7 @@ import { usePendingRounds } from "~/hooks/useWallet";
 import { COLORS } from "~/lib/styleConstants";
 import { getMempoolTxUrl } from "~/constants";
 import { truncateMiddle } from "~/lib/exitTimeline";
+import { copyToClipboard } from "~/lib/clipboardUtils";
 
 const PENDING_ROUNDS_REFETCH_MS = 30_000;
 
@@ -22,37 +23,73 @@ const formatRoundStatus = (status: PendingRoundStatus["status"]) =>
 const RoundDetailRow = ({
   label,
   value,
+  copyable = false,
   explorerUrl,
 }: {
   label: string;
   value: string;
+  copyable?: boolean;
   explorerUrl?: string | null;
-}) => (
-  <View className="flex-row items-center justify-between border-b border-border/10 py-3 last:border-b-0">
-    <Text className="mr-3 text-sm text-muted-foreground">{label}</Text>
-    {explorerUrl ? (
-      <Pressable
-        onPress={() => Linking.openURL(explorerUrl)}
-        className="min-w-0 flex-1 flex-row items-center justify-end gap-x-2"
-        accessibilityRole="button"
-        accessibilityLabel={`Open ${label} in browser`}
-      >
-        <Text className="min-w-0 text-right text-sm text-foreground" numberOfLines={1}>
-          {truncateMiddle(value, 10, 10)}
+}) => {
+  const [copied, setCopied] = useState(false);
+  const canUseActions = copyable || Boolean(explorerUrl);
+
+  const handleCopy = async () => {
+    await copyToClipboard(value, {
+      onCopy: () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1000);
+      },
+    });
+  };
+
+  return (
+    <View className="flex-row items-center justify-between border-b border-border/10 py-3 last:border-b-0">
+      <Text className="mr-3 text-sm text-muted-foreground">{label}</Text>
+      {canUseActions ? (
+        <View className="min-w-0 flex-1 flex-row items-center justify-end gap-x-3">
+          <Text className="min-w-0 flex-1 text-right text-sm text-foreground" numberOfLines={1}>
+            {truncateMiddle(value, 10, 10)}
+          </Text>
+          {copyable ? (
+            <Pressable
+              onPress={handleCopy}
+              hitSlop={10}
+              className="h-8 w-8 items-center justify-center rounded-full bg-background"
+              accessibilityRole="button"
+              accessibilityLabel={`Copy ${label}`}
+            >
+              <Icon
+                name={copied ? "checkmark-circle-outline" : "copy-outline"}
+                size={17}
+                color={copied ? COLORS.SUCCESS : COLORS.BITCOIN_ORANGE}
+              />
+            </Pressable>
+          ) : null}
+          {explorerUrl ? (
+            <Pressable
+              onPress={() => Linking.openURL(explorerUrl)}
+              hitSlop={10}
+              className="h-8 w-8 items-center justify-center rounded-full bg-background"
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${label} in browser`}
+            >
+              <Icon name="open-outline" size={17} color={COLORS.BITCOIN_ORANGE} />
+            </Pressable>
+          ) : null}
+        </View>
+      ) : (
+        <Text
+          className="min-w-0 flex-1 text-right text-sm text-foreground"
+          numberOfLines={2}
+          ellipsizeMode="middle"
+        >
+          {value}
         </Text>
-        <Icon name="open-outline" size={17} color={COLORS.BITCOIN_ORANGE} />
-      </Pressable>
-    ) : (
-      <Text
-        className="min-w-0 flex-1 text-right text-sm text-foreground"
-        numberOfLines={2}
-        ellipsizeMode="middle"
-      >
-        {value}
-      </Text>
-    )}
-  </View>
-);
+      )}
+    </View>
+  );
+};
 
 const PendingRoundDetail = ({ round }: { round: PendingRoundStatus }) => {
   const fundingTxUrl = round.funding_txid ? getMempoolTxUrl(round.funding_txid) : null;
@@ -66,7 +103,12 @@ const PendingRoundDetail = ({ round }: { round: PendingRoundStatus }) => {
       <RoundDetailRow label="Final" value={round.is_final ? "Yes" : "No"} />
       <RoundDetailRow label="Successful" value={round.is_success ? "Yes" : "No"} />
       {round.funding_txid ? (
-        <RoundDetailRow label="Funding tx" value={round.funding_txid} explorerUrl={fundingTxUrl} />
+        <RoundDetailRow
+          label="Funding tx"
+          value={round.funding_txid}
+          copyable
+          explorerUrl={fundingTxUrl}
+        />
       ) : null}
       {round.unsigned_funding_txids.map((txid, index) => (
         <RoundDetailRow
@@ -112,6 +154,8 @@ export const PendingRoundStatusBanner = () => {
         icon={<Clock3 size={16} color="#60a5fa" />}
         tone="info"
         onPress={() => setIsSheetOpen(true)}
+        actionLabel="View"
+        onActionPress={() => setIsSheetOpen(true)}
       />
       <AppBottomSheet
         isOpen={isSheetOpen}

--- a/client/src/components/PendingRoundStatusBanner.tsx
+++ b/client/src/components/PendingRoundStatusBanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Linking, Pressable, View } from "react-native";
 import { Clock3 } from "lucide-react-native";
 import Icon from "@react-native-vector-icons/ionicons";
@@ -128,7 +128,7 @@ export const PendingRoundStatusBanner = () => {
   const [shouldPoll, setShouldPoll] = useState(false);
   const { data: rounds = [] } = usePendingRounds(shouldPoll ? PENDING_ROUNDS_REFETCH_MS : false);
 
-  const activeRounds = useMemo(() => rounds.filter(isRoundActive), [rounds]);
+  const activeRounds = rounds.filter(isRoundActive);
 
   useEffect(() => {
     setShouldPoll(activeRounds.length > 0);

--- a/client/src/components/StatusBannerStrip.tsx
+++ b/client/src/components/StatusBannerStrip.tsx
@@ -12,6 +12,7 @@ type StatusBannerStripProps = {
   actionLabel?: string | null;
   actionBusyLabel?: string;
   isActionLoading?: boolean;
+  onPress?: () => void;
   onActionPress?: () => void;
   className?: string;
 };
@@ -24,6 +25,7 @@ export const StatusBannerStrip = ({
   actionLabel,
   actionBusyLabel = "Working",
   isActionLoading = false,
+  onPress,
   onActionPress,
   className = "",
 }: StatusBannerStripProps) => {
@@ -38,41 +40,54 @@ export const StatusBannerStrip = ({
     tone === "failed" ? "bg-red-500/10" : tone === "success" ? "bg-green-500/10" : "bg-blue-500/10";
 
   const actionTextClassName = tone === "failed" ? "text-red-500" : "text-foreground";
+  const content = (
+    <>
+      <View
+        className={`mr-3 h-8 w-8 items-center justify-center rounded-full ${iconContainerClassName}`}
+      >
+        {icon}
+      </View>
+
+      <View className="min-w-0 flex-1">
+        <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
+          {title}
+        </Text>
+        <Text className="text-xs text-muted-foreground" numberOfLines={1}>
+          {message}
+        </Text>
+      </View>
+
+      {actionLabel && onActionPress ? (
+        <Pressable
+          onPress={onActionPress}
+          disabled={isActionLoading}
+          accessibilityRole="button"
+          accessibilityLabel={actionLabel}
+          className="ml-3 h-8 items-center justify-center rounded-full border border-border/70 bg-background/60 px-3 active:opacity-80 disabled:opacity-50"
+        >
+          <Text className={`text-xs font-semibold ${actionTextClassName}`}>
+            {isActionLoading ? actionBusyLabel : actionLabel}
+          </Text>
+        </Pressable>
+      ) : null}
+    </>
+  );
+  const stripClassName = `min-h-[52px] flex-row items-center rounded-xl border px-3 py-2 ${containerClassName}`;
 
   return (
     <View className={className}>
-      <View
-        className={`min-h-[52px] flex-row items-center rounded-xl border px-3 py-2 ${containerClassName}`}
-      >
-        <View
-          className={`mr-3 h-8 w-8 items-center justify-center rounded-full ${iconContainerClassName}`}
+      {onPress ? (
+        <Pressable
+          onPress={onPress}
+          accessibilityRole="button"
+          accessibilityLabel={title}
+          className={`${stripClassName} active:opacity-80`}
         >
-          {icon}
-        </View>
-
-        <View className="min-w-0 flex-1">
-          <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
-            {title}
-          </Text>
-          <Text className="text-xs text-muted-foreground" numberOfLines={1}>
-            {message}
-          </Text>
-        </View>
-
-        {actionLabel && onActionPress ? (
-          <Pressable
-            onPress={onActionPress}
-            disabled={isActionLoading}
-            accessibilityRole="button"
-            accessibilityLabel={actionLabel}
-            className="ml-3 h-8 items-center justify-center rounded-full border border-border/70 bg-background/60 px-3 active:opacity-80 disabled:opacity-50"
-          >
-            <Text className={`text-xs font-semibold ${actionTextClassName}`}>
-              {isActionLoading ? actionBusyLabel : actionLabel}
-            </Text>
-          </Pressable>
-        ) : null}
-      </View>
+          {content}
+        </Pressable>
+      ) : (
+        <View className={stripClassName}>{content}</View>
+      )}
     </View>
   );
 };

--- a/client/src/hooks/useWallet.ts
+++ b/client/src/hooks/useWallet.ts
@@ -15,6 +15,7 @@ import {
   closeWalletIfLoaded,
   sync,
   getArkInfo,
+  syncPendingRounds,
 } from "../lib/walletApi";
 import { getAutoBoardThreshold } from "~/lib/autoBoarding";
 import { restoreWallet as restoreWalletAction } from "../lib/backupService";
@@ -133,6 +134,24 @@ export function useArkInfo(enabled = true) {
       return result.value;
     },
     enabled,
+    retry: false,
+  });
+}
+
+export function usePendingRounds(refetchIntervalMs: number | false = false) {
+  const { isInitialized, isWalletSuspended, isBackgroundJobRunning } = useWalletStore();
+
+  return useQuery({
+    queryKey: ["pending-rounds"],
+    queryFn: async () => {
+      const result = await syncPendingRounds();
+      if (result.isErr()) {
+        throw result.error;
+      }
+      return result.value;
+    },
+    enabled: isInitialized && !isWalletSuspended && !isBackgroundJobRunning,
+    refetchInterval: refetchIntervalMs,
     retry: false,
   });
 }

--- a/client/src/lib/walletApi.ts
+++ b/client/src/lib/walletApi.ts
@@ -17,6 +17,7 @@ import {
   maintenanceWithOnchainDelegated as maintenanceWithOnchainDelegatedNitro,
   refreshServer as refreshServerNitro,
   getArkInfo as getArkInfoNitro,
+  syncPendingRounds as syncPendingRoundsNitro,
   signMesssageWithMnemonic as signMessageWithMnemonicNitro,
   deriveKeypairFromMnemonic as deriveKeypairFromMnemonicNitro,
   vtxos as vtxosNitro,
@@ -24,6 +25,7 @@ import {
   type BarkArkInfo,
   type OnchainBalanceResult,
   type OffchainBalanceResult,
+  type PendingRoundStatus,
   KeyPairResult,
 } from "react-native-nitro-ark";
 import * as Keychain from "react-native-keychain";
@@ -224,6 +226,10 @@ export const fetchOffchainBalance = async (): Promise<Result<OffchainBalanceResu
 
 export const sync = async (): Promise<Result<void, Error>> => {
   return ResultAsync.fromPromise(syncNitro(), (e) => e as Error);
+};
+
+export const syncPendingRounds = async (): Promise<Result<PendingRoundStatus[], Error>> => {
+  return ResultAsync.fromPromise(syncPendingRoundsNitro(), (e) => e as Error);
 };
 
 export const signMesssageWithMnemonic = async (

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -19,8 +19,10 @@ import { UpdateWarningBanner } from "~/components/UpdateWarningBanner";
 import { EmailVerificationBanner } from "~/components/EmailVerificationBanner";
 import { BackupStatusBanner } from "~/components/BackupStatusBanner";
 import { AutoBoardingStatusBanner } from "~/components/AutoBoardingStatusBanner";
+import { PendingRoundStatusBanner } from "~/components/PendingRoundStatusBanner";
 import { useBackgroundJobCoordination } from "~/hooks/useBackgroundJobCoordination";
 import { useServerStore } from "~/store/serverStore";
+import { queryClient } from "~/queryClient";
 
 import Animated, {
   FadeInDown,
@@ -113,6 +115,7 @@ const HomeScreen = () => {
 
     await sync();
     await onchainSync();
+    await queryClient.invalidateQueries({ queryKey: ["pending-rounds"] });
     await refetch();
     await updateWidget();
     getRandomFact();
@@ -249,6 +252,7 @@ const HomeScreen = () => {
           />
         )}
         <BackupStatusBanner />
+        <PendingRoundStatusBanner />
         <AutoBoardingStatusBanner />
         {isBackgroundJobRunning && (
           <View className="px-4 py-2 bg-blue-500/20 border-b border-blue-500/40">


### PR DESCRIPTION
## Summary
- Add a pending-round status banner to Home that opens a bottom sheet with per-round details.
- Poll pending rounds while they are active and refresh the query after wallet sync.
- Update the status banner component so the strip itself can be tapped.
- Bump `react-native-nitro-ark` to `0.0.124` and refresh lockfiles.

## Testing
- Not run (not requested)
- Added client-side wiring for the new pending-round query and banner rendering path.