### PR TITLE
[codex] Batch mailbox lease renewals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4836,6 +4836,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-cron-scheduler",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower_governor",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,6 +9,7 @@ axum = { version = "0.8.7", features = ["json"] }
 anyhow = "1.0.100"
 dotenvy = "0.15"
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }
+tokio-util = "0.7.16"
 tracing = "0.1.43"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 tower-http = { version = "0.6.7", features = ["trace"] }

--- a/server/src/db/mailbox_authorization_repo.rs
+++ b/server/src/db/mailbox_authorization_repo.rs
@@ -435,6 +435,8 @@ impl<'a> MailboxAuthorizationRepository<'a> {
                   AND mailbox.authorization_hex IS NOT NULL
                   AND mailbox.authorization_expires_at IS NOT NULL
                   AND mailbox.authorization_expires_at > $4
+                  AND mailbox.lease_expires_at IS NOT NULL
+                  AND mailbox.lease_expires_at > $7
              ),
              renewed AS (
                 UPDATE mailbox_authorizations AS mailbox
@@ -449,10 +451,9 @@ impl<'a> MailboxAuthorizationRepository<'a> {
                   AND mailbox.authorization_hex IS NOT NULL
                   AND mailbox.authorization_expires_at IS NOT NULL
                   AND mailbox.authorization_expires_at > $4
-                  AND (
-                    mailbox.lease_expires_at IS NULL
-                    OR mailbox.lease_expires_at <= $5
-                  )
+                  AND mailbox.lease_expires_at IS NOT NULL
+                  AND mailbox.lease_expires_at > $7
+                  AND mailbox.lease_expires_at <= $5
                 RETURNING mailbox.pubkey
              )
              SELECT
@@ -467,6 +468,7 @@ impl<'a> MailboxAuthorizationRepository<'a> {
         .bind(now.timestamp())
         .bind(renew_after)
         .bind(lease_expires_at)
+        .bind(now)
         .fetch_all(self.pool)
         .await?;
 
@@ -478,7 +480,7 @@ impl<'a> MailboxAuthorizationRepository<'a> {
         pubkey: &str,
         auth_version: i64,
         worker_id: &str,
-        now: i64,
+        now: DateTime<Utc>,
     ) -> Result<bool> {
         let exists = sqlx::query_scalar::<_, bool>(
             "SELECT EXISTS (
@@ -492,11 +494,14 @@ impl<'a> MailboxAuthorizationRepository<'a> {
                   AND authorization_hex IS NOT NULL
                   AND authorization_expires_at IS NOT NULL
                   AND authorization_expires_at > $4
+                  AND lease_expires_at IS NOT NULL
+                  AND lease_expires_at > $5
             )",
         )
         .bind(pubkey)
         .bind(auth_version)
         .bind(worker_id)
+        .bind(now.timestamp())
         .bind(now)
         .fetch_one(self.pool)
         .await?;

--- a/server/src/db/mailbox_authorization_repo.rs
+++ b/server/src/db/mailbox_authorization_repo.rs
@@ -23,6 +23,12 @@ pub struct MailboxAuthorizationRepository<'a> {
     pool: &'a PgPool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, FromRow)]
+pub struct BulkRenewMailboxClaim {
+    pub pubkey: String,
+    pub renewed: bool,
+}
+
 impl<'a> MailboxAuthorizationRepository<'a> {
     pub fn new(pool: &'a PgPool) -> Self {
         Self { pool }
@@ -392,66 +398,110 @@ impl<'a> MailboxAuthorizationRepository<'a> {
         Ok(())
     }
 
-    pub async fn renew_claim(
+    pub async fn bulk_renew_claims(
         &self,
-        pubkey: &str,
-        auth_version: i64,
+        active_claims: &[(String, i64)],
         worker_id: &str,
         now: DateTime<Utc>,
         renew_after: DateTime<Utc>,
         lease_expires_at: DateTime<Utc>,
-    ) -> Result<bool> {
-        let should_renew = sqlx::query_scalar::<_, bool>(
-            "SELECT lease_expires_at IS NULL OR lease_expires_at <= $5
-             FROM mailbox_authorizations
-             WHERE pubkey = $1
-               AND auth_version = $2
-               AND lease_owner = $3
-               AND enabled = TRUE
-               AND status = 'active'
-               AND authorization_hex IS NOT NULL
-               AND authorization_expires_at IS NOT NULL
-               AND authorization_expires_at > $4",
-        )
-        .bind(pubkey)
-        .bind(auth_version)
-        .bind(worker_id)
-        .bind(now.timestamp())
-        .bind(renew_after)
-        .fetch_optional(self.pool)
-        .await?;
-
-        if should_renew != Some(true) {
-            return Ok(should_renew.is_some());
+    ) -> Result<Vec<BulkRenewMailboxClaim>> {
+        if active_claims.is_empty() {
+            return Ok(vec![]);
         }
 
-        let result = sqlx::query(
-            "UPDATE mailbox_authorizations
-             SET lease_expires_at = $6,
-                 updated_at = now()
-             WHERE pubkey = $1
-               AND auth_version = $2
-               AND lease_owner = $3
-               AND enabled = TRUE
-               AND status = 'active'
-               AND authorization_hex IS NOT NULL
-               AND authorization_expires_at IS NOT NULL
-               AND authorization_expires_at > $4
-               AND (
-                 lease_expires_at IS NULL
-                 OR lease_expires_at <= $5
-               )",
+        let pubkeys = active_claims
+            .iter()
+            .map(|(pubkey, _)| pubkey.clone())
+            .collect::<Vec<_>>();
+        let auth_versions = active_claims
+            .iter()
+            .map(|(_, auth_version)| *auth_version)
+            .collect::<Vec<_>>();
+
+        let rows = sqlx::query_as::<_, BulkRenewMailboxClaim>(
+            "WITH active(pubkey, auth_version) AS (
+                SELECT * FROM UNNEST($1::text[], $2::bigint[])
+             ),
+             valid AS (
+                SELECT mailbox.pubkey, mailbox.auth_version
+                FROM mailbox_authorizations AS mailbox
+                INNER JOIN active
+                  ON mailbox.pubkey = active.pubkey
+                 AND mailbox.auth_version = active.auth_version
+                WHERE mailbox.lease_owner = $3
+                  AND mailbox.enabled = TRUE
+                  AND mailbox.status = 'active'
+                  AND mailbox.authorization_hex IS NOT NULL
+                  AND mailbox.authorization_expires_at IS NOT NULL
+                  AND mailbox.authorization_expires_at > $4
+             ),
+             renewed AS (
+                UPDATE mailbox_authorizations AS mailbox
+                SET lease_expires_at = $6,
+                    updated_at = now()
+                FROM valid
+                WHERE mailbox.pubkey = valid.pubkey
+                  AND mailbox.auth_version = valid.auth_version
+                  AND mailbox.lease_owner = $3
+                  AND mailbox.enabled = TRUE
+                  AND mailbox.status = 'active'
+                  AND mailbox.authorization_hex IS NOT NULL
+                  AND mailbox.authorization_expires_at IS NOT NULL
+                  AND mailbox.authorization_expires_at > $4
+                  AND (
+                    mailbox.lease_expires_at IS NULL
+                    OR mailbox.lease_expires_at <= $5
+                  )
+                RETURNING mailbox.pubkey
+             )
+             SELECT
+                valid.pubkey,
+                renewed.pubkey IS NOT NULL AS renewed
+             FROM valid
+             LEFT JOIN renewed ON renewed.pubkey = valid.pubkey",
         )
-        .bind(pubkey)
-        .bind(auth_version)
+        .bind(pubkeys)
+        .bind(auth_versions)
         .bind(worker_id)
         .bind(now.timestamp())
         .bind(renew_after)
         .bind(lease_expires_at)
-        .execute(self.pool)
+        .fetch_all(self.pool)
         .await?;
 
-        Ok(result.rows_affected() > 0)
+        Ok(rows)
+    }
+
+    pub async fn claim_is_active(
+        &self,
+        pubkey: &str,
+        auth_version: i64,
+        worker_id: &str,
+        now: i64,
+    ) -> Result<bool> {
+        let exists = sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM mailbox_authorizations
+                WHERE pubkey = $1
+                  AND auth_version = $2
+                  AND lease_owner = $3
+                  AND enabled = TRUE
+                  AND status = 'active'
+                  AND authorization_hex IS NOT NULL
+                  AND authorization_expires_at IS NOT NULL
+                  AND authorization_expires_at > $4
+            )",
+        )
+        .bind(pubkey)
+        .bind(auth_version)
+        .bind(worker_id)
+        .bind(now)
+        .fetch_one(self.pool)
+        .await?;
+
+        Ok(exists)
     }
 
     pub async fn revoke(&self, pubkey: &str) -> Result<()> {
@@ -476,16 +526,23 @@ impl<'a> MailboxAuthorizationRepository<'a> {
         Ok(())
     }
 
-    pub async fn release_claim(&self, pubkey: &str, worker_id: &str) -> Result<()> {
+    pub async fn release_claim(
+        &self,
+        pubkey: &str,
+        auth_version: i64,
+        worker_id: &str,
+    ) -> Result<()> {
         sqlx::query(
             "UPDATE mailbox_authorizations
              SET lease_owner = NULL,
                  lease_expires_at = NULL,
                  updated_at = now()
              WHERE pubkey = $1
-               AND lease_owner = $2",
+               AND auth_version = $2
+               AND lease_owner = $3",
         )
         .bind(pubkey)
+        .bind(auth_version)
         .bind(worker_id)
         .execute(self.pool)
         .await?;

--- a/server/src/mailbox_worker.rs
+++ b/server/src/mailbox_worker.rs
@@ -715,7 +715,7 @@ async fn process_mailbox_message(
             &mailbox.pubkey,
             mailbox.auth_version,
             &session.worker_id,
-            Utc::now().timestamp(),
+            Utc::now(),
         )
         .await
         .map_err(ApiError::from)?

--- a/server/src/mailbox_worker.rs
+++ b/server/src/mailbox_worker.rs
@@ -2,8 +2,7 @@
 
 use std::{
     cmp,
-    collections::{HashSet, hash_map::DefaultHasher},
-    hash::{Hash, Hasher},
+    collections::{HashMap, HashSet},
     sync::Arc,
     time::Duration,
 };
@@ -25,6 +24,7 @@ use tokio::{
     task::JoinSet,
     time::{Instant, interval_at, sleep},
 };
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::{
@@ -152,9 +152,8 @@ fn env_duration_secs(key: &str, default: Duration) -> Duration {
 #[derive(Debug, Clone)]
 pub struct MailboxSessionContext {
     pub worker_id: String,
-    pub claim_ttl: Duration,
-    pub claim_renew_interval: Duration,
     pub stream_idle_reconnect: Duration,
+    pub cancellation_token: CancellationToken,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -183,6 +182,12 @@ pub struct MailboxWorker<T> {
     worker_id: String,
 }
 
+#[derive(Debug, Clone)]
+struct ActiveMailboxSession {
+    auth_version: i64,
+    cancellation_token: CancellationToken,
+}
+
 impl<T> MailboxWorker<T>
 where
     T: MailboxTransport + 'static,
@@ -200,11 +205,16 @@ where
 
     pub async fn run(&self) -> Result<()> {
         let mut join_set = JoinSet::new();
-        let mut active_pubkeys = HashSet::new();
+        let mut active_sessions = HashMap::new();
+        let mut claim_renewal = interval_at(
+            Instant::now() + self.config.claim_renew_interval,
+            self.config.claim_renew_interval,
+        );
 
         loop {
             while let Some(result) = join_set.try_join_next() {
-                if let Err(error) = Self::handle_session_result(result, &mut active_pubkeys).await {
+                if let Err(error) = Self::handle_session_result(result, &mut active_sessions).await
+                {
                     tracing::error!(
                         service = "mailbox_worker",
                         error = %error,
@@ -214,7 +224,7 @@ where
             }
 
             if let Err(error) = self
-                .schedule_runnable_sessions(&mut join_set, &mut active_pubkeys)
+                .schedule_runnable_sessions(&mut join_set, &mut active_sessions)
                 .await
             {
                 tracing::error!(
@@ -230,12 +240,22 @@ where
             tokio::select! {
                 result = join_set.join_next(), if !join_set.is_empty() => {
                     if let Some(result) = result
-                        && let Err(error) = Self::handle_session_result(result, &mut active_pubkeys).await
+                        && let Err(error) = Self::handle_session_result(result, &mut active_sessions).await
                     {
                         tracing::error!(
                             service = "mailbox_worker",
                             error = %error,
                             "mailbox session join failed"
+                        );
+                    }
+                }
+                _ = claim_renewal.tick(), if !active_sessions.is_empty() => {
+                    if let Err(error) = self.renew_active_sessions(&mut active_sessions).await {
+                        tracing::error!(
+                            service = "mailbox_worker",
+                            error = %error,
+                            active_sessions = active_sessions.len(),
+                            "mailbox bulk lease renewal failed"
                         );
                     }
                 }
@@ -246,13 +266,13 @@ where
 
     pub async fn run_once(&self) -> Result<usize> {
         let mut join_set = JoinSet::new();
-        let mut active_pubkeys = HashSet::new();
+        let mut active_sessions = HashMap::new();
         let scheduled = self
-            .schedule_runnable_sessions(&mut join_set, &mut active_pubkeys)
+            .schedule_runnable_sessions(&mut join_set, &mut active_sessions)
             .await?;
 
         while let Some(result) = join_set.join_next().await {
-            Self::handle_session_result(result, &mut active_pubkeys).await?;
+            Self::handle_session_result(result, &mut active_sessions).await?;
         }
 
         Ok(scheduled)
@@ -261,7 +281,7 @@ where
     async fn schedule_runnable_sessions(
         &self,
         join_set: &mut JoinSet<(String, Result<()>)>,
-        active_pubkeys: &mut HashSet<String>,
+        active_sessions: &mut HashMap<String, ActiveMailboxSession>,
     ) -> Result<usize> {
         let available_slots = self.semaphore.available_permits();
         if available_slots == 0 {
@@ -279,7 +299,7 @@ where
         let mut scheduled = 0usize;
 
         for mailbox in runnable {
-            if active_pubkeys.contains(&mailbox.pubkey) {
+            if active_sessions.contains_key(&mailbox.pubkey) {
                 continue;
             }
 
@@ -292,12 +312,26 @@ where
             let transport = self.transport.clone();
             let config = self.config.clone();
             let worker_id = self.worker_id.clone();
+            let cancellation_token = CancellationToken::new();
 
-            active_pubkeys.insert(pubkey.clone());
+            active_sessions.insert(
+                pubkey.clone(),
+                ActiveMailboxSession {
+                    auth_version: mailbox.auth_version,
+                    cancellation_token: cancellation_token.clone(),
+                },
+            );
             join_set.spawn(async move {
                 let _permit = permit;
-                let result =
-                    process_mailbox_session(app_state, transport, config, worker_id, mailbox).await;
+                let result = process_mailbox_session(
+                    app_state,
+                    transport,
+                    config,
+                    worker_id,
+                    mailbox,
+                    cancellation_token,
+                )
+                .await;
                 (pubkey, result)
             });
             scheduled += 1;
@@ -306,12 +340,66 @@ where
         Ok(scheduled)
     }
 
+    async fn renew_active_sessions(
+        &self,
+        active_sessions: &mut HashMap<String, ActiveMailboxSession>,
+    ) -> Result<()> {
+        let active_claims = active_sessions
+            .iter()
+            .map(|(pubkey, session)| (pubkey.clone(), session.auth_version))
+            .collect::<Vec<_>>();
+
+        let repo = MailboxAuthorizationRepository::new(&self.app_state.db_pool);
+        let now = Utc::now();
+        let renew_window = chrono::TimeDelta::from_std(self.config.claim_ttl / 2)?;
+        let renew_after = now + renew_window;
+        let lease_expires_at = now + chrono::TimeDelta::from_std(self.config.claim_ttl)?;
+        let claims = repo
+            .bulk_renew_claims(
+                &active_claims,
+                &self.worker_id,
+                now,
+                renew_after,
+                lease_expires_at,
+            )
+            .await?;
+
+        let valid_pubkeys = claims
+            .iter()
+            .map(|claim| claim.pubkey.clone())
+            .collect::<HashSet<_>>();
+        let renewed_count = claims.iter().filter(|claim| claim.renewed).count();
+        let lost_pubkeys = active_sessions
+            .keys()
+            .filter(|pubkey| !valid_pubkeys.contains(*pubkey))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for pubkey in &lost_pubkeys {
+            if let Some(session) = active_sessions.get(pubkey) {
+                session.cancellation_token.cancel();
+            }
+        }
+
+        if renewed_count > 0 || !lost_pubkeys.is_empty() {
+            tracing::debug!(
+                service = "mailbox_worker",
+                active_sessions = active_sessions.len(),
+                renewed_count,
+                lost_ownership_count = lost_pubkeys.len(),
+                "mailbox bulk lease renewal complete"
+            );
+        }
+
+        Ok(())
+    }
+
     async fn handle_session_result(
         result: std::result::Result<(String, Result<()>), tokio::task::JoinError>,
-        active_pubkeys: &mut HashSet<String>,
+        active_sessions: &mut HashMap<String, ActiveMailboxSession>,
     ) -> Result<()> {
         let (pubkey, session_result) = result?;
-        active_pubkeys.remove(&pubkey);
+        active_sessions.remove(&pubkey);
         if let Err(error) = session_result {
             tracing::error!(
                 service = "mailbox_worker",
@@ -331,6 +419,7 @@ async fn process_mailbox_session<T>(
     config: MailboxWorkerConfig,
     worker_id: String,
     mailbox: ActiveMailboxAuthorization,
+    cancellation_token: CancellationToken,
 ) -> Result<()>
 where
     T: MailboxTransport + 'static,
@@ -345,9 +434,8 @@ where
 
     let session = MailboxSessionContext {
         worker_id: worker_id.clone(),
-        claim_ttl: config.claim_ttl,
-        claim_renew_interval: config.claim_renew_interval,
         stream_idle_reconnect: config.stream_idle_reconnect,
+        cancellation_token,
     };
 
     let outcome = match transport
@@ -387,7 +475,8 @@ where
         }
     }
 
-    repo.release_claim(&mailbox.pubkey, &worker_id).await?;
+    repo.release_claim(&mailbox.pubkey, mailbox.auth_version, &worker_id)
+        .await?;
 
     Ok(())
 }
@@ -464,7 +553,7 @@ impl MailboxTransport for Beta8MailboxTransport {
 
             let mut catchup_count = 0u64;
             loop {
-                if !renew_mailbox_claim(&app_state, &mailbox, &session).await? {
+                if session.cancellation_token.is_cancelled() {
                     return Ok(MailboxSessionOutcome::Completed);
                 }
 
@@ -537,24 +626,14 @@ impl MailboxTransport for Beta8MailboxTransport {
                 "mailbox subscription started"
             );
 
-            let mut claim_renewal = interval_at(
-                jittered_claim_renewal_start(
-                    &mailbox.pubkey,
-                    session.claim_renew_interval,
-                    session.claim_ttl,
-                ),
-                session.claim_renew_interval,
-            );
             let idle_reconnect = sleep(session.stream_idle_reconnect);
             tokio::pin!(idle_reconnect);
 
             loop {
                 tokio::select! {
-                    _ = claim_renewal.tick() => {
-                        if !renew_mailbox_claim(&app_state, &mailbox, &session).await? {
-                            return Ok(MailboxSessionOutcome::Completed);
-                        }
-                    }
+                    _ = session.cancellation_token.cancelled() => {
+                        return Ok(MailboxSessionOutcome::Completed);
+                    },
                     _ = &mut idle_reconnect => {
                         tracing::trace!(
                             service = "mailbox_worker",
@@ -619,23 +698,6 @@ fn map_tonic_status(status: Status) -> MailboxSessionOutcome {
     }
 }
 
-fn jittered_claim_renewal_start(
-    pubkey: &str,
-    claim_renew_interval: Duration,
-    claim_ttl: Duration,
-) -> Instant {
-    let max_jitter_secs = cmp::min(
-        claim_renew_interval.as_secs().max(1),
-        claim_ttl.as_secs().saturating_div(2).max(1),
-    );
-
-    let mut hasher = DefaultHasher::new();
-    pubkey.hash(&mut hasher);
-    let jitter_secs = 1 + (hasher.finish() % max_jitter_secs);
-
-    Instant::now() + Duration::from_secs(jitter_secs)
-}
-
 async fn process_mailbox_message(
     app_state: &AppState,
     mailbox: &ActiveMailboxAuthorization,
@@ -643,7 +705,18 @@ async fn process_mailbox_message(
     message: &MailboxMessage,
     send_notifications: bool,
 ) -> Result<bool, ApiError> {
-    if !renew_mailbox_claim(app_state, mailbox, session)
+    if session.cancellation_token.is_cancelled() {
+        return Ok(false);
+    }
+
+    let repo = MailboxAuthorizationRepository::new(&app_state.db_pool);
+    if !repo
+        .claim_is_active(
+            &mailbox.pubkey,
+            mailbox.auth_version,
+            &session.worker_id,
+            Utc::now().timestamp(),
+        )
         .await
         .map_err(ApiError::from)?
     {
@@ -717,7 +790,6 @@ async fn process_mailbox_message(
         _ => {}
     }
 
-    let repo = MailboxAuthorizationRepository::new(&app_state.db_pool);
     repo.update_checkpoint(
         &mailbox.pubkey,
         message.checkpoint as i64,
@@ -771,27 +843,6 @@ fn build_receive_notification(raw_vtxo: &[u8]) -> Result<Option<PushNotification
         VtxoPolicyKind::ServerHtlcRecv | VtxoPolicyKind::ServerHtlcSend => Ok(None),
         _ => Ok(None),
     }
-}
-
-async fn renew_mailbox_claim(
-    app_state: &AppState,
-    mailbox: &ActiveMailboxAuthorization,
-    session: &MailboxSessionContext,
-) -> Result<bool> {
-    let now = Utc::now();
-    let renew_window = chrono::TimeDelta::from_std(session.claim_ttl / 2)?;
-    let renew_after = now + renew_window;
-    let lease_expires_at = now + chrono::TimeDelta::from_std(session.claim_ttl)?;
-    let repo = MailboxAuthorizationRepository::new(&app_state.db_pool);
-    repo.renew_claim(
-        &mailbox.pubkey,
-        mailbox.auth_version,
-        &session.worker_id,
-        now,
-        renew_after,
-        lease_expires_at,
-    )
-    .await
 }
 
 #[cfg(test)]
@@ -869,19 +920,6 @@ mod tests {
     }
 
     #[test]
-    fn jittered_claim_renewal_start_stays_within_safe_window() {
-        let now = Instant::now();
-        let start = jittered_claim_renewal_start(
-            "02df013fdcd1d3c311715a68002aa75ffaf65f01ec30f1d0ed9d68518da4c7fa7e",
-            Duration::from_secs(30),
-            Duration::from_secs(120),
-        );
-
-        assert!(start > now);
-        assert!(start <= now + Duration::from_secs(30));
-    }
-
-    #[test]
     fn build_receive_notification_for_pubkey_vtxo() {
         let raw = VTXO_VECTORS.arkoor2_vtxo.serialize();
 
@@ -946,18 +984,24 @@ mod tests {
     #[tokio::test]
     async fn handle_session_result_does_not_stop_worker_on_session_error() {
         let pubkey = "test-pubkey".to_string();
-        let mut active_pubkeys = HashSet::from([pubkey.clone()]);
+        let mut active_sessions = HashMap::from([(
+            pubkey.clone(),
+            ActiveMailboxSession {
+                auth_version: 1,
+                cancellation_token: CancellationToken::new(),
+            },
+        )]);
         let result = Ok((pubkey.clone(), Err(anyhow!("session failed"))));
 
         let handled = MailboxWorker::<MailboxTransportUnavailable>::handle_session_result(
             result,
-            &mut active_pubkeys,
+            &mut active_sessions,
         )
         .await;
 
         assert!(handled.is_ok(), "session errors should not stop the worker");
         assert!(
-            !active_pubkeys.contains(&pubkey),
+            !active_sessions.contains_key(&pubkey),
             "failed sessions should still be removed from the active set"
         );
     }


### PR DESCRIPTION
## Summary

- Move mailbox lease renewal from per-session polling to a worker-level bulk renewal loop.
- Track active mailbox sessions in process memory and cancel sessions that lose lease ownership.
- Keep the existing immediate Lightning claim push path intact while checking ownership before processing real mailbox messages.
- Tighten claim release with `auth_version` and add `tokio-util` for cancellation tokens.

## Why

The mailbox worker can maintain hundreds of long-lived subscriptions. Per-session lease checks and renewals were creating steady Postgres load and showing up as slow SQLx acquire/query warnings. Batching renewals keeps the same durable Postgres lease model while reducing idle DB chatter.

## Validation

- `cargo fmt --check`
- `cargo test -p server mailbox_worker --lib`
- `cargo check -p server --bins`
- `cargo clippy -p server --bins --lib -- -D warnings`
- pre-commit hook: `bun --cwd client check`
