### PR TITLE
[codex] Add home VTXO refresh banner

### DIFF
--- a/client/src/components/VtxoRefreshStatusBanner.tsx
+++ b/client/src/components/VtxoRefreshStatusBanner.tsx
@@ -1,0 +1,30 @@
+import Icon from "@react-native-vector-icons/ionicons";
+import { StatusBannerStrip } from "~/components/StatusBannerStrip";
+import { useGetExpiringVtxos, useRefreshExpiringVtxos } from "~/hooks/useWallet";
+import { COLORS } from "~/lib/styleConstants";
+
+export const VtxoRefreshStatusBanner = () => {
+  const { data: expiringVtxos = [] } = useGetExpiringVtxos();
+  const refreshExpiringVtxos = useRefreshExpiringVtxos();
+
+  if (expiringVtxos.length === 0) {
+    return null;
+  }
+
+  const vtxoLabel = expiringVtxos.length === 1 ? "VTXO" : "VTXOs";
+
+  return (
+    <StatusBannerStrip
+      className="mx-4 mt-3 mb-1"
+      title={expiringVtxos.length === 1 ? "VTXO expiring soon" : "VTXOs expiring soon"}
+      message={`Refresh ${expiringVtxos.length} ${vtxoLabel} to keep ${expiringVtxos.length === 1 ? "it" : "them"} available.`}
+      icon={<Icon name="warning-outline" size={16} color={COLORS.BITCOIN_ORANGE} />}
+      tone="info"
+      actionLabel="Refresh"
+      actionBusyLabel="Refreshing"
+      actionTextStyle={{ color: COLORS.BITCOIN_ORANGE }}
+      isActionLoading={refreshExpiringVtxos.isPending}
+      onActionPress={() => refreshExpiringVtxos.mutate()}
+    />
+  );
+};

--- a/client/src/hooks/useWallet.ts
+++ b/client/src/hooks/useWallet.ts
@@ -22,6 +22,7 @@ import { getAutoBoardThreshold } from "~/lib/autoBoarding";
 import { restoreWallet as restoreWalletAction } from "../lib/backupService";
 import { deregister } from "../lib/api";
 import { queryClient } from "~/queryClient";
+import { invalidateWalletDerivedQueries } from "~/lib/queryInvalidation";
 import { useTransactionStore } from "../store/transactionStore";
 import { useBackupStore } from "~/store/backupStore";
 import { ResultAsync } from "neverthrow";
@@ -158,6 +159,8 @@ export function usePendingRounds(refetchIntervalMs: number | false = false) {
 }
 
 export function useGetVtxos() {
+  const { isInitialized, isWalletSuspended, isBackgroundJobRunning } = useWalletStore();
+
   return useQuery({
     queryKey: ["vtxos"],
     queryFn: async () => {
@@ -167,11 +170,14 @@ export function useGetVtxos() {
       }
       return result.value;
     },
+    enabled: isInitialized && !isWalletSuspended && !isBackgroundJobRunning,
     retry: false,
   });
 }
 
 export function useGetExpiringVtxos() {
+  const { isInitialized, isWalletSuspended, isBackgroundJobRunning } = useWalletStore();
+
   return useQuery({
     queryKey: ["expiring-vtxos"],
     queryFn: async () => {
@@ -181,6 +187,7 @@ export function useGetExpiringVtxos() {
       }
       return result.value;
     },
+    enabled: isInitialized && !isWalletSuspended && !isBackgroundJobRunning,
     retry: false,
   });
 }
@@ -196,12 +203,10 @@ export function useRefreshExpiringVtxos() {
       }
     },
     onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["vtxos"] }),
-        queryClient.invalidateQueries({ queryKey: ["expiring-vtxos"] }),
-        queryClient.invalidateQueries({ queryKey: ["balance"] }),
-        queryClient.invalidateQueries({ queryKey: ["pending-rounds"] }),
-      ]);
+      await invalidateWalletDerivedQueries({
+        includePendingRounds: true,
+        includeTransactions: false,
+      });
       showAlert({
         title: "Refresh scheduled",
         description: "A delegated refresh has been scheduled for eligible VTXOs.",

--- a/client/src/lib/queryInvalidation.ts
+++ b/client/src/lib/queryInvalidation.ts
@@ -1,0 +1,27 @@
+import { queryClient } from "~/queryClient";
+
+type WalletQueryInvalidationOptions = {
+  includePendingRounds?: boolean;
+  includeTransactions?: boolean;
+};
+
+export const invalidateWalletDerivedQueries = async ({
+  includePendingRounds = false,
+  includeTransactions = true,
+}: WalletQueryInvalidationOptions = {}) => {
+  const invalidations = [
+    queryClient.invalidateQueries({ queryKey: ["balance"] }),
+    queryClient.invalidateQueries({ queryKey: ["vtxos"] }),
+    queryClient.invalidateQueries({ queryKey: ["expiring-vtxos"] }),
+  ];
+
+  if (includeTransactions) {
+    invalidations.push(queryClient.invalidateQueries({ queryKey: ["transactions"] }));
+  }
+
+  if (includePendingRounds) {
+    invalidations.push(queryClient.invalidateQueries({ queryKey: ["pending-rounds"] }));
+  }
+
+  await Promise.all(invalidations);
+};

--- a/client/src/lib/sync.ts
+++ b/client/src/lib/sync.ts
@@ -1,8 +1,8 @@
-import { queryClient } from "~/queryClient";
 import { useWalletStore } from "~/store/walletStore";
 import { onchainSync, sync } from "~/lib/walletApi";
 import logger from "~/lib/log";
 import { tryClaimAllLightningReceives } from "./paymentsApi";
+import { invalidateWalletDerivedQueries } from "~/lib/queryInvalidation";
 
 const log = logger("sync");
 
@@ -27,6 +27,5 @@ export const syncWallet = async () => {
     }
   });
 
-  await queryClient.invalidateQueries({ queryKey: ["balance"] });
-  await queryClient.invalidateQueries({ queryKey: ["transactions"] });
+  await invalidateWalletDerivedQueries();
 };

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -20,9 +20,9 @@ import { EmailVerificationBanner } from "~/components/EmailVerificationBanner";
 import { BackupStatusBanner } from "~/components/BackupStatusBanner";
 import { AutoBoardingStatusBanner } from "~/components/AutoBoardingStatusBanner";
 import { PendingRoundStatusBanner } from "~/components/PendingRoundStatusBanner";
+import { VtxoRefreshStatusBanner } from "~/components/VtxoRefreshStatusBanner";
 import { useBackgroundJobCoordination } from "~/hooks/useBackgroundJobCoordination";
 import { useServerStore } from "~/store/serverStore";
-import { queryClient } from "~/queryClient";
 
 import Animated, {
   FadeInDown,
@@ -45,6 +45,7 @@ import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
 import { TransactionDetailContent } from "~/screens/TransactionDetailScreen";
 import { usePrivacyStore } from "~/store/privacyStore";
 import { useProfileStore } from "~/store/profileStore";
+import { invalidateWalletDerivedQueries } from "~/lib/queryInvalidation";
 
 const getTransactionIcon = (type: Transaction["type"]) => {
   switch (type) {
@@ -78,7 +79,7 @@ const HomeScreen = () => {
   const parentNavigation = navigation.getParent<NavigationProp<TabParamList>>();
   const { walletError, isWalletSuspended } = useWalletStore();
   const { safelyExecuteWhenReady, isBackgroundJobRunning } = useBackgroundJobCoordination();
-  const { data: balance, refetch, error, isLoading: isBalanceLoading } = useBalance();
+  const { data: balance, error, isLoading: isBalanceLoading } = useBalance();
   const { isPending: isSyncPending } = useWalletSync();
   const { mutateAsync: loadWallet } = useLoadWallet();
   const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
@@ -115,11 +116,10 @@ const HomeScreen = () => {
 
     await sync();
     await onchainSync();
-    await queryClient.invalidateQueries({ queryKey: ["pending-rounds"] });
-    await refetch();
+    await invalidateWalletDerivedQueries({ includePendingRounds: true });
     await updateWidget();
     getRandomFact();
-  }, [refetch, getRandomFact, safelyExecuteWhenReady, loadWallet]);
+  }, [getRandomFact, safelyExecuteWhenReady, loadWallet]);
 
   const openHistory = () => {
     parentNavigation?.navigate("History", { screen: "TransactionsList" });
@@ -252,6 +252,7 @@ const HomeScreen = () => {
           />
         )}
         <BackupStatusBanner />
+        <VtxoRefreshStatusBanner />
         <PendingRoundStatusBanner />
         <AutoBoardingStatusBanner />
         {isBackgroundJobRunning && (


### PR DESCRIPTION
## Summary

- add a Home status banner for expiring VTXOs using the existing refresh mutation

- invalidate wallet-derived VTXO queries after sync so the Home banner reflects refreshed wallet state

## Validation
- bun client typecheck
- bun client lint







