### PR TITLE
Fix Board Ark onboarding copy

### DIFF
--- a/client/src/screens/BoardArkScreen.tsx
+++ b/client/src/screens/BoardArkScreen.tsx
@@ -723,7 +723,7 @@ const BoardArkScreen = () => {
             {flow === "onboard" ? (
               <>
                 <Text className="text-muted-foreground text-center mb-8">
-                  Swap you onchain bitcoin and enter the Ark network for fast, cheap offchain
+                  Swap your onchain bitcoin and enter the Ark network for fast, cheap offchain
                   transactions.
                 </Text>
                 <BalanceDisplay


### PR DESCRIPTION
Small copy fix: change 'Swap you onchain bitcoin' to 'Swap your onchain bitcoin' in client/src/screens/BoardArkScreen.tsx#L726.