### PR TITLE
[codex] Add configurable bitcoin amount display

### DIFF
--- a/client/src/Navigators.tsx
+++ b/client/src/Navigators.tsx
@@ -35,6 +35,7 @@ import DebugScreen from "~/screens/DebugScreen";
 import QRHubScreen from "~/screens/QRHubScreen";
 import ProfileScreen from "~/screens/ProfileScreen";
 import CurrencySettingsScreen from "~/screens/CurrencySettingsScreen";
+import BitcoinUnitSettingsScreen from "~/screens/BitcoinUnitSettingsScreen";
 import WalletLoader from "~/components/WalletLoader";
 import { useWalletStore } from "~/store/walletStore";
 import { useServerStore } from "~/store/serverStore";
@@ -70,6 +71,7 @@ export type SettingsStackParamList = {
   SettingsList: undefined;
   Profile: undefined;
   Currency: undefined;
+  BitcoinUnit: undefined;
   Mnemonic: { fromOnboarding: boolean };
   Logs: undefined;
   EmailVerification: { fromSettings?: boolean } | undefined;
@@ -128,6 +130,11 @@ const SettingsStackNav = () => (
     <Stack.Screen
       name="Currency"
       component={CurrencySettingsScreen}
+      options={{ animation: "default" }}
+    />
+    <Stack.Screen
+      name="BitcoinUnit"
+      component={BitcoinUnitSettingsScreen}
       options={{ animation: "default" }}
     />
     <Stack.Screen name="Mnemonic" component={MnemonicScreen} options={{ animation: "default" }} />

--- a/client/src/components/AutoBoardingService.tsx
+++ b/client/src/components/AutoBoardingService.tsx
@@ -11,7 +11,8 @@ import {
   buildAutoBoardPlan,
 } from "~/lib/autoBoarding";
 import logger from "~/lib/log";
-import { cn, formatBip177 } from "~/lib/utils";
+import { cn } from "~/lib/utils";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import { useTransactionStore } from "~/store/transactionStore";
 
 const log = logger("AutoBoardingService");
@@ -40,6 +41,7 @@ const AutoBoardPlanRow = ({
 );
 
 export const AutoBoardingService = memo(({ isReady }: AutoBoardingServiceProps) => {
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const [hasReportedAutoBoardPlanError, setHasReportedAutoBoardPlanError] = useState(false);
   const [autoBoardPlan, setAutoBoardPlan] = useState<AutoBoardPlan | null>(null);
   const [isAutoBoardDialogOpen, setIsAutoBoardDialogOpen] = useState(false);
@@ -278,40 +280,40 @@ export const AutoBoardingService = memo(({ isReady }: AutoBoardingServiceProps) 
           <View className="rounded-xl border border-border/70 bg-card/80 p-4">
             <Text className="text-sm font-medium text-muted-foreground">Amount to board</Text>
             <Text className="mt-1 text-3xl font-bold text-foreground">
-              {formatBip177(autoBoardPlan.grossBoardAmountSat)}
+              {formatBitcoinAmount(autoBoardPlan.grossBoardAmountSat)}
             </Text>
             <Text className="mt-1 text-xs leading-5 text-muted-foreground">
-              {formatBip177(autoBoardPlan.netBoardAmountSat)} becomes available in Ark after the
-              boarding fee.
+              {formatBitcoinAmount(autoBoardPlan.netBoardAmountSat)} becomes available in Ark after
+              the boarding fee.
             </Text>
           </View>
 
           <View className="rounded-xl border border-border/70 bg-card/60 px-3 py-1">
             <AutoBoardPlanRow
               label="Onchain balance"
-              value={formatBip177(autoBoardPlan.confirmedOnchainBalanceSat)}
+              value={formatBitcoinAmount(autoBoardPlan.confirmedOnchainBalanceSat)}
             />
             <View className="h-px bg-border/70" />
             <AutoBoardPlanRow
               label="Ark boarding fee"
-              value={formatBip177(autoBoardPlan.arkFeeSat)}
+              value={formatBitcoinAmount(autoBoardPlan.arkFeeSat)}
               valueClassName="text-red-500"
             />
             <View className="h-px bg-border/70" />
             <AutoBoardPlanRow
               label="Estimated onchain fee"
-              value={formatBip177(autoBoardPlan.estimatedOnchainFeeSat)}
+              value={formatBitcoinAmount(autoBoardPlan.estimatedOnchainFeeSat)}
               valueClassName="text-red-500"
             />
             <View className="h-px bg-border/70" />
             <AutoBoardPlanRow
               label="Stays in onchain wallet"
-              value={formatBip177(autoBoardPlan.estimatedRemainingOnchainSat)}
+              value={formatBitcoinAmount(autoBoardPlan.estimatedRemainingOnchainSat)}
             />
             <View className="h-px bg-border/70" />
             <AutoBoardPlanRow
               label="Ark amount after fee"
-              value={formatBip177(autoBoardPlan.netBoardAmountSat)}
+              value={formatBitcoinAmount(autoBoardPlan.netBoardAmountSat)}
               valueClassName="text-green-500"
             />
           </View>

--- a/client/src/components/FeeEstimateSummary.tsx
+++ b/client/src/components/FeeEstimateSummary.tsx
@@ -1,9 +1,9 @@
 import { Fragment } from "react";
 import type { BarkFeeEstimate } from "~/lib/paymentsApi";
 import { Text } from "~/components/ui/text";
-import { formatBip177 } from "~/lib/utils";
 import { COLORS } from "~/lib/styleConstants";
 import { FeeEstimateBox, FeeEstimateRow, FeeEstimateSeparator } from "~/components/FeeEstimateBox";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 type FeeEstimateRowKey = "net" | "fee" | "gross";
 
@@ -36,6 +36,8 @@ export const FeeEstimateSummary = ({
   feeValueClassName,
   rowOrder = ["net", "fee", "gross"],
 }: FeeEstimateSummaryProps) => {
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
+
   if (!estimate && !isLoading && !error) {
     return null;
   }
@@ -49,18 +51,18 @@ export const FeeEstimateSummary = ({
               rowKey === "net"
                 ? {
                     label: netLabel,
-                    value: formatBip177(estimate.net_amount_sat),
+                    value: formatBitcoinAmount(estimate.net_amount_sat),
                     valueClassName: undefined,
                   }
                 : rowKey === "fee"
                   ? {
                       label: feeLabel,
-                      value: formatBip177(estimate.fee_sat),
+                      value: formatBitcoinAmount(estimate.fee_sat),
                       valueClassName: feeValueClassName,
                     }
                   : {
                       label: grossLabel,
-                      value: formatBip177(estimate.gross_amount_sat),
+                      value: formatBitcoinAmount(estimate.gross_amount_sat),
                       valueClassName: undefined,
                     };
 

--- a/client/src/components/ReceiveSuccess.tsx
+++ b/client/src/components/ReceiveSuccess.tsx
@@ -5,13 +5,13 @@ import { Text } from "./ui/text";
 import { NoahButton } from "./ui/NoahButton";
 import ReceiveAnimation from "./ReceiveAnimation";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
-import { formatBip177 } from "~/lib/utils";
 import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
 import * as Haptics from "expo-haptics";
 import { useThemeColors } from "~/hooks/useTheme";
 import { COLORS } from "~/lib/styleConstants";
 import { useBottomTabBarHeight } from "react-native-bottom-tabs";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 type ReceiveSuccessProps = {
   amountSat: number;
@@ -28,6 +28,7 @@ export const ReceiveSuccess: React.FC<ReceiveSuccessProps> = ({
   totalWalletBalanceSat,
   handleDone,
 }) => {
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const fiatAmount = btcPrice ? satsToFiat(amountSat, btcPrice, fiatCurrency) : null;
   const colors = useThemeColors();
   const bottomTabBarHeight = useBottomTabBarHeight();
@@ -52,7 +53,7 @@ export const ReceiveSuccess: React.FC<ReceiveSuccessProps> = ({
 
           <Animated.View entering={FadeInUp.duration(520).delay(180)} className="mt-6 items-center">
             <Text className="text-center text-4xl font-bold text-foreground">
-              {formatBip177(amountSat)}
+              {formatBitcoinAmount(amountSat)}
             </Text>
             {btcPrice && (
               <Text className="mt-3 text-base font-medium text-muted-foreground">
@@ -83,7 +84,9 @@ export const ReceiveSuccess: React.FC<ReceiveSuccessProps> = ({
             <View className="mt-4 flex-row items-center justify-between">
               <Text className="text-base text-muted-foreground">Wallet balance</Text>
               <Text className="text-base font-semibold text-foreground">
-                {totalWalletBalanceSat !== undefined ? formatBip177(totalWalletBalanceSat) : "…"}
+                {totalWalletBalanceSat !== undefined
+                  ? formatBitcoinAmount(totalWalletBalanceSat)
+                  : "…"}
               </Text>
             </View>
           </Animated.View>

--- a/client/src/components/SendConfirmation.tsx
+++ b/client/src/components/SendConfirmation.tsx
@@ -3,7 +3,6 @@ import { Pressable, View } from "react-native";
 import { Text } from "./ui/text";
 import { NoahButton } from "./ui/NoahButton";
 import { Button } from "./ui/button";
-import { formatBip177 } from "~/lib/utils";
 import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
 import { DestinationTypes, ParsedBip321 } from "~/lib/sendUtils";
@@ -12,6 +11,7 @@ import { COLORS } from "~/lib/styleConstants";
 import { Bip321Picker } from "./Bip321Picker";
 import { FeeEstimateSummary } from "./FeeEstimateSummary";
 import type { BarkFeeEstimate, OnchainSendSource } from "~/lib/paymentsApi";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 interface SendConfirmationProps {
   destination: string;
@@ -76,6 +76,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
   feeEstimateWarning = null,
   sendError = null,
 }) => {
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const colors = useThemeColors();
   const isOnchainDestination =
     destinationType === "onchain" ||
@@ -160,7 +161,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
 
       <View className="mt-4 items-center">
         <Text className="text-center text-3xl font-bold text-foreground">
-          {formatBip177(amount)}
+          {formatBitcoinAmount(amount)}
         </Text>
         {btcPrice ? (
           <Text className="mt-1 text-sm font-medium text-muted-foreground">
@@ -237,7 +238,7 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
                           {getOnchainSourceLabel(source)}
                         </Text>
                         <Text className="mt-1 text-xs text-muted-foreground">
-                          {formatBip177(getOnchainSourceBalance(source))}
+                          {formatBitcoinAmount(getOnchainSourceBalance(source))}
                         </Text>
                       </Pressable>
                     );

--- a/client/src/components/SendSuccessBottomSheet.tsx
+++ b/client/src/components/SendSuccessBottomSheet.tsx
@@ -3,12 +3,12 @@ import { Pressable, View } from "react-native";
 import { Text } from "./ui/text";
 import { NoahButton } from "./ui/NoahButton";
 import SuccessAnimation from "./SuccessAnimation";
-import { formatBip177 } from "~/lib/utils";
 import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
 import { useCopyToClipboard } from "~/lib/clipboardUtils";
 import { COLORS } from "~/lib/styleConstants";
 import { useThemeColors } from "~/hooks/useTheme";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 type ParsedResult = {
   amount_sat: number;
@@ -64,6 +64,7 @@ export const SendSuccessBottomSheet: React.FC<SendSuccessBottomSheetProps> = ({
   btcPrice,
   fiatCurrency,
 }) => {
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const fiatAmount = btcPrice ? satsToFiat(parsedResult.amount_sat, btcPrice, fiatCurrency) : null;
   const colors = useThemeColors();
 
@@ -76,7 +77,7 @@ export const SendSuccessBottomSheet: React.FC<SendSuccessBottomSheetProps> = ({
 
       <View className="mt-6 items-center">
         <Text className="text-center text-4xl font-bold text-foreground">
-          {formatBip177(parsedResult.amount_sat)}
+          {formatBitcoinAmount(parsedResult.amount_sat)}
         </Text>
         {btcPrice && (
           <Text className="mt-3 text-lg font-medium text-muted-foreground">

--- a/client/src/hooks/useBitcoinAmountFormatter.ts
+++ b/client/src/hooks/useBitcoinAmountFormatter.ts
@@ -1,0 +1,10 @@
+import { formatBitcoinAmount } from "~/lib/bitcoinAmount";
+import { useProfileStore } from "~/store/profileStore";
+
+export const useBitcoinAmountFormatter = () => {
+  const bitcoinAmountUnit = useProfileStore((state) => state.bitcoinAmountUnit);
+
+  return (sats: number) => formatBitcoinAmount(sats, bitcoinAmountUnit);
+};
+
+export const useBitcoinAmountUnit = () => useProfileStore((state) => state.bitcoinAmountUnit);

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -18,7 +18,7 @@ import { useQRCodeScanner } from "~/hooks/useQRCodeScanner";
 import { useBtcToFiatRate } from "./useMarketData";
 import { useBalance } from "./useWallet";
 import { useLightningAddressSuggestions } from "./useLightningAddressSuggestions";
-import { formatBip177 } from "../lib/utils";
+import { formatBitcoinAmount } from "~/lib/bitcoinAmount";
 import { fiatToSats, satsToFiat } from "~/lib/fiatCurrency";
 import { useProfileStore } from "~/store/profileStore";
 import logger from "~/lib/log";
@@ -60,6 +60,7 @@ export const useSendScreen = () => {
   const route = useRoute<SendScreenRouteProp>();
   const { showAlert } = useAlert();
   const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
+  const bitcoinAmountUnit = useProfileStore((state) => state.bitcoinAmountUnit);
   const { data: btcPrice } = useBtcToFiatRate();
   const { data: balance } = useBalance();
   const [destination, setDestination] = useState("");
@@ -305,8 +306,9 @@ export const useSendScreen = () => {
     }
 
     const sourceLabel = resolvedOnchainSource === "offchain" ? "Ark" : "onchain";
-    return `Estimated total is ${formatBip177(estimatedTotal)}, but your ${sourceLabel} balance is ${formatBip177(sourceBalance)}. The send may fail if the final fee is not lower.`;
+    return `Estimated total is ${formatBitcoinAmount(estimatedTotal, bitcoinAmountUnit)}, but your ${sourceLabel} balance is ${formatBitcoinAmount(sourceBalance, bitcoinAmountUnit)}. The send may fail if the final fee is not lower.`;
   }, [
+    bitcoinAmountUnit,
     feeEstimateQuery.data,
     isOnchainSend,
     offchainWalletBalance,

--- a/client/src/lib/bitcoinAmount.ts
+++ b/client/src/lib/bitcoinAmount.ts
@@ -1,0 +1,47 @@
+export const BITCOIN_AMOUNT_UNITS = ["bip177", "sats"] as const;
+
+export type BitcoinAmountUnit = (typeof BITCOIN_AMOUNT_UNITS)[number];
+
+type BitcoinAmountUnitInfo = {
+  unit: BitcoinAmountUnit;
+  title: string;
+  value: string;
+  description: string;
+};
+
+const BITCOIN_AMOUNT_UNIT_INFO: Record<BitcoinAmountUnit, BitcoinAmountUnitInfo> = {
+  bip177: {
+    unit: "bip177",
+    title: "BIP177",
+    value: "₿\u00A01,234",
+    description: "Show bitcoin amounts with the Bitcoin symbol.",
+  },
+  sats: {
+    unit: "sats",
+    title: "Sats",
+    value: "1,234 sats",
+    description: "Show bitcoin amounts in satoshis.",
+  },
+};
+
+export const isBitcoinAmountUnit = (value: unknown): value is BitcoinAmountUnit =>
+  typeof value === "string" && BITCOIN_AMOUNT_UNITS.includes(value as BitcoinAmountUnit);
+
+export const getBitcoinAmountUnitInfo = (unit: BitcoinAmountUnit): BitcoinAmountUnitInfo =>
+  BITCOIN_AMOUNT_UNIT_INFO[unit];
+
+export const formatBip177 = (sats: number): string => {
+  return `₿\u00A0${sats.toLocaleString()}`;
+};
+
+export const formatSatsAmount = (sats: number): string => {
+  return `${sats.toLocaleString()} sats`;
+};
+
+export const formatBitcoinAmount = (sats: number, unit: BitcoinAmountUnit): string => {
+  if (unit === "sats") {
+    return formatSatsAmount(sats);
+  }
+
+  return formatBip177(sats);
+};

--- a/client/src/lib/pushNotifications.ts
+++ b/client/src/lib/pushNotifications.ts
@@ -15,9 +15,10 @@ import { registerPushToken, reportJobStatus, heartbeatResponse } from "~/lib/api
 import { err, ok, Result, ResultAsync } from "neverthrow";
 import { NotificationData, ReportType } from "~/types/serverTypes";
 import { useWalletStore } from "~/store/walletStore";
-import { formatBip177 } from "./utils";
+import { formatBitcoinAmount } from "~/lib/bitcoinAmount";
 import { updateWidget } from "~/hooks/useWidget";
 import { shouldUseUnifiedPush } from "~/constants";
+import { useProfileStore } from "~/store/profileStore";
 
 const log = logger("pushNotifications");
 
@@ -56,11 +57,12 @@ async function ensureDefaultNotificationChannel() {
 
 async function scheduleLightningPaymentNotification(amountSat: number): Promise<string> {
   await ensureDefaultNotificationChannel();
+  const { bitcoinAmountUnit } = useProfileStore.getState();
 
   return Notifications.scheduleNotificationAsync({
     content: {
       title: "Lightning Payment Received! ⚡",
-      body: `You received ${formatBip177(amountSat)}`,
+      body: `You received ${formatBitcoinAmount(amountSat, bitcoinAmountUnit)}`,
       sound: "default",
       priority: Notifications.AndroidNotificationPriority.MAX,
       data: {

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { APP_VARIANT } from "../config";
+export { formatBip177 } from "~/lib/bitcoinAmount";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -26,10 +27,6 @@ export const formatNumber = (num: number | string) => {
 
 export const satsToBtc = (sats: number) => {
   return (sats / 100_000_000).toFixed(8);
-};
-
-export const formatBip177 = (sats: number): string => {
-  return `₿\u00A0${sats.toLocaleString()}`;
 };
 
 export const isNetworkMatch = (

--- a/client/src/screens/BitcoinUnitSettingsScreen.tsx
+++ b/client/src/screens/BitcoinUnitSettingsScreen.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { Pressable, ScrollView, View } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import Icon from "@react-native-vector-icons/ionicons";
+import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
+import { Text } from "~/components/ui/text";
+import type { SettingsStackParamList } from "~/Navigators";
+import {
+  BITCOIN_AMOUNT_UNITS,
+  getBitcoinAmountUnitInfo,
+  type BitcoinAmountUnit,
+} from "~/lib/bitcoinAmount";
+import { COLORS } from "~/lib/styleConstants";
+import { useIconColor, useThemeColors } from "~/hooks/useTheme";
+import { useProfileStore } from "~/store/profileStore";
+
+type BitcoinUnitNavigationProp = NativeStackNavigationProp<SettingsStackParamList, "BitcoinUnit">;
+
+const BitcoinUnitSettingsScreen = () => {
+  const navigation = useNavigation<BitcoinUnitNavigationProp>();
+  const iconColor = useIconColor();
+  const colors = useThemeColors();
+  const bitcoinAmountUnit = useProfileStore((state) => state.bitcoinAmountUnit);
+  const setBitcoinAmountUnit = useProfileStore((state) => state.setBitcoinAmountUnit);
+
+  const handleSelectUnit = (unit: BitcoinAmountUnit) => {
+    setBitcoinAmountUnit(unit);
+    navigation.goBack();
+  };
+
+  return (
+    <NoahSafeAreaView className="flex-1 bg-background">
+      <ScrollView
+        className="flex-1"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 32 }}
+      >
+        <View className="px-5 pb-8 pt-4">
+          <View className="flex-row items-center">
+            <Pressable onPress={() => navigation.goBack()} className="mr-4">
+              <Icon name="arrow-back-outline" size={24} color={iconColor} />
+            </Pressable>
+            <Text className="text-2xl font-bold text-foreground">Bitcoin Unit</Text>
+          </View>
+
+          <View
+            className="mt-8 overflow-hidden rounded-[18px] border"
+            style={{
+              borderColor: `${colors.mutedForeground}24`,
+              backgroundColor: `${colors.card}CC`,
+            }}
+          >
+            {BITCOIN_AMOUNT_UNITS.map((unit, index) => {
+              const info = getBitcoinAmountUnitInfo(unit);
+              const isSelected = unit === bitcoinAmountUnit;
+
+              return (
+                <Pressable
+                  key={unit}
+                  onPress={() => handleSelectUnit(unit)}
+                  className={`flex-row items-center justify-between px-4 py-4 ${
+                    index < BITCOIN_AMOUNT_UNITS.length - 1 ? "border-b border-border" : ""
+                  }`}
+                >
+                  <View className="min-w-0 flex-1">
+                    <Text className="text-base font-semibold text-foreground">
+                      {info.title} · {info.value}
+                    </Text>
+                    <Text className="mt-1 text-sm text-muted-foreground">{info.description}</Text>
+                  </View>
+                  {isSelected ? (
+                    <Icon name="checkmark-circle" size={24} color={COLORS.BITCOIN_ORANGE} />
+                  ) : (
+                    <Icon name="ellipse-outline" size={24} color={iconColor} />
+                  )}
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+      </ScrollView>
+    </NoahSafeAreaView>
+  );
+};
+
+export default BitcoinUnitSettingsScreen;

--- a/client/src/screens/BoardArkScreen.tsx
+++ b/client/src/screens/BoardArkScreen.tsx
@@ -28,7 +28,7 @@ import {
   type BoardArkFeeEstimateResult,
 } from "../hooks/usePayments";
 import { copyToClipboard } from "../lib/clipboardUtils";
-import { cn, formatBip177, isNetworkMatch } from "../lib/utils";
+import { cn, isNetworkMatch } from "../lib/utils";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import { useAlert } from "~/contexts/AlertProvider";
@@ -38,6 +38,7 @@ import { BoardResult } from "react-native-nitro-ark";
 import { useTransactionStore } from "~/store/transactionStore";
 import { FeeEstimateSummary } from "~/components/FeeEstimateSummary";
 import { FeeEstimateBox, FeeEstimateRow, FeeEstimateSeparator } from "~/components/FeeEstimateBox";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 const log = logger("BoardArkScreen");
 
@@ -94,31 +95,37 @@ const BalanceDisplay = ({
   pendingAmount?: number;
   isLoading: boolean;
   compact?: boolean;
-}) => (
-  <View className={compact ? "mb-5" : "mb-8"}>
-    <Text className={compact ? "text-sm text-muted-foreground" : "text-lg text-muted-foreground"}>
-      {title}
-    </Text>
-    {isLoading ? (
-      <NoahActivityIndicator className="mt-2" />
-    ) : (
-      <>
-        <Text className={cn("font-bold text-foreground mt-1", compact ? "text-2xl" : "text-3xl")}>
-          {formatBip177(amount)}
-        </Text>
-        {pendingAmount !== undefined && pendingAmount > 0 && (
-          <Text
-            className={
-              compact ? "text-sm text-muted-foreground mt-1" : "text-xl text-muted-foreground mt-1"
-            }
-          >
-            {formatBip177(pendingAmount)} pending
+}) => {
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
+
+  return (
+    <View className={compact ? "mb-5" : "mb-8"}>
+      <Text className={compact ? "text-sm text-muted-foreground" : "text-lg text-muted-foreground"}>
+        {title}
+      </Text>
+      {isLoading ? (
+        <NoahActivityIndicator className="mt-2" />
+      ) : (
+        <>
+          <Text className={cn("font-bold text-foreground mt-1", compact ? "text-2xl" : "text-3xl")}>
+            {formatBitcoinAmount(amount)}
           </Text>
-        )}
-      </>
-    )}
-  </View>
-);
+          {pendingAmount !== undefined && pendingAmount > 0 && (
+            <Text
+              className={
+                compact
+                  ? "text-sm text-muted-foreground mt-1"
+                  : "text-xl text-muted-foreground mt-1"
+              }
+            >
+              {formatBitcoinAmount(pendingAmount)} pending
+            </Text>
+          )}
+        </>
+      )}
+    </View>
+  );
+};
 
 // Flow toggle component
 const FlowToggle = ({ flow, onFlowChange }: { flow: Flow; onFlowChange: (flow: Flow) => void }) => (
@@ -208,6 +215,8 @@ const BoardFeeEstimateSummary = ({
   error: Error | null;
   isWaitingForDebounce: boolean;
 }) => {
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
+
   if (!result && !isLoading && !error && !isWaitingForDebounce) {
     return null;
   }
@@ -226,7 +235,7 @@ const BoardFeeEstimateSummary = ({
           {estimate.is_below_minimum_board_amount ? (
             <Text className="mb-2 text-xs leading-5 text-muted-foreground">
               This estimate is below Ark's minimum board amount of{" "}
-              {formatBip177(estimate.minimum_board_amount_sat)}. The final amount will be
+              {formatBitcoinAmount(estimate.minimum_board_amount_sat)}. The final amount will be
               calculated when you board.
             </Text>
           ) : estimate.is_max_amount ? (
@@ -236,27 +245,27 @@ const BoardFeeEstimateSummary = ({
           ) : null}
           <FeeEstimateRow
             label="Amount to board"
-            value={formatBip177(estimate.gross_amount_sat)}
+            value={formatBitcoinAmount(estimate.gross_amount_sat)}
             compact
           />
           <FeeEstimateSeparator />
           <FeeEstimateRow
             label="Ark boarding fee"
-            value={formatBip177(estimate.fee_sat)}
+            value={formatBitcoinAmount(estimate.fee_sat)}
             compact
             valueClassName="text-red-500"
           />
           <FeeEstimateSeparator />
           <FeeEstimateRow
             label="Estimated onchain fee"
-            value={formatBip177(estimate.estimated_onchain_fee_sat)}
+            value={formatBitcoinAmount(estimate.estimated_onchain_fee_sat)}
             compact
             valueClassName="text-red-500"
           />
           <FeeEstimateSeparator />
           <FeeEstimateRow
             label="Stays in onchain wallet"
-            value={formatBip177(estimate.estimated_remaining_onchain_sat)}
+            value={formatBitcoinAmount(estimate.estimated_remaining_onchain_sat)}
             compact
             valueClassName={
               estimate.estimated_remaining_onchain_sat < 0 ? "text-red-500" : undefined
@@ -265,7 +274,7 @@ const BoardFeeEstimateSummary = ({
           <FeeEstimateSeparator />
           <FeeEstimateRow
             label="Ark amount after fee"
-            value={formatBip177(estimate.net_amount_sat)}
+            value={formatBitcoinAmount(estimate.net_amount_sat)}
             compact
             valueClassName="text-green-500"
           />
@@ -278,13 +287,13 @@ const BoardFeeEstimateSummary = ({
         <>
           <Text className="text-sm leading-5 text-muted-foreground">
             {unavailable.is_max_amount
-              ? `This Max estimate is below Ark's minimum board amount of ${formatBip177(unavailable.minimum_board_amount_sat)}. The final amount will be calculated when you board.`
-              : `This estimate is below Ark's minimum board amount of ${formatBip177(unavailable.minimum_board_amount_sat)}. The final amount will be calculated when you board.`}
+              ? `This Max estimate is below Ark's minimum board amount of ${formatBitcoinAmount(unavailable.minimum_board_amount_sat)}. The final amount will be calculated when you board.`
+              : `This estimate is below Ark's minimum board amount of ${formatBitcoinAmount(unavailable.minimum_board_amount_sat)}. The final amount will be calculated when you board.`}
           </Text>
           <FeeEstimateSeparator className="mt-2" />
           <FeeEstimateRow
             label="Amount to board"
-            value={formatBip177(unavailable.boardable_amount_sat)}
+            value={formatBitcoinAmount(unavailable.boardable_amount_sat)}
             compact
           />
           <FeeEstimateSeparator />
@@ -297,14 +306,14 @@ const BoardFeeEstimateSummary = ({
           <FeeEstimateSeparator />
           <FeeEstimateRow
             label="Estimated onchain fee"
-            value={formatBip177(unavailable.estimated_onchain_fee_sat)}
+            value={formatBitcoinAmount(unavailable.estimated_onchain_fee_sat)}
             compact
             valueClassName="text-red-500"
           />
           <FeeEstimateSeparator />
           <FeeEstimateRow
             label="Stays in onchain wallet"
-            value={formatBip177(unavailable.estimated_remaining_onchain_sat)}
+            value={formatBitcoinAmount(unavailable.estimated_remaining_onchain_sat)}
             compact
             valueClassName={
               unavailable.estimated_remaining_onchain_sat < 0 ? "text-red-500" : undefined
@@ -320,7 +329,7 @@ const BoardFeeEstimateSummary = ({
           <FeeEstimateSeparator />
           <FeeEstimateRow
             label="Minimum board amount"
-            value={formatBip177(unavailable.minimum_board_amount_sat)}
+            value={formatBitcoinAmount(unavailable.minimum_board_amount_sat)}
             compact
           />
           <Text className="mt-2 text-xs leading-5 text-muted-foreground">
@@ -339,19 +348,27 @@ const BoardFeeEstimateSummary = ({
   );
 };
 
-const MinimumBoardAmountSummary = ({ minimumBoardAmountSat }: { minimumBoardAmountSat: number }) => (
-  <FeeEstimateBox title="Minimum board amount" compact>
-    <Text className="text-sm leading-5 text-muted-foreground">
-      Enter at least {formatBip177(minimumBoardAmountSat)} to board to Ark.
-    </Text>
-    <FeeEstimateSeparator className="mt-2" />
-    <FeeEstimateRow
-      label="Minimum board amount"
-      value={formatBip177(minimumBoardAmountSat)}
-      compact
-    />
-  </FeeEstimateBox>
-);
+const MinimumBoardAmountSummary = ({
+  minimumBoardAmountSat,
+}: {
+  minimumBoardAmountSat: number;
+}) => {
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
+
+  return (
+    <FeeEstimateBox title="Minimum board amount" compact>
+      <Text className="text-sm leading-5 text-muted-foreground">
+        Enter at least {formatBitcoinAmount(minimumBoardAmountSat)} to board to Ark.
+      </Text>
+      <FeeEstimateSeparator className="mt-2" />
+      <FeeEstimateRow
+        label="Minimum board amount"
+        value={formatBitcoinAmount(minimumBoardAmountSat)}
+        compact
+      />
+    </FeeEstimateBox>
+  );
+};
 
 // Transaction result component
 const TransactionResult = ({
@@ -431,6 +448,7 @@ const BoardArkScreen = () => {
   const { showAlert } = useAlert();
   const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
   const iconColor = useIconColor();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const isAutoBoardingEnabled = useTransactionStore((state) => state.isAutoBoardingEnabled);
   const { data: balance, isLoading: isBalanceLoading } = useBalance();
   const {
@@ -649,7 +667,7 @@ const BoardArkScreen = () => {
     if (arkInfo && amountSat < arkInfo.min_board_amount) {
       showAlert({
         title: "Amount Too Low",
-        description: `Enter at least ${formatBip177(arkInfo.min_board_amount)} to board to Ark.`,
+        description: `Enter at least ${formatBitcoinAmount(arkInfo.min_board_amount)} to board to Ark.`,
       });
       return;
     }

--- a/client/src/screens/BoardingTransactionDetailScreen.tsx
+++ b/client/src/screens/BoardingTransactionDetailScreen.tsx
@@ -9,8 +9,8 @@ import { type ComponentProps, useState } from "react";
 import { COLORS } from "~/lib/styleConstants";
 import type { BoardingTransaction } from "~/types/boardingTransaction";
 import { formatMovementStatusLabel } from "~/types/movement";
-import { formatBip177 } from "~/lib/utils";
 import { getMempoolTxUrl } from "~/constants";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 const BoardingTransactionDetailRow = ({
   label,
@@ -134,6 +134,7 @@ export const BoardingTransactionDetailContent = ({
   closeIconName?: ComponentProps<typeof Icon>["name"];
 }) => {
   const iconColor = useIconColor();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const explorerUrl = transaction.txid ? getMempoolTxUrl(transaction.txid) : null;
   const statusLabel = formatBoardingStatus(transaction);
 
@@ -199,7 +200,10 @@ export const BoardingTransactionDetailContent = ({
         />
         <BoardingTransactionDetailRow label="Type" value={formatBoardingType(transaction.type)} />
         <BoardingTransactionDetailRow label="Status" value={statusLabel} />
-        <BoardingTransactionDetailRow label="Amount" value={formatBip177(transaction.amountSat)} />
+        <BoardingTransactionDetailRow
+          label="Amount"
+          value={formatBitcoinAmount(transaction.amountSat)}
+        />
       </View>
 
       {(transaction.txid || transaction.destination) && (
@@ -228,25 +232,25 @@ export const BoardingTransactionDetailContent = ({
         {typeof transaction.intendedBalanceSat === "number" ? (
           <BoardingTransactionDetailRow
             label="Intended Delta"
-            value={formatBip177(transaction.intendedBalanceSat)}
+            value={formatBitcoinAmount(transaction.intendedBalanceSat)}
           />
         ) : null}
         {typeof transaction.effectiveBalanceSat === "number" ? (
           <BoardingTransactionDetailRow
             label="Effective Delta"
-            value={formatBip177(transaction.effectiveBalanceSat)}
+            value={formatBitcoinAmount(transaction.effectiveBalanceSat)}
           />
         ) : null}
         {typeof transaction.offchainFeeSat === "number" ? (
           <BoardingTransactionDetailRow
             label="Offchain Fee"
-            value={formatBip177(transaction.offchainFeeSat)}
+            value={formatBitcoinAmount(transaction.offchainFeeSat)}
           />
         ) : null}
         {typeof transaction.onchainFeeSat === "number" ? (
           <BoardingTransactionDetailRow
             label="Onchain Fee"
-            value={formatBip177(transaction.onchainFeeSat)}
+            value={formatBitcoinAmount(transaction.onchainFeeSat)}
           />
         ) : null}
       </View>

--- a/client/src/screens/BoardingTransactionsScreen.tsx
+++ b/client/src/screens/BoardingTransactionsScreen.tsx
@@ -16,11 +16,11 @@ import RNFSTurbo from "react-native-fs-turbo";
 import { useBoardingTransactions } from "~/hooks/useBoardingTransactions";
 import type { BoardingTransaction } from "~/types/boardingTransaction";
 import { formatMovementStatusLabel } from "~/types/movement";
-import { formatBip177 } from "~/lib/utils";
 import logger from "~/lib/log";
 import { HistoryRefreshButton } from "~/components/HistoryRefreshButton";
 import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
 import { BoardingTransactionDetailContent } from "~/screens/BoardingTransactionDetailScreen";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 const log = logger("BoardingTransactionsScreen");
 
@@ -39,6 +39,7 @@ const formatBoardingStatus = (status: BoardingTransaction["status"]) => {
 const BoardingTransactionsScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
   const iconColor = useIconColor();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const {
     data: transactions = [],
     isLoading,
@@ -232,7 +233,7 @@ const BoardingTransactionsScreen = () => {
                           </Text>
                         </View>
                         <Text className="text-foreground text-sm mt-1">
-                          {formatBip177(item.amountSat)}
+                          {formatBitcoinAmount(item.amountSat)}
                         </Text>
                         <Text className="text-muted-foreground text-sm mt-1">
                           {new Date(item.date).toLocaleString()}

--- a/client/src/screens/ExitVtxoDetailScreen.tsx
+++ b/client/src/screens/ExitVtxoDetailScreen.tsx
@@ -20,9 +20,10 @@ import {
   type ExitTimelineItem,
 } from "~/lib/exitTimeline";
 import { COLORS } from "~/lib/styleConstants";
-import { cn, formatBip177 } from "~/lib/utils";
+import { cn } from "~/lib/utils";
 import type { SettingsStackParamList } from "~/Navigators";
 import type { ExitProgressState } from "react-native-nitro-ark";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 type ExitVtxoDetailRouteProp = RouteProp<SettingsStackParamList, "ExitVtxoDetail">;
 type IconName = React.ComponentProps<typeof Icon>["name"];
@@ -146,6 +147,7 @@ const ExitVtxoDetailScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList>>();
   const route = useRoute<ExitVtxoDetailRouteProp>();
   const iconColor = useIconColor();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const overviewQuery = useExitOverview();
   const syncExits = useSyncExits();
   const overview = overviewQuery.data;
@@ -225,7 +227,7 @@ const ExitVtxoDetailScreen = () => {
               <View className="flex-row items-start justify-between">
                 <View className="flex-1">
                   <Text className="text-3xl font-bold text-foreground">
-                    {formatBip177(exit.amount_sat)}
+                    {formatBitcoinAmount(exit.amount_sat)}
                   </Text>
                   <Text className="mt-2 text-base font-medium text-foreground">
                     {getExitStatusText({

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -35,7 +35,6 @@ import { useBottomTabBarHeight } from "react-native-bottom-tabs";
 import { useBtcToFiatRate } from "~/hooks/useMarketData";
 import { useWalletStore } from "~/store/walletStore";
 import { updateWidget, useWidget } from "~/hooks/useWidget";
-import { formatBip177 } from "~/lib/utils";
 import { formatFiatAmount, getFiatCurrencyInfo, satsToFiat } from "~/lib/fiatCurrency";
 import { calculateBalances } from "~/lib/balanceUtils";
 import { onchainSync, sync } from "~/lib/walletApi";
@@ -45,6 +44,7 @@ import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
 import { TransactionDetailContent } from "~/screens/TransactionDetailScreen";
 import { usePrivacyStore } from "~/store/privacyStore";
 import { useProfileStore } from "~/store/profileStore";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 const getTransactionIcon = (type: Transaction["type"]) => {
   switch (type) {
@@ -75,6 +75,7 @@ const getTransactionLabel = (transaction: Transaction) => {
 const HomeScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
   const iconColor = useIconColor();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const parentNavigation = navigation.getParent<NavigationProp<TabParamList>>();
   const { walletError, isWalletSuspended } = useWalletStore();
   const { safelyExecuteWhenReady, isBackgroundJobRunning } = useBackgroundJobCoordination();
@@ -142,7 +143,7 @@ const HomeScreen = () => {
   const errorMessage = error instanceof Error ? error.message : String(error);
   const maskedBalance = "••••";
   const formatHomeBalance = (amount: number) =>
-    isHomeBalanceHidden ? maskedBalance : formatBip177(amount);
+    isHomeBalanceHidden ? maskedBalance : formatBitcoinAmount(amount);
 
   useWidget(balances);
 
@@ -459,7 +460,7 @@ const HomeScreen = () => {
                             transaction.direction === "outgoing" ? "text-red-500" : "text-green-500"
                           }`}
                         >
-                          {`${transaction.direction === "outgoing" ? "-" : "+"}${formatBip177(transaction.amount)}`}
+                          {`${transaction.direction === "outgoing" ? "-" : "+"}${formatBitcoinAmount(transaction.amount)}`}
                         </Text>
                       </Pressable>
                     ))

--- a/client/src/screens/ReceiveScreen.tsx
+++ b/client/src/screens/ReceiveScreen.tsx
@@ -26,7 +26,7 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { TabParamList } from "~/Navigators";
 import Icon from "@react-native-vector-icons/ionicons";
 import { useIconColor, useThemeColors } from "../hooks/useTheme";
-import { satsToBtc, formatBip177 } from "~/lib/utils";
+import { satsToBtc } from "~/lib/utils";
 import { formatFiatAmount, getFiatCurrencyInfo, satsToFiat } from "~/lib/fiatCurrency";
 import { useReceiveScreen } from "../hooks/useReceiveScreen";
 import { COLORS } from "~/lib/styleConstants";
@@ -42,6 +42,7 @@ import logger from "~/lib/log";
 import type { Bolt11Invoice } from "react-native-nitro-ark";
 import { queryClient } from "~/queryClient";
 import { BlinkingCaret } from "~/components/BlinkingCaret";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 const minAmount = 1;
 const SUBSCRIPTION_RETRY_DELAY_MS = 1000;
@@ -183,6 +184,7 @@ const ReceiveScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<TabParamList>>();
   const iconColor = useIconColor();
   const colors = useThemeColors();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const { amount, setAmount, currency, toggleCurrency, amountSat, btcPrice, fiatCurrency } =
     useReceiveScreen();
   const fiatCurrencyInfo = getFiatCurrencyInfo(fiatCurrency);
@@ -749,7 +751,7 @@ const ReceiveScreen = () => {
                             )
                           : formatFiatAmount("0.00", fiatCurrency)
                       }`
-                    : `≈ ${!isNaN(amountSat) && amount ? formatBip177(amountSat) : formatBip177(0)}`}
+                    : `≈ ${!isNaN(amountSat) && amount ? formatBitcoinAmount(amountSat) : formatBitcoinAmount(0)}`}
                 </Text>
 
                 <View

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -16,7 +16,6 @@ import {
 import Icon from "@react-native-vector-icons/ionicons";
 import { useIconColor, useThemeColors } from "../hooks/useTheme";
 import * as Clipboard from "expo-clipboard";
-import { formatBip177 } from "~/lib/utils";
 import { formatFiatAmount, getFiatCurrencyInfo, satsToFiat } from "~/lib/fiatCurrency";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
 import { Button } from "~/components/ui/button";
@@ -28,12 +27,14 @@ import { CurrencyToggle } from "~/components/CurrencyToggle";
 import { COLORS } from "~/lib/styleConstants";
 import { useBottomTabBarHeight } from "react-native-bottom-tabs";
 import { BlinkingCaret } from "~/components/BlinkingCaret";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 const SendScreen = () => {
   const navigation = useNavigation();
   const isFocused = useIsFocused();
   const iconColor = useIconColor();
   const colors = useThemeColors();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const bottomTabBarHeight = useBottomTabBarHeight();
   const destinationInputRef = React.useRef<TextInput>(null);
   const amountInputRef = React.useRef<TextInput>(null);
@@ -237,7 +238,7 @@ const SendScreen = () => {
                                 )
                               : formatFiatAmount("0.00", fiatCurrency)
                           }`
-                        : `≈ ${!isNaN(amountSat) && amount ? formatBip177(amountSat) : formatBip177(0)}`}
+                        : `≈ ${!isNaN(amountSat) && amount ? formatBitcoinAmount(amountSat) : formatBitcoinAmount(0)}`}
                   </Text>
                 </View>
               </View>

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -32,11 +32,13 @@ import { revokeMailboxAuthorization } from "~/lib/api";
 import { AUTO_BOARD_ONCHAIN_BUFFER_AMOUNT, formatAutoBoardThreshold } from "~/lib/autoBoarding";
 import { useProfileStore } from "~/store/profileStore";
 import { getFiatCurrencyInfo } from "~/lib/fiatCurrency";
+import { getBitcoinAmountUnitInfo } from "~/lib/bitcoinAmount";
 
 type Setting = {
   id:
     | "profile"
     | "currency"
+    | "bitcoinUnit"
     | "showMnemonic"
     | "showLogs"
     | "resetRegistration"
@@ -77,6 +79,8 @@ const SettingsScreen = () => {
   const { isAutoBoardingEnabled, setAutoBoardingEnabled } = useTransactionStore();
   const preferredCurrency = useProfileStore((state) => state.preferredCurrency);
   const preferredCurrencyInfo = getFiatCurrencyInfo(preferredCurrency);
+  const bitcoinAmountUnit = useProfileStore((state) => state.bitcoinAmountUnit);
+  const bitcoinAmountUnitInfo = getBitcoinAmountUnitInfo(bitcoinAmountUnit);
   const {
     data: autoBoardThreshold,
     isError: isAutoBoardThresholdError,
@@ -185,6 +189,8 @@ const SettingsScreen = () => {
       navigation.navigate("Profile");
     } else if (item.id === "currency") {
       navigation.navigate("Currency");
+    } else if (item.id === "bitcoinUnit") {
+      navigation.navigate("BitcoinUnit");
     } else if (item.id === "showMnemonic") {
       navigation.navigate("Mnemonic", { fromOnboarding: false });
     } else if (item.id === "showLogs") {
@@ -225,6 +231,13 @@ const SettingsScreen = () => {
       title: "Currency",
       value: `${preferredCurrencyInfo.code} · ${preferredCurrencyInfo.name}`,
       description: "Choose the fiat currency used for balances and payment amounts.",
+      isPressable: true,
+    });
+    profileData.push({
+      id: "bitcoinUnit",
+      title: "Bitcoin Unit",
+      value: `${bitcoinAmountUnitInfo.title} · ${bitcoinAmountUnitInfo.value}`,
+      description: "Choose how bitcoin amounts are displayed.",
       isPressable: true,
     });
 

--- a/client/src/screens/TransactionDetailScreen.tsx
+++ b/client/src/screens/TransactionDetailScreen.tsx
@@ -8,12 +8,12 @@ import { copyToClipboard } from "../lib/clipboardUtils";
 import { type Transaction } from "../types/transaction";
 import { type ComponentProps, useState } from "react";
 import { COLORS } from "~/lib/styleConstants";
-import { formatBip177 } from "~/lib/utils";
 import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
 import { formatMovementKindLabel, formatMovementStatusLabel } from "~/types/movement";
 import { getMempoolTxUrl } from "~/constants";
 import { useProfileStore } from "~/store/profileStore";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 const TransactionDetailRow = ({
   label,
@@ -91,6 +91,8 @@ const MovementDestinationList = ({
   title: string;
   destinations: NonNullable<Transaction["sentTo"]>;
 }) => {
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
+
   return (
     <View className="bg-card p-4 rounded-lg mb-4">
       <Text className="text-sm font-semibold text-foreground mb-3">{title}</Text>
@@ -102,7 +104,9 @@ const MovementDestinationList = ({
           <Text className="text-foreground text-sm mb-1" numberOfLines={2}>
             {dest.destination}
           </Text>
-          <Text className="text-muted-foreground text-xs">{formatBip177(dest.amount_sat)}</Text>
+          <Text className="text-muted-foreground text-xs">
+            {formatBitcoinAmount(dest.amount_sat)}
+          </Text>
         </View>
       ))}
     </View>
@@ -121,6 +125,7 @@ export const TransactionDetailContent = ({
   closeIconName?: ComponentProps<typeof Icon>["name"];
 }) => {
   const iconColor = useIconColor();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
 
   const fiatAmount = transaction.btcPrice
     ? satsToFiat(transaction.amount, transaction.btcPrice, fiatCurrency)
@@ -168,7 +173,7 @@ export const TransactionDetailContent = ({
 
       <View className="items-center my-8">
         <Text className="text-4xl font-bold text-foreground">
-          {formatBip177(transaction.amount)}
+          {formatBitcoinAmount(transaction.amount)}
         </Text>
         <Text className="text-xl text-muted-foreground">{formattedFiatAmount}</Text>
       </View>
@@ -177,7 +182,7 @@ export const TransactionDetailContent = ({
         <TransactionDetailRow label={`Bitcoin Price (${fiatCurrency})`} value={bitcoinPrice} />
         <TransactionDetailRow
           label="Amount"
-          value={`${formatBip177(transaction.amount)} (${formattedFiatAmount})`}
+          value={`${formatBitcoinAmount(transaction.amount)} (${formattedFiatAmount})`}
         />
       </View>
 
@@ -201,13 +206,13 @@ export const TransactionDetailContent = ({
           {typeof transaction.balanceChangeSat === "number" ? (
             <TransactionDetailRow
               label="Balance Δ"
-              value={formatBip177(transaction.balanceChangeSat)}
+              value={formatBitcoinAmount(transaction.balanceChangeSat)}
             />
           ) : null}
           {transaction.hasOnchainFee && typeof transaction.onchainFeeSat === "number" ? (
             <TransactionDetailRow
               label="Onchain Fee"
-              value={formatBip177(transaction.onchainFeeSat)}
+              value={formatBitcoinAmount(transaction.onchainFeeSat)}
             />
           ) : null}
           {typeof transaction.confirmationHeight === "number" ? (
@@ -258,19 +263,19 @@ export const TransactionDetailContent = ({
           {typeof transaction.intendedBalanceSat === "number" ? (
             <TransactionDetailRow
               label="Intended Δ"
-              value={formatBip177(transaction.intendedBalanceSat)}
+              value={formatBitcoinAmount(transaction.intendedBalanceSat)}
             />
           ) : null}
           {typeof transaction.effectiveBalanceSat === "number" ? (
             <TransactionDetailRow
               label="Effective Δ"
-              value={formatBip177(transaction.effectiveBalanceSat)}
+              value={formatBitcoinAmount(transaction.effectiveBalanceSat)}
             />
           ) : null}
           {typeof transaction.offchainFeeSat === "number" ? (
             <TransactionDetailRow
               label="Offchain Fee"
-              value={formatBip177(transaction.offchainFeeSat)}
+              value={formatBitcoinAmount(transaction.offchainFeeSat)}
             />
           ) : null}
         </View>

--- a/client/src/screens/TransactionsScreen.tsx
+++ b/client/src/screens/TransactionsScreen.tsx
@@ -15,12 +15,12 @@ import { Result, ResultAsync } from "neverthrow";
 import { CACHES_DIRECTORY_PATH } from "~/constants";
 import RNFSTurbo from "react-native-fs-turbo";
 import logger from "~/lib/log";
-import { formatBip177 } from "~/lib/utils";
 import { useTransactions } from "~/hooks/useTransactions";
 import { HistoryRefreshButton } from "~/components/HistoryRefreshButton";
 import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
 import { TransactionDetailContent } from "~/screens/TransactionDetailScreen";
 import { useProfileStore } from "~/store/profileStore";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 const log = logger("TransactionsScreen");
 
@@ -28,6 +28,7 @@ const TransactionsScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<TransactionsStackParamList>>();
   const parentNavigation = navigation.getParent<NavigationProp<TabParamList>>();
   const iconColor = useIconColor();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const { data: transactions = [], isLoading, isError, isRefetching, refetch } = useTransactions();
   const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
   const [filter, setFilter] = useState<PaymentTypes | "all" | "Lightning">("all");
@@ -234,7 +235,7 @@ const TransactionsScreen = () => {
                                 item.direction === "outgoing" ? "text-red-500" : "text-green-500"
                               }`}
                             >
-                              {`${item.direction === "outgoing" ? "-" : "+"}${formatBip177(item.amount)}`}
+                              {`${item.direction === "outgoing" ? "-" : "+"}${formatBitcoinAmount(item.amount)}`}
                             </Text>
                           </View>
                         </View>

--- a/client/src/screens/UnilateralExitScreen.tsx
+++ b/client/src/screens/UnilateralExitScreen.tsx
@@ -43,7 +43,7 @@ import {
   truncateMiddle,
 } from "~/lib/exitTimeline";
 import { COLORS } from "~/lib/styleConstants";
-import { cn, formatBip177, isNetworkMatch } from "~/lib/utils";
+import { cn, isNetworkMatch } from "~/lib/utils";
 import type { SettingsStackParamList } from "~/Navigators";
 import type {
   ExitProgressState,
@@ -51,6 +51,7 @@ import type {
   ExitStatusResult,
   ExitVtxoResult,
 } from "react-native-nitro-ark";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 type UnilateralExitRouteProp = RouteProp<SettingsStackParamList, "UnilateralExit">;
 type IconName = React.ComponentProps<typeof Icon>["name"];
@@ -263,6 +264,7 @@ const ExitVtxoRow = ({
   currentBlockHeight?: number;
   onPress: () => void;
 }) => {
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const state = status?.state ?? exit.state;
   const details = status?.state_details ?? exit.state_details;
   const historyDetails =
@@ -280,7 +282,7 @@ const ExitVtxoRow = ({
       <View>
         <View className="flex-row items-center justify-between">
           <Text className="text-xl font-semibold text-foreground">
-            {formatBip177(exit.amount_sat)}
+            {formatBitcoinAmount(exit.amount_sat)}
           </Text>
           <View className={cn("rounded-full border px-3 py-1.5", tone.bgClassName)}>
             <Text className={cn("text-sm font-semibold", tone.className)}>
@@ -352,6 +354,7 @@ const UnilateralExitScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList>>();
   const route = useRoute<UnilateralExitRouteProp>();
   const iconColor = useIconColor();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const selectedVtxoIds = route.params?.vtxoIds;
 
   const [destinationAddress, setDestinationAddress] = useState("");
@@ -519,11 +522,14 @@ const UnilateralExitScreen = () => {
                     <ExitSummaryItem label="Tracked" value={`${exits.length}`} />
                     <ExitSummaryItem
                       label="Pending"
-                      value={formatBip177(overview?.pendingTotal ?? 0)}
+                      value={formatBitcoinAmount(overview?.pendingTotal ?? 0)}
                     />
                   </View>
                   <View className="mt-4 flex-row gap-x-4">
-                    <ExitSummaryItem label="Claimable" value={formatBip177(claimableTotal)} />
+                    <ExitSummaryItem
+                      label="Claimable"
+                      value={formatBitcoinAmount(claimableTotal)}
+                    />
                     <ExitSummaryItem label="All Claimable" value={claimableBlockLabel} />
                   </View>
                   <View className="mt-4 flex-row gap-x-4">
@@ -539,7 +545,7 @@ const UnilateralExitScreen = () => {
                     />
                     <ExitSummaryItem
                       label="Available Value"
-                      value={formatBip177(overview?.spendableVtxoTotal ?? 0)}
+                      value={formatBitcoinAmount(overview?.spendableVtxoTotal ?? 0)}
                     />
                   </View>
                 </View>

--- a/client/src/screens/VTXODetailScreen.tsx
+++ b/client/src/screens/VTXODetailScreen.tsx
@@ -10,11 +10,11 @@ import { useState } from "react";
 import { COLORS } from "~/lib/styleConstants";
 import type { BarkVtxo } from "react-native-nitro-ark";
 import { useGetBlockHeight } from "~/hooks/useMarketData";
-import { formatBip177 } from "~/lib/utils";
 import { getMempoolTxUrl } from "~/constants";
 import type { SettingsStackParamList } from "~/Navigators";
 import { useGetExpiringVtxos, useGetVtxos, useRefreshExpiringVtxos } from "~/hooks/useWallet";
 import { StatusBannerStrip } from "~/components/StatusBannerStrip";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 type VTXOWithStatus = BarkVtxo & {
   isExpiring: boolean;
@@ -96,6 +96,7 @@ const VTXODetailScreen = () => {
   const route = useRoute();
   const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList>>();
   const iconColor = useIconColor();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const { data: blockHeight } = useGetBlockHeight();
   const { vtxo: routeVtxo } = route.params as { vtxo: VTXOWithStatus };
   const { data: allVtxos = [] } = useGetVtxos();
@@ -188,7 +189,7 @@ const VTXODetailScreen = () => {
               <Icon name={getVtxoIcon(vtxo)} size={64} color={getVtxoColor(vtxo)} />
             </View>
             <Text className="text-3xl font-bold text-foreground mb-2">
-              {formatBip177(vtxo.amount)}
+              {formatBitcoinAmount(vtxo.amount)}
             </Text>
             <View className="flex-row items-center">
               <Icon name={getStatusIcon(vtxo)} size={20} color={getVtxoColor(vtxo)} />
@@ -199,7 +200,7 @@ const VTXODetailScreen = () => {
           </View>
 
           <View className="bg-card p-4 rounded-lg mb-4">
-            <VTXODetailRow label="Amount" value={formatBip177(vtxo.amount)} />
+            <VTXODetailRow label="Amount" value={formatBitcoinAmount(vtxo.amount)} />
             <VTXODetailRow label="State" value={vtxo.state} />
             <VTXODetailRow label="Status" value={statusLabel} />
             <VTXODetailRow

--- a/client/src/screens/VTXOsScreen.tsx
+++ b/client/src/screens/VTXOsScreen.tsx
@@ -12,8 +12,8 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { SettingsStackParamList } from "~/Navigators";
 import { useGetVtxos, useGetExpiringVtxos } from "~/hooks/useWallet";
 import { BarkVtxo } from "react-native-nitro-ark";
-import { formatBip177 } from "~/lib/utils";
 import { useGetBlockHeight } from "~/hooks/useMarketData";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 
 const EXPIRED_COLOR = "#ef4444";
 const EXPIRING_COLOR = "#f97316";
@@ -30,6 +30,7 @@ const filters: VtxoFilter[] = ["all", "active", "expiring", "expired", "locked"]
 const VTXOsScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList>>();
   const iconColor = useIconColor();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const [filter, setFilter] = useState<VtxoFilter>("all");
 
   const { data: allVtxos = [], isLoading: isLoadingAll } = useGetVtxos();
@@ -196,7 +197,7 @@ const VTXOsScreen = () => {
                       <View className="flex-1">
                         <View className="flex-row justify-between items-center">
                           <Label className="text-foreground text-base">
-                            {formatBip177(item.amount)}
+                            {formatBitcoinAmount(item.amount)}
                           </Label>
                         </View>
                         <Text className="text-muted-foreground text-sm mt-1" numberOfLines={1}>

--- a/client/src/store/profileStore.ts
+++ b/client/src/store/profileStore.ts
@@ -4,6 +4,8 @@ import { mmkv } from "~/lib/mmkv";
 import logger from "~/lib/log";
 import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { isFiatCurrencyCode } from "~/lib/fiatCurrency";
+import type { BitcoinAmountUnit } from "~/lib/bitcoinAmount";
+import { isBitcoinAmountUnit } from "~/lib/bitcoinAmount";
 
 const log = logger("profileStore");
 
@@ -38,8 +40,10 @@ const zustandStorage: StateStorage = {
 interface ProfileState {
   displayName: string;
   preferredCurrency: FiatCurrencyCode;
+  bitcoinAmountUnit: BitcoinAmountUnit;
   setDisplayName: (displayName: string) => void;
   setPreferredCurrency: (preferredCurrency: FiatCurrencyCode) => void;
+  setBitcoinAmountUnit: (bitcoinAmountUnit: BitcoinAmountUnit) => void;
 }
 
 export const useProfileStore = create<ProfileState>()(
@@ -47,8 +51,10 @@ export const useProfileStore = create<ProfileState>()(
     (set) => ({
       displayName: "",
       preferredCurrency: "USD",
+      bitcoinAmountUnit: "bip177",
       setDisplayName: (displayName) => set({ displayName }),
       setPreferredCurrency: (preferredCurrency) => set({ preferredCurrency }),
+      setBitcoinAmountUnit: (bitcoinAmountUnit) => set({ bitcoinAmountUnit }),
     }),
     {
       name: "profile-storage",
@@ -61,6 +67,9 @@ export const useProfileStore = create<ProfileState>()(
           preferredCurrency: isFiatCurrencyCode(state?.preferredCurrency)
             ? state.preferredCurrency
             : "USD",
+          bitcoinAmountUnit: isBitcoinAmountUnit(state?.bitcoinAmountUnit)
+            ? state.bitcoinAmountUnit
+            : "bip177",
         };
       },
     },


### PR DESCRIPTION
## Summary

- Adds a persisted Bitcoin amount display preference with BIP177 as the default and sats as the alternative.
- Adds a Settings > Bitcoin Unit picker backed by the existing MMKV/Zustand profile store.
- Routes wallet amount displays, send/receive summaries, fee estimates, transaction details, emergency exits, and notification text through the selected display unit.

## Validation

- `just check`
- Commit hook reran `bun --cwd client check` successfully.