### PR TITLE
Reduce mailbox session startup writes

### DIFF
--- a/server/src/db/mailbox_authorization_repo.rs
+++ b/server/src/db/mailbox_authorization_repo.rs
@@ -177,6 +177,7 @@ impl<'a> MailboxAuthorizationRepository<'a> {
              UPDATE mailbox_authorizations AS mailbox
              SET lease_owner = $3,
                  lease_expires_at = $5,
+                 last_connected_at = now(),
                  updated_at = now()
              FROM candidates
              WHERE mailbox.pubkey = candidates.pubkey
@@ -235,30 +236,6 @@ impl<'a> MailboxAuthorizationRepository<'a> {
         )
         .bind(pubkey)
         .bind(checkpoint)
-        .bind(auth_version)
-        .bind(worker_id)
-        .execute(self.pool)
-        .await?;
-
-        Ok(result.rows_affected() > 0)
-    }
-
-    pub async fn mark_connected(
-        &self,
-        pubkey: &str,
-        auth_version: i64,
-        worker_id: &str,
-    ) -> Result<bool> {
-        let result = sqlx::query(
-            "UPDATE mailbox_authorizations
-             SET last_connected_at = now(),
-                 status = 'active',
-                 updated_at = now()
-             WHERE pubkey = $1
-               AND auth_version = $2
-               AND lease_owner = $3",
-        )
-        .bind(pubkey)
         .bind(auth_version)
         .bind(worker_id)
         .execute(self.pool)

--- a/server/src/mailbox_worker.rs
+++ b/server/src/mailbox_worker.rs
@@ -425,13 +425,6 @@ where
     T: MailboxTransport + 'static,
 {
     let repo = MailboxAuthorizationRepository::new(&app_state.db_pool);
-    let is_connected = repo
-        .mark_connected(&mailbox.pubkey, mailbox.auth_version, &worker_id)
-        .await?;
-    if !is_connected {
-        return Ok(());
-    }
-
     let session = MailboxSessionContext {
         worker_id: worker_id.clone(),
         stream_idle_reconnect: config.stream_idle_reconnect,

--- a/server/src/tests/gated_auth_tests.rs
+++ b/server/src/tests/gated_auth_tests.rs
@@ -602,6 +602,17 @@ async fn test_claim_runnable_mailboxes_is_exclusive_per_worker() {
     assert_eq!(first_claim.len(), 1);
     assert_eq!(first_claim[0].pubkey, user.pubkey().to_string());
     assert_eq!(second_claim.len(), 0);
+
+    let last_connected_at = sqlx::query_scalar::<_, Option<chrono::DateTime<Utc>>>(
+        "SELECT last_connected_at
+         FROM mailbox_authorizations
+         WHERE pubkey = $1",
+    )
+    .bind(user.pubkey().to_string())
+    .fetch_one(&app_state.db_pool)
+    .await
+    .unwrap();
+    assert!(last_connected_at.is_some());
 }
 
 #[tracing_test::traced_test]


### PR DESCRIPTION
## Summary
- Remove the standalone mailbox mark_connected update that was showing up as a slow query
- Set last_connected_at as part of the existing claim_runnable update instead
- Add coverage that claiming a mailbox records last_connected_at

## Tests
- env -u CARGO_TARGET_DIR cargo fmt --check
- env -u CARGO_TARGET_DIR cargo test -p server mailbox_worker --lib
- env -u CARGO_TARGET_DIR cargo check -p server --bins

## Notes
- The DB-backed gated auth test was attempted twice but local TEST_DATABASE_URL connection acquisition timed out before the test body ran.