### PR TITLE
Add KRW currency support

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -158,6 +158,9 @@ export const msatToSatoshi = (msat: number) => msat / 1000;
 export const mempoolPriceEndpoint = "https://mempool.noderunner.wtf/api/v1/prices";
 export const mempoolHistoricalPriceEndpoint =
   "https://mempool.noderunner.wtf/api/v1/historical-price";
+export const upbitTickerEndpoint = "https://api.upbit.com/v1/ticker";
+export const upbitDailyCandlesEndpoint = "https://api.upbit.com/v1/candles/days";
+export const upbitBtcKrwMarket = "KRW-BTC";
 
 export const getBlockheightEndpoint = () => {
   switch (APP_VARIANT) {

--- a/client/src/hooks/useMarketData.ts
+++ b/client/src/hooks/useMarketData.ts
@@ -2,6 +2,9 @@ import { useQuery } from "@tanstack/react-query";
 import {
   mempoolPriceEndpoint,
   mempoolHistoricalPriceEndpoint,
+  upbitTickerEndpoint,
+  upbitDailyCandlesEndpoint,
+  upbitBtcKrwMarket,
   getBlockheightEndpoint,
   REGTEST_CONFIG,
 } from "~/constants";
@@ -15,7 +18,80 @@ import { APP_VARIANT } from "~/config";
 import type { FiatCurrencyCode, FiatRates } from "~/lib/fiatCurrency";
 import { useProfileStore } from "~/store/profileStore";
 
+type MarketDataProvider = {
+  getCurrentRate: () => ResultAsync<number, Error>;
+  getHistoricalRate: (date: string) => ResultAsync<number, Error>;
+};
+
+type UpbitPriceResponse = Array<{
+  trade_price?: number;
+}>;
+
+const isValidRate = (rate: unknown): rate is number =>
+  typeof rate === "number" && Number.isFinite(rate) && rate > 0;
+
+const getNextUtcDayStartIso = (date: string): string => {
+  const parsedDate = new Date(date);
+  const nextUtcDayStart = new Date(
+    Date.UTC(parsedDate.getUTCFullYear(), parsedDate.getUTCMonth(), parsedDate.getUTCDate() + 1),
+  );
+
+  return nextUtcDayStart.toISOString().replace(".000Z", "Z");
+};
+
+const getUpbitBtcToKrwRate = (): ResultAsync<number, Error> => {
+  return ResultAsync.fromPromise(
+    ky
+      .get(upbitTickerEndpoint, {
+        searchParams: {
+          markets: upbitBtcKrwMarket,
+        },
+      })
+      .json<UpbitPriceResponse>(),
+    (e) => new Error(`Failed to fetch BTC to KRW rate from Upbit: ${e}`),
+  ).andThen((data) => {
+    const rate = data[0]?.trade_price;
+    if (isValidRate(rate)) {
+      return ok(rate);
+    }
+    return err(new Error("Invalid response from Upbit ticker API"));
+  });
+};
+
+const getHistoricalUpbitBtcToKrwRate = (date: string): ResultAsync<number, Error> => {
+  return ResultAsync.fromPromise(
+    ky
+      .get(upbitDailyCandlesEndpoint, {
+        searchParams: {
+          market: upbitBtcKrwMarket,
+          to: getNextUtcDayStartIso(date),
+          count: "1",
+        },
+      })
+      .json<UpbitPriceResponse>(),
+    (e) => new Error(`Failed to fetch historical BTC to KRW rate from Upbit: ${e}`),
+  ).andThen((data) => {
+    const rate = data[0]?.trade_price;
+    if (isValidRate(rate)) {
+      return ok(rate);
+    }
+    return err(new Error("Invalid response from Upbit daily candles API"));
+  });
+};
+
+const CUSTOM_MARKET_DATA_PROVIDERS: Partial<Record<FiatCurrencyCode, MarketDataProvider>> = {
+  KRW: {
+    getCurrentRate: getUpbitBtcToKrwRate,
+    getHistoricalRate: getHistoricalUpbitBtcToKrwRate,
+  },
+};
+
 export const getBtcToFiatRate = (currency: FiatCurrencyCode): ResultAsync<number, Error> => {
+  const customRateProvider = CUSTOM_MARKET_DATA_PROVIDERS[currency]?.getCurrentRate;
+  if (customRateProvider) {
+    return customRateProvider();
+  }
+
   return ResultAsync.fromPromise(
     ky.get(mempoolPriceEndpoint).json<FiatRates>(),
     (e) => new Error(`Failed to fetch BTC to ${currency} rate: ${e}`),
@@ -104,6 +180,15 @@ export const getHistoricalBtcToFiatRate = (
   date: string,
   currency: FiatCurrencyCode,
 ): ResultAsync<number, Error> => {
+  const customHistoricalRateProvider = CUSTOM_MARKET_DATA_PROVIDERS[currency]?.getHistoricalRate;
+
+  if (customHistoricalRateProvider) {
+    return customHistoricalRateProvider(date).orElse((error) => {
+      log.e(`Failed to fetch historical BTC to ${currency} rate:`, [error]);
+      return getBtcToFiatRate(currency);
+    });
+  }
+
   const timestamp = Math.floor(new Date(date).getTime() / 1000);
   return ResultAsync.fromPromise(
     ky

--- a/client/src/lib/fiatCurrency.ts
+++ b/client/src/lib/fiatCurrency.ts
@@ -1,6 +1,15 @@
 import { formatNumber } from "~/lib/utils";
 
-export const SUPPORTED_FIAT_CURRENCIES = ["USD", "EUR", "GBP", "CAD", "CHF", "AUD", "JPY"] as const;
+export const SUPPORTED_FIAT_CURRENCIES = [
+  "USD",
+  "EUR",
+  "GBP",
+  "CAD",
+  "CHF",
+  "AUD",
+  "JPY",
+  "KRW",
+] as const;
 
 export type FiatCurrencyCode = (typeof SUPPORTED_FIAT_CURRENCIES)[number];
 
@@ -19,6 +28,7 @@ export const FIAT_CURRENCY_INFO: Record<FiatCurrencyCode, FiatCurrencyInfo> = {
   CHF: { code: "CHF", name: "Swiss Franc", symbol: "CHF", decimals: 2 },
   AUD: { code: "AUD", name: "Australian Dollar", symbol: "A$", decimals: 2 },
   JPY: { code: "JPY", name: "Japanese Yen", symbol: "¥", decimals: 0 },
+  KRW: { code: "KRW", name: "South Korean Won", symbol: "₩", decimals: 0 },
 };
 
 export type FiatRates = Partial<Record<FiatCurrencyCode, number>>;


### PR DESCRIPTION
## Summary

Adds South Korean won (KRW) as a supported fiat currency.

KRW pricing uses Upbit's KRW-BTC market for both current and historical BTC price lookups. Existing fiat currencies continue to use the existing mempool price APIs.

## Changes

- Add KRW to the supported fiat currency list
- Add KRW metadata with the ₩ symbol and zero decimal places
- Fetch current BTC/KRW rates from Upbit ticker data
- Fetch historical BTC/KRW rates from Upbit daily candle data
- Keep existing mempool price handling for non-KRW currencies