### PR TITLE
[codex] Relax fiat price rate limiting

### DIFF
--- a/client/src/hooks/useMarketData.ts
+++ b/client/src/hooks/useMarketData.ts
@@ -11,6 +11,9 @@ import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { getFiatPrices, getHistoricalFiatPrice } from "~/lib/api";
 import { useProfileStore } from "~/store/profileStore";
 
+const HISTORICAL_RATE_CACHE_MAX_SIZE = 200;
+const historicalBtcToFiatRateCache = new Map<string, Promise<Result<number, Error>>>();
+
 export const getBtcToFiatRate = (currency: FiatCurrencyCode): ResultAsync<number, Error> => {
   return ResultAsync.fromSafePromise(getFiatPrices()).andThen((result) => {
     if (result.isErr()) {
@@ -98,12 +101,34 @@ export function useGetBlockHeight() {
   });
 }
 
-export const getHistoricalBtcToFiatRate = (
+const getHistoricalRateCacheKey = (date: string, currency: FiatCurrencyCode): string => {
+  const timestampMs = new Date(date).getTime();
+  if (Number.isNaN(timestampMs)) {
+    return `${currency}:invalid:${date}`;
+  }
+
+  return `${currency}:${new Date(timestampMs).toISOString().slice(0, 10)}`;
+};
+
+const trimHistoricalRateCache = () => {
+  while (historicalBtcToFiatRateCache.size > HISTORICAL_RATE_CACHE_MAX_SIZE) {
+    const oldestKey = historicalBtcToFiatRateCache.keys().next().value;
+    if (oldestKey === undefined) {
+      return;
+    }
+    historicalBtcToFiatRateCache.delete(oldestKey);
+  }
+};
+
+const fetchHistoricalBtcToFiatRate = async (
   date: string,
   currency: FiatCurrencyCode,
-): ResultAsync<number, Error> => {
+): Promise<Result<number, Error>> => {
   const timestamp = Math.floor(new Date(date).getTime() / 1000);
-  return ResultAsync.fromSafePromise(getHistoricalFiatPrice({ currency, timestamp }))
+  return ResultAsync.fromPromise(
+    getHistoricalFiatPrice({ currency, timestamp }),
+    (e) => e as Error,
+  )
     .andThen((result) => {
       if (result.isErr()) {
         return err(
@@ -124,4 +149,31 @@ export const getHistoricalBtcToFiatRate = (
       // Fallback to current price on error
       return getBtcToFiatRate(currency);
     });
+};
+
+export const getHistoricalBtcToFiatRate = (
+  date: string,
+  currency: FiatCurrencyCode,
+): ResultAsync<number, Error> => {
+  const cacheKey = getHistoricalRateCacheKey(date, currency);
+  const cachedRate = historicalBtcToFiatRateCache.get(cacheKey);
+  if (cachedRate) {
+    return ResultAsync.fromSafePromise(cachedRate).andThen((result) => result);
+  }
+
+  const ratePromise = fetchHistoricalBtcToFiatRate(date, currency);
+  historicalBtcToFiatRateCache.set(cacheKey, ratePromise);
+  trimHistoricalRateCache();
+
+  ratePromise
+    .then((result) => {
+      if (result.isErr()) {
+        historicalBtcToFiatRateCache.delete(cacheKey);
+      }
+    })
+    .catch(() => {
+      historicalBtcToFiatRateCache.delete(cacheKey);
+    });
+
+  return ResultAsync.fromSafePromise(ratePromise).andThen((result) => result);
 };

--- a/client/src/hooks/useMarketData.ts
+++ b/client/src/hooks/useMarketData.ts
@@ -12,7 +12,11 @@ import { getFiatPrices, getHistoricalFiatPrice } from "~/lib/api";
 import { useProfileStore } from "~/store/profileStore";
 
 const HISTORICAL_RATE_CACHE_MAX_SIZE = 200;
-const historicalBtcToFiatRateCache = new Map<string, Promise<Result<number, Error>>>();
+type HistoricalRateLookup = {
+  rate: number;
+  cacheable: boolean;
+};
+const historicalBtcToFiatRateCache = new Map<string, Promise<Result<HistoricalRateLookup, Error>>>();
 
 export const getBtcToFiatRate = (currency: FiatCurrencyCode): ResultAsync<number, Error> => {
   return ResultAsync.fromSafePromise(getFiatPrices()).andThen((result) => {
@@ -123,7 +127,7 @@ const trimHistoricalRateCache = () => {
 const fetchHistoricalBtcToFiatRate = async (
   date: string,
   currency: FiatCurrencyCode,
-): Promise<Result<number, Error>> => {
+): Promise<Result<HistoricalRateLookup, Error>> => {
   const timestamp = Math.floor(new Date(date).getTime() / 1000);
   return ResultAsync.fromPromise(
     getHistoricalFiatPrice({ currency, timestamp }),
@@ -139,15 +143,21 @@ const fetchHistoricalBtcToFiatRate = async (
       const data = result.value;
       const rate = data.rate;
       if (rate) {
-        return ok(rate);
+        return ok({ rate, cacheable: true });
       }
       // If no price is available for that day, fetch the current price as a fallback.
-      return getBtcToFiatRate(currency);
+      return getBtcToFiatRate(currency).map((fallbackRate) => ({
+        rate: fallbackRate,
+        cacheable: false,
+      }));
     })
     .orElse((error) => {
       log.e(`Failed to fetch historical BTC to ${currency} rate:`, [error]);
       // Fallback to current price on error
-      return getBtcToFiatRate(currency);
+      return getBtcToFiatRate(currency).map((fallbackRate) => ({
+        rate: fallbackRate,
+        cacheable: false,
+      }));
     });
 };
 
@@ -158,7 +168,9 @@ export const getHistoricalBtcToFiatRate = (
   const cacheKey = getHistoricalRateCacheKey(date, currency);
   const cachedRate = historicalBtcToFiatRateCache.get(cacheKey);
   if (cachedRate) {
-    return ResultAsync.fromSafePromise(cachedRate).andThen((result) => result);
+    return ResultAsync.fromSafePromise(cachedRate).andThen((result) =>
+      result.map(({ rate }) => rate),
+    );
   }
 
   const ratePromise = fetchHistoricalBtcToFiatRate(date, currency);
@@ -167,7 +179,7 @@ export const getHistoricalBtcToFiatRate = (
 
   ratePromise
     .then((result) => {
-      if (result.isErr()) {
+      if (result.isErr() || !result.value.cacheable) {
         historicalBtcToFiatRateCache.delete(cacheKey);
       }
     })
@@ -175,5 +187,7 @@ export const getHistoricalBtcToFiatRate = (
       historicalBtcToFiatRateCache.delete(cacheKey);
     });
 
-  return ResultAsync.fromSafePromise(ratePromise).andThen((result) => result);
+  return ResultAsync.fromSafePromise(ratePromise).andThen((result) =>
+    result.map(({ rate }) => rate),
+  );
 };

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -250,6 +250,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     let public_rate_limiter = rate_limit::create_public_rate_limiter();
     let auth_login_rate_limiter = rate_limit::create_public_rate_limiter();
     let auth_rate_limiter = rate_limit::create_auth_rate_limiter();
+    let fiat_rate_limiter = rate_limit::create_fiat_rate_limiter();
 
     // Optional email setup routes need auth and a registered user.
     let email_verification_router = Router::new()
@@ -259,8 +260,6 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     // Gated routes need auth and a registered user. Email is optional.
     let gated_router = Router::new()
-        .route("/prices", post(fiat_prices))
-        .route("/historical-price", post(historical_fiat_price))
         .route("/register_push_token", post(register_push_token))
         .route("/mailbox/authorize", post(authorize_mailbox))
         .route("/mailbox/revoke", post(revoke_mailbox_authorization))
@@ -279,7 +278,16 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         .route("/report_job_status", post(report_job_status))
         .route("/heartbeat_response", post(heartbeat_response))
         .route("/report_last_login", post(report_last_login))
-        .layer(user_exists_layer);
+        .layer(user_exists_layer.clone());
+
+    // Fiat routes need auth and a registered user, but use their own limiter so
+    // wallet history price lookups do not consume the general authenticated API bucket.
+    let fiat_router = Router::new()
+        .route("/prices", post(fiat_prices))
+        .route("/historical-price", post(historical_fiat_price))
+        .layer(user_exists_layer)
+        .layer(fiat_rate_limiter)
+        .layer(auth_layer.clone());
 
     // Routes that need auth but user may not exist (like registration)
     // Apply auth rate limiter to these routes
@@ -298,6 +306,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
             post(auth_login).layer(auth_login_rate_limiter),
         )
         .route("/app_version", post(check_app_version))
+        .merge(fiat_router)
         .merge(bearer_router);
 
     // Public route

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -35,3 +35,17 @@ pub fn create_auth_rate_limiter() -> RateLimiter {
 
     GovernorLayer::new(config)
 }
+
+/// Creates a rate limiting layer for authenticated fiat price endpoints.
+/// These endpoints read cached server-side data, so allow a larger burst than the
+/// general authenticated API without loosening unrelated protected routes.
+pub fn create_fiat_rate_limiter() -> RateLimiter {
+    let config = GovernorConfigBuilder::default()
+        .per_second(20)
+        .burst_size(300)
+        .key_extractor(SmartIpKeyExtractor)
+        .finish()
+        .expect("Failed to create rate limiter config");
+
+    GovernorLayer::new(config)
+}

--- a/server/src/tests/common.rs
+++ b/server/src/tests/common.rs
@@ -168,8 +168,6 @@ pub async fn setup_test_app() -> (Router, AppState, TestDbGuard) {
 
     // Gated routes that need auth AND user to exist in database
     let gated_router = Router::new()
-        .route("/prices", post(fiat_prices))
-        .route("/historical-price", post(historical_fiat_price))
         .route("/register_push_token", post(register_push_token))
         .route("/mailbox/authorize", post(authorize_mailbox))
         .route("/mailbox/revoke", post(revoke_mailbox_authorization))
@@ -188,7 +186,13 @@ pub async fn setup_test_app() -> (Router, AppState, TestDbGuard) {
         .route("/report_job_status", post(report_job_status))
         .route("/heartbeat_response", post(heartbeat_response))
         .route("/report_last_login", post(report_last_login))
-        .layer(user_exists_layer);
+        .layer(user_exists_layer.clone());
+
+    let fiat_router = Router::new()
+        .route("/prices", post(fiat_prices))
+        .route("/historical-price", post(historical_fiat_price))
+        .layer(user_exists_layer)
+        .layer(auth_layer.clone());
 
     // Routes that need auth but user may not exist (like registration)
     let auth_router = Router::new()
@@ -200,6 +204,7 @@ pub async fn setup_test_app() -> (Router, AppState, TestDbGuard) {
     let app = Router::new()
         .route("/getk1", axum::routing::get(get_k1))
         .route("/auth/login", post(auth_login))
+        .merge(fiat_router)
         .merge(auth_router)
         .with_state(app_state.clone());
 

--- a/server/src/tests/public_api_v0.rs
+++ b/server/src/tests/public_api_v0.rs
@@ -324,6 +324,39 @@ async fn test_fiat_prices_requires_authentication() {
 
 #[tracing_test::traced_test]
 #[tokio::test]
+async fn test_fiat_prices_requires_registered_user() {
+    let (app, app_state, _guard) = setup_test_app().await;
+    let user = TestUser::new();
+    let access_token = user.access_token(&app_state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/prices")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::from(
+                    serde_json::to_vec(&FiatPricesPayload {}).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let res: ApiErrorResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(res.code, "USER_NOT_FOUND");
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
 async fn test_fiat_prices_returns_cached_typed_response() {
     let (app, app_state, _guard) = setup_test_app().await;
     let user = TestUser::new();


### PR DESCRIPTION
## Summary

- move fiat price endpoints onto a dedicated authenticated rate limiter
- keep auth and registered-user gating on `/v0/prices` and `/v0/historical-price`
- dedupe client historical fiat price lookups by currency and UTC day

## Why

The fiat endpoints previously shared the general authenticated API limiter. A burst of historical price lookups from wallet history could drain that shared IP-keyed bucket and cause unrelated authenticated calls, including `/v0/prices`, to receive 429 responses.

## Validation

- `bun run lint`
- `bun run typecheck`
- `cargo fmt --check`
- `cargo test -p server fiat_price`