### PR TITLE
[codex] Validate mailbox auth and expire stale rows

### DIFF
--- a/server/src/bin/cli.rs
+++ b/server/src/bin/cli.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use expo_push_notification_client::{Expo, ExpoClientOptions, ExpoPushMessage, Sound};
 use server::config::Config;
+use server::mailbox_auth::backfill_mailbox_authorizations;
 use sqlx::postgres::PgPoolOptions;
 
 #[derive(Parser)]
@@ -47,6 +48,13 @@ enum Commands {
         domain: Option<String>,
 
         /// Dry run - print generated users without inserting
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
+    },
+
+    /// Validate and normalize existing active mailbox authorizations
+    BackfillMailboxAuth {
+        /// Dry run - classify rows without updating the database
         #[arg(long, default_value_t = false)]
         dry_run: bool,
     },
@@ -291,6 +299,28 @@ async fn cmd_seed_users(
     Ok(())
 }
 
+async fn cmd_backfill_mailbox_auth(config: &Config, dry_run: bool) -> Result<()> {
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&config.postgres_url)
+        .await
+        .context("Failed to connect to database")?;
+
+    let report = backfill_mailbox_authorizations(&pool, dry_run)
+        .await
+        .context("Failed to backfill mailbox authorizations")?;
+
+    println!("Mailbox authorization backfill complete");
+    println!("  dry_run: {}", dry_run);
+    println!("  checked: {}", report.checked);
+    println!("  valid: {}", report.valid);
+    println!("  normalized: {}", report.normalized);
+    println!("  expired: {}", report.expired);
+    println!("  invalid: {}", report.invalid);
+
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -315,6 +345,9 @@ async fn main() -> Result<()> {
             dry_run,
         } => {
             cmd_seed_users(&config, count, start_index, domain, dry_run).await?;
+        }
+        Commands::BackfillMailboxAuth { dry_run } => {
+            cmd_backfill_mailbox_auth(&config, dry_run).await?;
         }
     }
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub heartbeat_cron: String,
     pub deregister_cron: String,
     pub fiat_rate_refresh_cron: String,
+    pub mailbox_auth_cleanup_cron: String,
     pub fiat_rate_backfill_days: u64,
     pub coingecko_demo_api_key: Option<String>,
     pub notification_spacing_minutes: i64,
@@ -89,6 +90,8 @@ impl Config {
                 .unwrap_or_else(|_| "every 12 hours".to_string()),
             fiat_rate_refresh_cron: std::env::var("FIAT_RATE_REFRESH_CRON")
                 .unwrap_or_else(|_| "every 5 minutes".to_string()),
+            mailbox_auth_cleanup_cron: std::env::var("MAILBOX_AUTH_CLEANUP_CRON")
+                .unwrap_or_else(|_| "every 10 minutes".to_string()),
             fiat_rate_backfill_days: std::env::var("FIAT_RATE_BACKFILL_DAYS")
                 .ok()
                 .and_then(|v| v.parse().ok())
@@ -183,6 +186,10 @@ impl Config {
         tracing::debug!("Heartbeat Cron: {}", self.heartbeat_cron);
         tracing::debug!("Deregister Cron: {}", self.deregister_cron);
         tracing::debug!("Fiat Rate Refresh Cron: {}", self.fiat_rate_refresh_cron);
+        tracing::debug!(
+            "Mailbox Auth Cleanup Cron: {}",
+            self.mailbox_auth_cleanup_cron
+        );
         tracing::debug!("Fiat Rate Backfill Days: {}", self.fiat_rate_backfill_days);
         tracing::debug!(
             "CoinGecko Demo API Key: {}",

--- a/server/src/cron.rs
+++ b/server/src/cron.rs
@@ -184,6 +184,22 @@ pub async fn timeout_stale_pending_heartbeats(app_state: AppState) -> anyhow::Re
     Ok(())
 }
 
+pub async fn mark_expired_mailbox_authorizations(app_state: AppState) -> anyhow::Result<()> {
+    let affected = MailboxAuthorizationRepository::new(&app_state.db_pool)
+        .mark_expired_authorizations(chrono::Utc::now().timestamp())
+        .await?;
+
+    if affected > 0 {
+        tracing::info!(
+            job = "mailbox_auth_expiry",
+            updated_count = affected,
+            "marked expired mailbox authorizations"
+        );
+    }
+
+    Ok(())
+}
+
 pub async fn refresh_fiat_rates(app_state: AppState) -> anyhow::Result<()> {
     let mut conn = app_state.db_pool.acquire().await?;
     let lock_acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
@@ -226,6 +242,7 @@ pub async fn cron_scheduler(
     heartbeat_cron: String,
     deregister_cron: String,
     fiat_rate_refresh_cron: String,
+    mailbox_auth_cleanup_cron: String,
 ) -> anyhow::Result<JobScheduler> {
     let sched = JobScheduler::new().await?;
 
@@ -235,6 +252,7 @@ pub async fn cron_scheduler(
         heartbeat_schedule = %heartbeat_cron,
         deregister_schedule = %deregister_cron,
         fiat_rate_refresh_schedule = %fiat_rate_refresh_cron,
+        mailbox_auth_cleanup_schedule = %mailbox_auth_cleanup_cron,
         stale_pending_job_cleanup_schedule = %STALE_PENDING_JOB_SWEEP_SCHEDULE,
         stale_pending_job_timeout_minutes = STALE_PENDING_JOB_TIMEOUT_MINUTES,
         stale_pending_heartbeat_cleanup_schedule = %STALE_PENDING_HEARTBEAT_SWEEP_SCHEDULE,
@@ -287,6 +305,17 @@ pub async fn cron_scheduler(
         })
     })?;
     sched.add(fiat_rate_refresh_job).await?;
+
+    let mailbox_auth_cleanup_state = app_state.clone();
+    let mailbox_auth_cleanup_job = Job::new_async(&mailbox_auth_cleanup_cron, move |_, _| {
+        let app_state = mailbox_auth_cleanup_state.clone();
+        Box::pin(async move {
+            if let Err(e) = mark_expired_mailbox_authorizations(app_state).await {
+                tracing::error!(job = "mailbox_auth_expiry", error = %e, "job failed");
+            }
+        })
+    })?;
+    sched.add(mailbox_auth_cleanup_job).await?;
 
     // Mark stale pending job reports as timeout
     let stale_pending_job_cleanup_state = app_state.clone();

--- a/server/src/db/mailbox_authorization_repo.rs
+++ b/server/src/db/mailbox_authorization_repo.rs
@@ -29,6 +29,15 @@ pub struct BulkRenewMailboxClaim {
     pub renewed: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, FromRow)]
+pub struct MailboxAuthorizationBackfillCandidate {
+    pub pubkey: String,
+    pub mailbox_id: String,
+    pub authorization_hex: String,
+    pub authorization_expires_at: i64,
+    pub auth_version: i64,
+}
+
 impl<'a> MailboxAuthorizationRepository<'a> {
     pub fn new(pool: &'a PgPool) -> Self {
         Self { pool }
@@ -115,6 +124,7 @@ impl<'a> MailboxAuthorizationRepository<'a> {
                 FROM mailbox_authorizations
                 WHERE pubkey = $1
                   AND enabled = TRUE
+                  AND status = 'active'
                   AND authorization_hex IS NOT NULL
                   AND authorization_expires_at IS NOT NULL
                   AND authorization_expires_at > $2
@@ -369,6 +379,148 @@ impl<'a> MailboxAuthorizationRepository<'a> {
         .bind(last_error)
         .bind(auth_version)
         .bind(worker_id)
+        .execute(self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn mark_expired_authorizations(&self, now: i64) -> Result<u64> {
+        let result = sqlx::query(
+            "UPDATE mailbox_authorizations
+             SET status = 'expired',
+                 last_error = 'mailbox authorization expired',
+                 lease_owner = NULL,
+                 lease_expires_at = NULL,
+                 next_retry_at = NULL,
+                 updated_at = now()
+             WHERE enabled = TRUE
+               AND status = 'active'
+               AND authorization_expires_at IS NOT NULL
+               AND authorization_expires_at <= $1",
+        )
+        .bind(now)
+        .execute(self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+
+    pub async fn find_active_authorizations_for_backfill(
+        &self,
+    ) -> Result<Vec<MailboxAuthorizationBackfillCandidate>> {
+        let records = sqlx::query_as::<_, MailboxAuthorizationBackfillCandidate>(
+            "SELECT
+                pubkey,
+                mailbox_id,
+                authorization_hex,
+                authorization_expires_at,
+                auth_version
+             FROM mailbox_authorizations
+             WHERE enabled = TRUE
+               AND status = 'active'
+               AND authorization_hex IS NOT NULL
+               AND authorization_expires_at IS NOT NULL
+             ORDER BY updated_at ASC",
+        )
+        .fetch_all(self.pool)
+        .await?;
+
+        Ok(records)
+    }
+
+    pub async fn normalize_authorization(
+        &self,
+        pubkey: &str,
+        auth_version: i64,
+        mailbox_id: &str,
+        authorization_expires_at: i64,
+        authorization_hex: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE mailbox_authorizations
+             SET mailbox_id = $3,
+                 authorization_expires_at = $4,
+                 authorization_hex = $5,
+                 failure_count = 0,
+                 last_error = NULL,
+                 lease_owner = NULL,
+                 lease_expires_at = NULL,
+                 next_retry_at = NULL,
+                 status = 'active',
+                 updated_at = now()
+             WHERE pubkey = $1
+               AND auth_version = $2
+               AND enabled = TRUE
+               AND status = 'active'",
+        )
+        .bind(pubkey)
+        .bind(auth_version)
+        .bind(mailbox_id)
+        .bind(authorization_expires_at)
+        .bind(authorization_hex)
+        .execute(self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn mark_backfill_expired(
+        &self,
+        pubkey: &str,
+        auth_version: i64,
+        mailbox_id: Option<&str>,
+        authorization_expires_at: Option<i64>,
+        last_error: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE mailbox_authorizations
+             SET mailbox_id = COALESCE($3, mailbox_id),
+                 authorization_expires_at = COALESCE($4, authorization_expires_at),
+                 status = 'expired',
+                 last_error = $5,
+                 lease_owner = NULL,
+                 lease_expires_at = NULL,
+                 next_retry_at = NULL,
+                 updated_at = now()
+             WHERE pubkey = $1
+               AND auth_version = $2
+               AND enabled = TRUE
+               AND status = 'active'",
+        )
+        .bind(pubkey)
+        .bind(auth_version)
+        .bind(mailbox_id)
+        .bind(authorization_expires_at)
+        .bind(last_error)
+        .execute(self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn mark_backfill_invalid(
+        &self,
+        pubkey: &str,
+        auth_version: i64,
+        last_error: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE mailbox_authorizations
+             SET status = 'invalid',
+                 last_error = $3,
+                 lease_owner = NULL,
+                 lease_expires_at = NULL,
+                 next_retry_at = NULL,
+                 updated_at = now()
+             WHERE pubkey = $1
+               AND auth_version = $2
+               AND enabled = TRUE
+               AND status = 'active'",
+        )
+        .bind(pubkey)
+        .bind(auth_version)
+        .bind(last_error)
         .execute(self.pool)
         .await?;
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod db;
 pub mod email_client;
 pub mod errors;
+pub mod mailbox_auth;
 pub mod mailbox_worker;
 pub mod push;
 pub mod types;

--- a/server/src/mailbox_auth.rs
+++ b/server/src/mailbox_auth.rs
@@ -1,0 +1,224 @@
+use ark::{ProtocolEncoding, mailbox::MailboxAuthorization};
+use chrono::Utc;
+use sqlx::PgPool;
+
+use crate::{
+    db::mailbox_authorization_repo::{
+        MailboxAuthorizationBackfillCandidate, MailboxAuthorizationRepository,
+    },
+    errors::ApiError,
+    types::AuthorizeMailboxPayload,
+};
+
+#[allow(dead_code)]
+const MAILBOX_AUTH_EXPIRED_ERROR: &str = "mailbox authorization expired";
+#[allow(dead_code)]
+const MAILBOX_AUTH_INVALID_ERROR: &str = "mailbox authorization invalid";
+#[allow(dead_code)]
+const MAILBOX_AUTH_MISMATCH_ERROR: &str = "mailbox authorization does not match stored mailbox";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedMailboxAuthorization {
+    pub mailbox_id: String,
+    pub authorization_hex: String,
+    pub authorization_expires_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[allow(dead_code)]
+pub struct MailboxAuthorizationBackfillReport {
+    pub checked: usize,
+    pub valid: usize,
+    pub normalized: usize,
+    pub expired: usize,
+    pub invalid: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+enum MailboxAuthorizationBackfillAction {
+    Valid,
+    Normalize {
+        mailbox_id: String,
+        authorization_expires_at: i64,
+        authorization_hex: String,
+    },
+    Expired {
+        mailbox_id: Option<String>,
+        authorization_expires_at: Option<i64>,
+        last_error: String,
+    },
+    Invalid {
+        last_error: String,
+    },
+}
+
+pub fn validate_authorize_mailbox_payload(
+    payload: &AuthorizeMailboxPayload,
+    now: i64,
+    max_ttl_secs: i64,
+) -> Result<ValidatedMailboxAuthorization, ApiError> {
+    let authorization = decode_mailbox_authorization(&payload.encoded)?;
+    if !authorization.verify() {
+        return Err(ApiError::InvalidArgument(
+            "Mailbox authorization signature is invalid".to_string(),
+        ));
+    }
+
+    let mailbox_id = authorization.mailbox().serialize_hex();
+    if !mailbox_id.eq_ignore_ascii_case(&payload.mailbox_id) {
+        return Err(ApiError::InvalidArgument(
+            "Mailbox authorization does not match mailbox ID".to_string(),
+        ));
+    }
+
+    let embedded_expiry = authorization.expiry().timestamp();
+    if embedded_expiry != payload.expiry {
+        return Err(ApiError::InvalidArgument(
+            "Mailbox authorization expiry does not match encoded authorization".to_string(),
+        ));
+    }
+
+    if embedded_expiry <= now {
+        return Err(ApiError::InvalidArgument(
+            "Mailbox authorization expiry must be a future Unix timestamp".to_string(),
+        ));
+    }
+
+    if embedded_expiry > now + max_ttl_secs {
+        return Err(ApiError::InvalidArgument(
+            "Mailbox authorization expiry exceeds maximum allowed TTL".to_string(),
+        ));
+    }
+
+    Ok(ValidatedMailboxAuthorization {
+        mailbox_id,
+        authorization_hex: authorization.serialize_hex(),
+        authorization_expires_at: embedded_expiry,
+    })
+}
+
+#[allow(dead_code)]
+pub async fn backfill_mailbox_authorizations(
+    pool: &PgPool,
+    dry_run: bool,
+) -> anyhow::Result<MailboxAuthorizationBackfillReport> {
+    let repo = MailboxAuthorizationRepository::new(pool);
+    let candidates = repo.find_active_authorizations_for_backfill().await?;
+    let now = Utc::now().timestamp();
+    let mut report = MailboxAuthorizationBackfillReport {
+        checked: candidates.len(),
+        ..Default::default()
+    };
+
+    for candidate in candidates {
+        match classify_backfill_candidate(&candidate, now) {
+            MailboxAuthorizationBackfillAction::Valid => {
+                report.valid += 1;
+            }
+            MailboxAuthorizationBackfillAction::Normalize {
+                mailbox_id,
+                authorization_expires_at,
+                authorization_hex,
+            } => {
+                report.normalized += 1;
+                if !dry_run {
+                    repo.normalize_authorization(
+                        &candidate.pubkey,
+                        candidate.auth_version,
+                        &mailbox_id,
+                        authorization_expires_at,
+                        &authorization_hex,
+                    )
+                    .await?;
+                }
+            }
+            MailboxAuthorizationBackfillAction::Expired {
+                mailbox_id,
+                authorization_expires_at,
+                last_error,
+            } => {
+                report.expired += 1;
+                if !dry_run {
+                    repo.mark_backfill_expired(
+                        &candidate.pubkey,
+                        candidate.auth_version,
+                        mailbox_id.as_deref(),
+                        authorization_expires_at,
+                        &last_error,
+                    )
+                    .await?;
+                }
+            }
+            MailboxAuthorizationBackfillAction::Invalid { last_error } => {
+                report.invalid += 1;
+                if !dry_run {
+                    repo.mark_backfill_invalid(
+                        &candidate.pubkey,
+                        candidate.auth_version,
+                        &last_error,
+                    )
+                    .await?;
+                }
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+fn decode_mailbox_authorization(encoded: &str) -> Result<MailboxAuthorization, ApiError> {
+    MailboxAuthorization::deserialize_hex(encoded).map_err(|_| {
+        ApiError::InvalidArgument("Mailbox authorization must be valid protocol hex".to_string())
+    })
+}
+
+#[allow(dead_code)]
+fn classify_backfill_candidate(
+    candidate: &MailboxAuthorizationBackfillCandidate,
+    now: i64,
+) -> MailboxAuthorizationBackfillAction {
+    let authorization = match MailboxAuthorization::deserialize_hex(&candidate.authorization_hex) {
+        Ok(authorization) => authorization,
+        Err(error) => {
+            return MailboxAuthorizationBackfillAction::Invalid {
+                last_error: format!("{MAILBOX_AUTH_INVALID_ERROR}: {error}"),
+            };
+        }
+    };
+
+    if !authorization.verify() {
+        return MailboxAuthorizationBackfillAction::Invalid {
+            last_error: "mailbox authorization signature is invalid".to_string(),
+        };
+    }
+
+    let mailbox_id = authorization.mailbox().serialize_hex();
+    let embedded_expiry = authorization.expiry().timestamp();
+    if !mailbox_id.eq_ignore_ascii_case(&candidate.mailbox_id) {
+        return MailboxAuthorizationBackfillAction::Invalid {
+            last_error: MAILBOX_AUTH_MISMATCH_ERROR.to_string(),
+        };
+    }
+
+    if embedded_expiry <= now {
+        return MailboxAuthorizationBackfillAction::Expired {
+            mailbox_id: Some(mailbox_id),
+            authorization_expires_at: Some(embedded_expiry),
+            last_error: MAILBOX_AUTH_EXPIRED_ERROR.to_string(),
+        };
+    }
+
+    if candidate.mailbox_id != mailbox_id
+        || candidate.authorization_expires_at != embedded_expiry
+        || candidate.authorization_hex != authorization.serialize_hex()
+    {
+        return MailboxAuthorizationBackfillAction::Normalize {
+            mailbox_id,
+            authorization_expires_at: embedded_expiry,
+            authorization_hex: authorization.serialize_hex(),
+        };
+    }
+
+    MailboxAuthorizationBackfillAction::Valid
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -49,6 +49,7 @@ pub mod db;
 mod email_client;
 mod errors;
 mod fiat_rates;
+mod mailbox_auth;
 mod mailbox_worker;
 mod notification_coordinator;
 mod push;
@@ -185,12 +186,14 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     let heartbeat_cron = config.heartbeat_cron.clone();
     let deregister_cron = config.deregister_cron.clone();
     let fiat_rate_refresh_cron = config.fiat_rate_refresh_cron.clone();
+    let mailbox_auth_cleanup_cron = config.mailbox_auth_cleanup_cron.clone();
     let cron_handle = cron_scheduler(
         app_state.clone(),
         backup_cron,
         heartbeat_cron,
         deregister_cron,
         fiat_rate_refresh_cron,
+        mailbox_auth_cleanup_cron,
     )
     .await?;
 

--- a/server/src/routes/gated_api_v0.rs
+++ b/server/src/routes/gated_api_v0.rs
@@ -17,6 +17,7 @@ use crate::types::{
 use crate::{
     AppState,
     errors::ApiError,
+    mailbox_auth::validate_authorize_mailbox_payload,
     types::{
         AuthenticatedUser, GetUploadUrlPayload, RegisterPushToken, UpdateLnAddressPayload,
         UploadUrlResponse,
@@ -137,43 +138,27 @@ pub async fn authorize_mailbox(
         .validate()
         .map_err(|e| ApiError::InvalidArgument(e.to_string()))?;
 
-    let now = Utc::now().timestamp();
-    if payload.expiry <= now {
-        return Err(ApiError::InvalidArgument(
-            "Mailbox authorization expiry must be a future Unix timestamp".to_string(),
-        ));
-    }
-
-    if payload.expiry > now + MAX_MAILBOX_AUTH_TTL_SECS {
-        return Err(ApiError::InvalidArgument(
-            "Mailbox authorization expiry exceeds maximum allowed TTL".to_string(),
-        ));
-    }
-
-    if hex::decode(&payload.mailbox_id).is_err() {
-        return Err(ApiError::InvalidArgument(
-            "Mailbox ID must be valid hex".to_string(),
-        ));
-    }
-
-    if hex::decode(&payload.encoded).is_err() {
-        return Err(ApiError::InvalidArgument(
-            "Mailbox authorization must be valid hex".to_string(),
-        ));
-    }
+    let validated = validate_authorize_mailbox_payload(
+        &payload,
+        Utc::now().timestamp(),
+        MAX_MAILBOX_AUTH_TTL_SECS,
+    )?;
 
     if let Some(Extension(event)) = event {
         event.add_context("has_mailbox_authorization", true);
-        event.add_context("mailbox_authorization_expiry", payload.expiry);
+        event.add_context(
+            "mailbox_authorization_expiry",
+            validated.authorization_expires_at,
+        );
     }
 
     let mailbox_repo = MailboxAuthorizationRepository::new(&app_state.db_pool);
     mailbox_repo
         .upsert(
             &auth_payload.key,
-            &payload.mailbox_id,
-            &payload.encoded,
-            payload.expiry,
+            &validated.mailbox_id,
+            &validated.authorization_hex,
+            validated.authorization_expires_at,
         )
         .await?;
 

--- a/server/src/tests/common.rs
+++ b/server/src/tests/common.rs
@@ -88,6 +88,7 @@ impl TestUser {
             heartbeat_cron: "0 0 * * *".to_string(),
             deregister_cron: "0 0 * * *".to_string(),
             fiat_rate_refresh_cron: "0 0 * * *".to_string(),
+            mailbox_auth_cleanup_cron: "0 0 * * *".to_string(),
             fiat_rate_backfill_days: 60,
             coingecko_demo_api_key: None,
             notification_spacing_minutes: 45,

--- a/server/src/tests/gated_auth_tests.rs
+++ b/server/src/tests/gated_auth_tests.rs
@@ -1,6 +1,8 @@
+use ark::{ProtocolEncoding, mailbox::MailboxAuthorization};
 use axum::body::Body;
 use axum::http::{self, Request, StatusCode};
-use chrono::Utc;
+use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+use chrono::{Duration, Local, Utc};
 use http_body_util::BodyExt;
 use serde_json::json;
 use tower::ServiceExt;
@@ -8,6 +10,19 @@ use tower::ServiceExt;
 use crate::tests::common::{TestUser, create_test_user, setup_test_app};
 use crate::types::{AuthLoginResponse, RegisterResponse};
 use crate::utils::make_k1;
+
+fn test_mailbox_authorization(expiry: chrono::DateTime<Local>) -> (String, i64, String) {
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[0x42; 32]).unwrap();
+    let mailbox_key = Keypair::from_secret_key(&secp, &secret_key);
+    let authorization = MailboxAuthorization::new(&mailbox_key, expiry);
+
+    (
+        authorization.mailbox().serialize_hex(),
+        authorization.expiry().timestamp(),
+        authorization.serialize_hex(),
+    )
+}
 
 #[tracing_test::traced_test]
 #[tokio::test]
@@ -317,6 +332,8 @@ async fn test_authorize_mailbox() {
     let user = TestUser::new();
     let access_token = user.access_token(&app_state);
     create_test_user(&app_state, &user, None).await;
+    let (mailbox_id, expiry, encoded) =
+        test_mailbox_authorization(Local::now() + Duration::seconds(60));
 
     let response = app
         .oneshot(
@@ -330,9 +347,9 @@ async fn test_authorize_mailbox() {
                 )
                 .body(Body::from(
                     serde_json::to_vec(&json!({
-                        "mailbox_id": "deadbeef",
-                        "expiry": Utc::now().timestamp() + 60,
-                        "encoded": "cafebabe"
+                        "mailbox_id": &mailbox_id,
+                        "expiry": expiry,
+                        "encoded": &encoded
                     }))
                     .unwrap(),
                 ))
@@ -351,8 +368,8 @@ async fn test_authorize_mailbox() {
         .unwrap()
         .unwrap();
 
-    assert_eq!(record.mailbox_id, "deadbeef");
-    assert_eq!(record.authorization_hex, "cafebabe");
+    assert_eq!(record.mailbox_id, mailbox_id);
+    assert_eq!(record.authorization_hex, encoded);
     assert!(record.authorization_expires_at > Utc::now().timestamp());
     assert_eq!(record.auth_version, 1);
     assert_eq!(record.last_checkpoint, 0);
@@ -407,6 +424,8 @@ async fn test_authorize_mailbox_rejects_invalid_mailbox_id_hex() {
     let user = TestUser::new();
     let access_token = user.access_token(&app_state);
     create_test_user(&app_state, &user, None).await;
+    let (_mailbox_id, expiry, encoded) =
+        test_mailbox_authorization(Local::now() + Duration::seconds(60));
 
     let response = app
         .oneshot(
@@ -421,8 +440,8 @@ async fn test_authorize_mailbox_rejects_invalid_mailbox_id_hex() {
                 .body(Body::from(
                     serde_json::to_vec(&json!({
                         "mailbox_id": "mailbox-123",
-                        "expiry": Utc::now().timestamp() + 60,
-                        "encoded": "deadbeef"
+                        "expiry": expiry,
+                        "encoded": &encoded
                     }))
                     .unwrap(),
                 ))
@@ -449,6 +468,8 @@ async fn test_authorize_mailbox_rejects_past_expiry() {
     let user = TestUser::new();
     let access_token = user.access_token(&app_state);
     create_test_user(&app_state, &user, None).await;
+    let (mailbox_id, expiry, encoded) =
+        test_mailbox_authorization(Local::now() - Duration::seconds(60));
 
     let response = app
         .oneshot(
@@ -462,9 +483,9 @@ async fn test_authorize_mailbox_rejects_past_expiry() {
                 )
                 .body(Body::from(
                     serde_json::to_vec(&json!({
-                        "mailbox_id": "deadbeef",
-                        "expiry": Utc::now().timestamp() - 60,
-                        "encoded": "deadbeef"
+                        "mailbox_id": &mailbox_id,
+                        "expiry": expiry,
+                        "encoded": &encoded
                     }))
                     .unwrap(),
                 ))
@@ -485,6 +506,8 @@ async fn test_authorize_mailbox_rejects_expiry_beyond_max_ttl() {
     create_test_user(&app_state, &user, None).await;
 
     let max_ttl_secs = 90 * 24 * 60 * 60;
+    let (mailbox_id, expiry, encoded) =
+        test_mailbox_authorization(Local::now() + Duration::seconds(max_ttl_secs + 1));
 
     let response = app
         .oneshot(
@@ -498,9 +521,85 @@ async fn test_authorize_mailbox_rejects_expiry_beyond_max_ttl() {
                 )
                 .body(Body::from(
                     serde_json::to_vec(&json!({
-                        "mailbox_id": "deadbeef",
-                        "expiry": Utc::now().timestamp() + max_ttl_secs + 1,
-                        "encoded": "deadbeef"
+                        "mailbox_id": &mailbox_id,
+                        "expiry": expiry,
+                        "encoded": &encoded
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_authorize_mailbox_rejects_expiry_mismatch() {
+    let (app, app_state, _guard) = setup_test_app().await;
+    let user = TestUser::new();
+    let access_token = user.access_token(&app_state);
+    create_test_user(&app_state, &user, None).await;
+    let (mailbox_id, expiry, encoded) =
+        test_mailbox_authorization(Local::now() + Duration::seconds(60));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/mailbox/authorize")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "mailbox_id": &mailbox_id,
+                        "expiry": expiry + 1,
+                        "encoded": &encoded
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_authorize_mailbox_rejects_invalid_signature() {
+    let (app, app_state, _guard) = setup_test_app().await;
+    let user = TestUser::new();
+    let access_token = user.access_token(&app_state);
+    create_test_user(&app_state, &user, None).await;
+    let (mailbox_id, expiry, encoded) =
+        test_mailbox_authorization(Local::now() + Duration::seconds(60));
+    let mut encoded_bytes = hex::decode(&encoded).unwrap();
+    let last_index = encoded_bytes.len() - 1;
+    encoded_bytes[last_index] ^= 0x01;
+    let invalid_encoded = hex::encode(encoded_bytes);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/mailbox/authorize")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "mailbox_id": &mailbox_id,
+                        "expiry": expiry,
+                        "encoded": &invalid_encoded
                     }))
                     .unwrap(),
                 ))
@@ -562,6 +661,237 @@ async fn test_revoke_mailbox_authorization() {
         .unwrap();
     assert_eq!(revoked_record.mailbox_id, "deadbeef");
     assert_eq!(revoked_record.last_checkpoint, 0);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_has_active_authorization_requires_active_status() {
+    let (_app, app_state, _guard) = setup_test_app().await;
+    let user = TestUser::new();
+    create_test_user(&app_state, &user, None).await;
+
+    use crate::db::mailbox_authorization_repo::MailboxAuthorizationRepository;
+    let mailbox_repo = MailboxAuthorizationRepository::new(&app_state.db_pool);
+    let pubkey = user.pubkey().to_string();
+    mailbox_repo
+        .upsert(&pubkey, "deadbeef", "cafebabe", Utc::now().timestamp() + 60)
+        .await
+        .unwrap();
+
+    assert!(
+        mailbox_repo
+            .has_active_authorization(&pubkey, Utc::now().timestamp())
+            .await
+            .unwrap()
+    );
+
+    sqlx::query("UPDATE mailbox_authorizations SET status = 'expired' WHERE pubkey = $1")
+        .bind(&pubkey)
+        .execute(&app_state.db_pool)
+        .await
+        .unwrap();
+
+    assert!(
+        !mailbox_repo
+            .has_active_authorization(&pubkey, Utc::now().timestamp())
+            .await
+            .unwrap()
+    );
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_mark_expired_mailbox_authorizations_updates_only_active_expired_rows() {
+    let (_app, app_state, _guard) = setup_test_app().await;
+    let user1 = TestUser::new_with_key(&[0xa1; 32]);
+    let user2 = TestUser::new_with_key(&[0xa2; 32]);
+    let user3 = TestUser::new_with_key(&[0xa3; 32]);
+    for (user, address) in [
+        (&user1, "expired-active@localhost"),
+        (&user2, "future-active@localhost"),
+        (&user3, "expired-invalid@localhost"),
+    ] {
+        sqlx::query(
+            "INSERT INTO users (pubkey, lightning_address, ark_address) VALUES ($1, $2, NULL)",
+        )
+        .bind(user.pubkey().to_string())
+        .bind(address)
+        .execute(&app_state.db_pool)
+        .await
+        .unwrap();
+    }
+
+    use crate::db::mailbox_authorization_repo::MailboxAuthorizationRepository;
+    let mailbox_repo = MailboxAuthorizationRepository::new(&app_state.db_pool);
+    let now = Utc::now().timestamp();
+    mailbox_repo
+        .upsert(
+            &user1.pubkey().to_string(),
+            "deadbeef",
+            "cafebabe",
+            now - 60,
+        )
+        .await
+        .unwrap();
+    mailbox_repo
+        .upsert(
+            &user2.pubkey().to_string(),
+            "feedface",
+            "cafed00d",
+            now + 60,
+        )
+        .await
+        .unwrap();
+    mailbox_repo
+        .upsert(&user3.pubkey().to_string(), "badc0de", "c001d00d", now - 60)
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE mailbox_authorizations
+         SET status = 'invalid',
+             lease_owner = 'worker-a',
+             lease_expires_at = now() + interval '1 minute',
+             next_retry_at = now() + interval '1 minute'
+         WHERE pubkey = $1",
+    )
+    .bind(user3.pubkey().to_string())
+    .execute(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    let affected = mailbox_repo.mark_expired_authorizations(now).await.unwrap();
+
+    assert_eq!(affected, 1);
+    let rows = sqlx::query_as::<_, (String, String, Option<String>)>(
+        "SELECT pubkey, status, lease_owner FROM mailbox_authorizations ORDER BY pubkey",
+    )
+    .fetch_all(&app_state.db_pool)
+    .await
+    .unwrap();
+
+    assert!(rows.iter().any(|(pubkey, status, lease_owner)| {
+        pubkey == &user1.pubkey().to_string() && status == "expired" && lease_owner.is_none()
+    }));
+    assert!(rows.iter().any(|(pubkey, status, _)| {
+        pubkey == &user2.pubkey().to_string() && status == "active"
+    }));
+    assert!(rows.iter().any(|(pubkey, status, lease_owner)| {
+        pubkey == &user3.pubkey().to_string() && status == "invalid" && lease_owner.is_some()
+    }));
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_backfill_mailbox_authorizations_classifies_existing_rows() {
+    let (_app, app_state, _guard) = setup_test_app().await;
+    let users = [
+        (
+            TestUser::new_with_key(&[0xb1; 32]),
+            "valid-backfill@localhost",
+        ),
+        (
+            TestUser::new_with_key(&[0xb2; 32]),
+            "normalize-backfill@localhost",
+        ),
+        (
+            TestUser::new_with_key(&[0xb3; 32]),
+            "expired-backfill@localhost",
+        ),
+        (
+            TestUser::new_with_key(&[0xb4; 32]),
+            "invalid-backfill@localhost",
+        ),
+    ];
+    for (user, address) in &users {
+        sqlx::query(
+            "INSERT INTO users (pubkey, lightning_address, ark_address) VALUES ($1, $2, NULL)",
+        )
+        .bind(user.pubkey().to_string())
+        .bind(address)
+        .execute(&app_state.db_pool)
+        .await
+        .unwrap();
+    }
+
+    use crate::db::mailbox_authorization_repo::MailboxAuthorizationRepository;
+    let mailbox_repo = MailboxAuthorizationRepository::new(&app_state.db_pool);
+    let (valid_mailbox_id, valid_expiry, valid_encoded) =
+        test_mailbox_authorization(Local::now() + Duration::seconds(60));
+    mailbox_repo
+        .upsert(
+            &users[0].0.pubkey().to_string(),
+            &valid_mailbox_id,
+            &valid_encoded,
+            valid_expiry,
+        )
+        .await
+        .unwrap();
+
+    let (normalize_mailbox_id, normalize_expiry, normalize_encoded) =
+        test_mailbox_authorization(Local::now() + Duration::seconds(120));
+    mailbox_repo
+        .upsert(
+            &users[1].0.pubkey().to_string(),
+            &normalize_mailbox_id.to_ascii_uppercase(),
+            &normalize_encoded.to_ascii_uppercase(),
+            normalize_expiry + 30,
+        )
+        .await
+        .unwrap();
+
+    let (expired_mailbox_id, expired_expiry, expired_encoded) =
+        test_mailbox_authorization(Local::now() - Duration::seconds(60));
+    mailbox_repo
+        .upsert(
+            &users[2].0.pubkey().to_string(),
+            &expired_mailbox_id,
+            &expired_encoded,
+            expired_expiry + 120,
+        )
+        .await
+        .unwrap();
+
+    mailbox_repo
+        .upsert(
+            &users[3].0.pubkey().to_string(),
+            "deadbeef",
+            "not-protocol-hex",
+            Utc::now().timestamp() + 60,
+        )
+        .await
+        .unwrap();
+
+    let report = crate::mailbox_auth::backfill_mailbox_authorizations(&app_state.db_pool, false)
+        .await
+        .unwrap();
+
+    assert_eq!(report.checked, 4);
+    assert_eq!(report.valid, 1);
+    assert_eq!(report.normalized, 1);
+    assert_eq!(report.expired, 1);
+    assert_eq!(report.invalid, 1);
+
+    let normalized = mailbox_repo
+        .find_by_pubkey(&users[1].0.pubkey().to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(normalized.mailbox_id, normalize_mailbox_id);
+    assert_eq!(normalized.authorization_hex, normalize_encoded);
+    assert_eq!(normalized.authorization_expires_at, normalize_expiry);
+
+    let statuses = sqlx::query_as::<_, (String, String)>(
+        "SELECT pubkey, status FROM mailbox_authorizations ORDER BY pubkey",
+    )
+    .fetch_all(&app_state.db_pool)
+    .await
+    .unwrap();
+    assert!(statuses.iter().any(|(pubkey, status)| {
+        pubkey == &users[2].0.pubkey().to_string() && status == "expired"
+    }));
+    assert!(statuses.iter().any(|(pubkey, status)| {
+        pubkey == &users[3].0.pubkey().to_string() && status == "invalid"
+    }));
 }
 
 #[tracing_test::traced_test]


### PR DESCRIPTION
## Summary

- Validate mailbox authorizations server-side by decoding the ark-lib `MailboxAuthorization`, checking the signature, embedded mailbox id, and embedded expiry before storing it.
- Require active mailbox authorization status for LNURL invoice gating.
- Add a cron cleanup that marks timestamp-expired active mailbox authorizations as `expired` without deleting rows.
- Add an explicit `noah-cli backfill-mailbox-auth` command to classify, normalize, expire, or invalidate existing active rows.

## Why

Stale mailbox rows from old or deleted app installs can leave the server retrying authorizations that are no longer accepted by the mailbox server. The server also previously trusted client-provided mailbox expiry fields instead of the encoded authorization itself.

## Validation

- `cargo fmt --check`
- `just server-test`
- `just server-check`
- Commit hook: `bun --cwd client check`