### PR TITLE
Add feedback social links

### DIFF
--- a/client/src/components/BrandIcons.tsx
+++ b/client/src/components/BrandIcons.tsx
@@ -1,0 +1,31 @@
+import Svg, { Circle, Path, type SvgProps } from "react-native-svg";
+
+export const TELEGRAM_SUPPORT_URL = "https://t.me/blixtwallet/605026";
+export const GITHUB_URL = "https://github.com/smolcars/noah";
+
+type BrandIconProps = SvgProps & {
+  size?: number;
+};
+
+export const TelegramBrandIcon = ({ size = 24, ...props }: BrandIconProps) => (
+  <Svg width={size} height={size} viewBox="0 0 240 240" {...props}>
+    <Circle cx="120" cy="120" r="120" fill="#26A5E4" />
+    <Path
+      fill="#ffffff"
+      d="M178.2 77.4 157 177.3c-1.6 7.1-5.8 8.9-11.7 5.5l-32.4-23.9-15.6 15c-1.7 1.7-3.2 3.2-6.6 3.2l2.3-33 60.1-54.3c2.6-2.3-.6-3.6-4-1.3l-74.3 46.8-32-10c-7-2.2-7.1-7 1.5-10.3l125.1-48.2c5.8-2.1 10.9 1.4 8.8 10.6Z"
+    />
+  </Svg>
+);
+
+export const GitHubBrandIcon = ({
+  size = 24,
+  color = "#181717",
+  ...props
+}: BrandIconProps & { color?: string }) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" {...props}>
+    <Path
+      fill={color}
+      d="M12 .5C5.7.5.8 5.4.8 11.7c0 5 3.2 9.2 7.7 10.7.6.1.8-.2.8-.5v-1.9c-3.1.7-3.8-1.5-3.8-1.5-.5-1.3-1.2-1.6-1.2-1.6-1-.7.1-.7.1-.7 1.1.1 1.7 1.2 1.7 1.2 1 .1.7 2.6 2.6 1.9.1-.7.4-1.2.7-1.5-2.5-.3-5.1-1.2-5.1-5.6 0-1.2.4-2.2 1.2-3-.1-.3-.5-1.4.1-3 0 0 .9-.3 3.1 1.2.9-.2 1.9-.4 2.8-.4 1 0 1.9.1 2.8.4 2.2-1.5 3.1-1.2 3.1-1.2.6 1.6.2 2.7.1 3 .7.8 1.2 1.8 1.2 3 0 4.3-2.6 5.3-5.1 5.6.4.3.8 1 .8 2.1v3.1c0 .3.2.6.8.5 4.5-1.5 7.7-5.7 7.7-10.7C23.2 5.4 18.3.5 12 .5Z"
+    />
+  </Svg>
+);

--- a/client/src/screens/FeedbackScreen.tsx
+++ b/client/src/screens/FeedbackScreen.tsx
@@ -13,6 +13,7 @@ import React, { useRef, useState } from "react";
 import {
   Image,
   Keyboard,
+  Linking,
   Platform,
   Pressable,
   ScrollView,
@@ -24,6 +25,7 @@ import { fromByteArray } from "react-native-quick-base64";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import type { SettingsStackParamList } from "~/Navigators";
+import { TelegramBrandIcon, TELEGRAM_SUPPORT_URL } from "~/components/BrandIcons";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
 import { Text } from "~/components/ui/text";
@@ -158,6 +160,10 @@ const FeedbackScreen = () => {
     setSubmitState("success");
   };
 
+  const handleTelegramPress = () => {
+    Linking.openURL(TELEGRAM_SUPPORT_URL);
+  };
+
   const isSubmitDisabled =
     !name.trim() || !subject.trim() || !body.trim() || submitState !== "idle";
 
@@ -206,6 +212,13 @@ const FeedbackScreen = () => {
             </View>
           ) : (
             <View className="gap-5 pb-2">
+              <Pressable onPress={handleTelegramPress} className="flex-row items-center gap-3">
+                <TelegramBrandIcon size={32} />
+                <Text className="flex-1 text-sm text-muted-foreground">
+                  You can also join our Telegram chat for support and feedback.
+                </Text>
+              </Pressable>
+
               {errorMessage ? (
                 <View className="flex-row items-center gap-3 rounded-md border border-red-900 bg-red-950/40 p-3">
                   <AlertCircle size={20} color="#ef4444" />

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -32,6 +32,12 @@ import { getFiatCurrencyInfo } from "~/lib/fiatCurrency";
 import { getBitcoinAmountUnitInfo } from "~/lib/bitcoinAmount";
 import { NativeSwitch } from "~/components/ui/native-switch";
 import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
+import {
+  GitHubBrandIcon,
+  GITHUB_URL,
+  TelegramBrandIcon,
+  TELEGRAM_SUPPORT_URL,
+} from "~/components/BrandIcons";
 
 type Setting = {
   id:
@@ -135,8 +141,12 @@ const SettingsScreen = () => {
     }
   };
 
-  const handleSupportPress = () => {
-    Linking.openURL("https://t.me/blixtwallet/605026");
+  const handleTelegramPress = () => {
+    Linking.openURL(TELEGRAM_SUPPORT_URL);
+  };
+
+  const handleGithubPress = () => {
+    Linking.openURL(GITHUB_URL);
   };
 
   const handleBiometricsToggle = async (value: boolean) => {
@@ -576,15 +586,25 @@ const SettingsScreen = () => {
               {isDebugModeEnabled && " 🔧"}
             </Text>
           </Pressable>
-          <Pressable onPress={handleSupportPress} className="mb-1">
-            <Text className="text-muted-foreground text-sm text-center">
-              For support, reach us on{" "}
-              <Text className="text-sm font-semibold" style={{ color: COLORS.BITCOIN_ORANGE }}>
-                Telegram
-              </Text>
-            </Text>
-          </Pressable>
           <Text className="text-muted-foreground text-sm">Made with ❤️ from Noah team</Text>
+          <View className="mt-3 flex-row items-center justify-center gap-4">
+            <Pressable
+              onPress={handleTelegramPress}
+              className="h-10 w-10 items-center justify-center rounded-full bg-card"
+              accessibilityRole="link"
+              accessibilityLabel="Open Telegram support chat"
+            >
+              <TelegramBrandIcon size={28} />
+            </Pressable>
+            <Pressable
+              onPress={handleGithubPress}
+              className="h-10 w-10 items-center justify-center rounded-full bg-card"
+              accessibilityRole="link"
+              accessibilityLabel="Open Noah GitHub repository"
+            >
+              <GitHubBrandIcon size={28} color={iconColor} />
+            </Pressable>
+          </View>
         </View>
       </ScrollView>
     </NoahSafeAreaView>


### PR DESCRIPTION
## Summary
- add reusable Telegram and GitHub brand icons with shared URLs
- add a Telegram support prompt near the top of the feedback screen
- replace the Settings footer Telegram text link with Telegram and GitHub icon buttons below the Noah team line

## Validation
- bun run check
- git diff --check
