### PR TITLE
Route Lightning-address payments through compatible Ark servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,8 +275,8 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ark-lib"
-version = "0.2.2"
-source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.2.2#ed530001e95ef776d3af0d7d1cca904d827c5197"
+version = "0.3.0"
+source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.3.0#46e41188d9d355173a6eece9190866c2b4455002"
 dependencies = [
  "async-trait",
  "bark-bitcoin-ext",
@@ -907,8 +907,8 @@ dependencies = [
 
 [[package]]
 name = "bark-bitcoin-ext"
-version = "0.2.2"
-source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.2.2#ed530001e95ef776d3af0d7d1cca904d827c5197"
+version = "0.3.0"
+source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.3.0#46e41188d9d355173a6eece9190866c2b4455002"
 dependencies = [
  "bitcoin",
  "lazy_static",
@@ -919,8 +919,8 @@ dependencies = [
 
 [[package]]
 name = "bark-server-rpc"
-version = "0.2.2"
-source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.2.2#ed530001e95ef776d3af0d7d1cca904d827c5197"
+version = "0.3.0"
+source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.3.0#46e41188d9d355173a6eece9190866c2b4455002"
 dependencies = [
  "ark-lib",
  "bitcoin",

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -26,6 +26,7 @@ import {
   estimateOffboardAllFee,
   estimateBoardOffchainFee,
   estimateStandardOnchainTxFee,
+  validateArkoorPaymentAddress,
   type StandardOnchainWalletFeeEstimate,
 } from "../lib/paymentsApi";
 import { queryClient } from "~/queryClient";
@@ -34,7 +35,6 @@ import { getArkInfo } from "~/lib/walletApi";
 import logger from "~/lib/log";
 import ky from "ky";
 import { Result } from "neverthrow";
-import { getLnurlDomain } from "~/constants";
 
 const log = logger("usePayments");
 
@@ -48,7 +48,7 @@ interface LnurlpDefaultResponse {
   ark?: string;
 }
 
-export type NoahPaymentRoute =
+export type LightningAddressPaymentRoute =
   | {
       method: "ark";
       destination: string;
@@ -74,48 +74,74 @@ const parseLightningAddress = (destination: string) => {
   return { username: parts[0], domain: parts[1] };
 };
 
-export const isNoahLightningAddress = (destination: string): boolean => {
-  const parsed = parseLightningAddress(destination);
-  return parsed?.domain === getLnurlDomain().toLowerCase();
+const fetchLnurlpResponse = async (url: URL): Promise<LnurlpDefaultResponse> => {
+  const response = await ky.get(url.toString()).json<LnurlpDefaultResponse>();
+  if (response.tag !== "payRequest" || !response.callback) {
+    throw new Error("Invalid LNURL response for lightning address payment");
+  }
+
+  return response;
 };
 
-export const resolveNoahPaymentRoute = async (destination: string): Promise<NoahPaymentRoute> => {
+const paymentRouteFromLnurlpResponse = async (
+  response: LnurlpDefaultResponse,
+  acceptArkAddress: boolean,
+): Promise<LightningAddressPaymentRoute> => {
+  const limits = {
+    minSendableMsat: response.minSendable,
+    maxSendableMsat: response.maxSendable,
+  };
+
+  if (acceptArkAddress && response.ark) {
+    const validationResult = await validateArkoorPaymentAddress(response.ark);
+    if (validationResult.isOk()) {
+      return { method: "ark", destination: response.ark, ...limits };
+    }
+
+    log.w("Ignoring incompatible Ark address returned by LNURL provider", [validationResult.error]);
+  }
+
+  return { method: "lightning", ...limits };
+};
+
+export const resolveLightningAddressPaymentRoute = async (
+  destination: string,
+): Promise<LightningAddressPaymentRoute> => {
   const parsed = parseLightningAddress(destination);
-  if (!parsed || parsed.domain !== getLnurlDomain().toLowerCase()) {
-    throw new Error("Destination is not a Noah lightning address");
+  if (!parsed) {
+    throw new Error("Destination is not a lightning address");
   }
 
   const lnurlEndpoint = new URL(`https://${parsed.domain}/.well-known/lnurlp/${parsed.username}`);
   const arkInfoResult = await getArkInfo();
   if (arkInfoResult.isErr()) {
-    throw arkInfoResult.error;
-  }
-  lnurlEndpoint.searchParams.set("ark", arkInfoResult.value.server_pubkey);
-  const lnurlJson = await ky.get(lnurlEndpoint.toString()).json<LnurlpDefaultResponse>();
-
-  if (lnurlJson.tag !== "payRequest" || !lnurlJson.callback) {
-    throw new Error("Invalid LNURL response for Noah payment");
+    log.w("Unable to load Ark server info, using standard LNURL discovery", [arkInfoResult.error]);
+    const response = await fetchLnurlpResponse(lnurlEndpoint);
+    return paymentRouteFromLnurlpResponse(response, false);
   }
 
-  const limits = {
-    minSendableMsat: lnurlJson.minSendable,
-    maxSendableMsat: lnurlJson.maxSendable,
-  };
+  const arkLnurlEndpoint = new URL(lnurlEndpoint);
+  arkLnurlEndpoint.searchParams.set("ark", arkInfoResult.value.server_pubkey);
 
-  return lnurlJson.ark
-    ? { method: "ark", destination: lnurlJson.ark, ...limits }
-    : { method: "lightning", ...limits };
+  try {
+    const response = await fetchLnurlpResponse(arkLnurlEndpoint);
+    return paymentRouteFromLnurlpResponse(response, true);
+  } catch (error) {
+    log.w("Ark route discovery failed, retrying with standard LNURL", [error]);
+    const response = await fetchLnurlpResponse(lnurlEndpoint);
+    return paymentRouteFromLnurlpResponse(response, false);
+  }
 };
 
-export function useNoahPaymentRoute(destination: string | null) {
+export function useLightningAddressPaymentRoute(destination: string | null) {
   return useQuery({
-    queryKey: ["payment-route", "noah", destination],
+    queryKey: ["payment-route", "lightning-address", destination],
     queryFn: () => {
       if (!destination) {
-        throw new Error("Noah payment destination is required");
+        throw new Error("Lightning address payment destination is required");
       }
 
-      return resolveNoahPaymentRoute(destination);
+      return resolveLightningAddressPaymentRoute(destination);
     },
     enabled: destination !== null,
     staleTime: 0,
@@ -243,7 +269,7 @@ type SendVariables = {
   resolvedAmountSat: number;
   comment: string | null;
   onchainSource?: OnchainSendSource;
-  noahPaymentRoute?: NoahPaymentRoute;
+  lightningAddressPaymentRoute?: LightningAddressPaymentRoute;
   btcPrice?: number;
 };
 
@@ -435,8 +461,8 @@ const readLightningPayment = async (
   return result.value;
 };
 
-const sendNoahPayment = async (
-  route: NoahPaymentRoute,
+const sendLightningAddressPayment = async (
+  route: LightningAddressPaymentRoute,
   destination: string,
   amountSat: number,
   comment: string | null,
@@ -447,7 +473,7 @@ const sendNoahPayment = async (
   }
 
   if (route.method === "ark") {
-    log.d("Paying Noah user via Ark direct payment");
+    log.d("Paying lightning address via Ark direct payment");
     const result = await sendArkoorPayment(route.destination, amountSat);
     if (result.isErr()) {
       throw result.error;
@@ -455,14 +481,15 @@ const sendNoahPayment = async (
     return result.value;
   }
 
-  log.d("Paying Noah user via Lightning Address");
+  log.d("Paying via standard Lightning Address flow");
   return readLightningPayment(payLightningAddress(destination, amountSat, comment || ""));
 };
 
 export function useSend(destinationType: DestinationTypes) {
   return useMutation<SendResult, Error, SendVariables>({
     mutationFn: async (variables) => {
-      const { destination, amountSat, comment, onchainSource, noahPaymentRoute } = variables;
+      const { destination, amountSat, comment, onchainSource, lightningAddressPaymentRoute } =
+        variables;
       if (amountSat === undefined && destinationType !== "lightning") {
         throw new Error("Amount is required");
       }
@@ -491,27 +518,24 @@ export function useSend(destinationType: DestinationTypes) {
             throw new Error("Amount is required for LNURL payments");
           }
 
-          if (isNoahLightningAddress(destination)) {
-            if (noahPaymentRoute) {
-              return sendNoahPayment(noahPaymentRoute, destination, amountSat, comment);
-            }
-
-            let route: NoahPaymentRoute;
-            try {
-              route = await resolveNoahPaymentRoute(destination);
-            } catch (routeError) {
-              log.w("Failed to resolve Noah payment route, falling back to standard LNURL", [
-                routeError,
-              ]);
-              return readLightningPayment(
-                payLightningAddress(destination, amountSat, comment || ""),
-              );
-            }
-
-            return sendNoahPayment(route, destination, amountSat, comment);
+          if (lightningAddressPaymentRoute) {
+            return sendLightningAddressPayment(
+              lightningAddressPaymentRoute,
+              destination,
+              amountSat,
+              comment,
+            );
           }
 
-          return readLightningPayment(payLightningAddress(destination, amountSat, comment || ""));
+          try {
+            const route = await resolveLightningAddressPaymentRoute(destination);
+            return sendLightningAddressPayment(route, destination, amountSat, comment);
+          } catch (routeError) {
+            log.w("Failed to resolve lightning address payment route, using standard LNURL", [
+              routeError,
+            ]);
+            return readLightningPayment(payLightningAddress(destination, amountSat, comment || ""));
+          }
         }
         case "offer":
           return readLightningPayment(payLightningOffer(destination, amountSat));

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -123,14 +123,8 @@ export const resolveLightningAddressPaymentRoute = async (
   const arkLnurlEndpoint = new URL(lnurlEndpoint);
   arkLnurlEndpoint.searchParams.set("ark", arkInfoResult.value.server_pubkey);
 
-  try {
-    const response = await fetchLnurlpResponse(arkLnurlEndpoint);
-    return paymentRouteFromLnurlpResponse(response, true);
-  } catch (error) {
-    log.w("Ark route discovery failed, retrying with standard LNURL", [error]);
-    const response = await fetchLnurlpResponse(lnurlEndpoint);
-    return paymentRouteFromLnurlpResponse(response, false);
-  }
+  const response = await fetchLnurlpResponse(arkLnurlEndpoint);
+  return paymentRouteFromLnurlpResponse(response, true);
 };
 
 export function useLightningAddressPaymentRoute(destination: string | null) {

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -30,6 +30,7 @@ import {
 } from "../lib/paymentsApi";
 import { queryClient } from "~/queryClient";
 import { DestinationTypes } from "~/lib/sendUtils";
+import { getArkInfo } from "~/lib/walletApi";
 import logger from "~/lib/log";
 import ky from "ky";
 import { Result } from "neverthrow";
@@ -44,12 +45,82 @@ interface LnurlpDefaultResponse {
   metadata: string;
   tag: "payRequest";
   commentAllowed: number;
+  ark?: string;
 }
 
-interface LnurlpInvoiceResponse {
-  pr: string;
-  routes: string[];
-  ark?: string;
+export type NoahPaymentRoute =
+  | {
+      method: "ark";
+      destination: string;
+      minSendableMsat: number;
+      maxSendableMsat: number;
+    }
+  | {
+      method: "lightning";
+      minSendableMsat: number;
+      maxSendableMsat: number;
+    };
+
+const parseLightningAddress = (destination: string) => {
+  const normalized = destination
+    .trim()
+    .toLowerCase()
+    .replace(/^lightning:/, "");
+  const parts = normalized.split("@");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return null;
+  }
+
+  return { username: parts[0], domain: parts[1] };
+};
+
+export const isNoahLightningAddress = (destination: string): boolean => {
+  const parsed = parseLightningAddress(destination);
+  return parsed?.domain === getLnurlDomain().toLowerCase();
+};
+
+export const resolveNoahPaymentRoute = async (destination: string): Promise<NoahPaymentRoute> => {
+  const parsed = parseLightningAddress(destination);
+  if (!parsed || parsed.domain !== getLnurlDomain().toLowerCase()) {
+    throw new Error("Destination is not a Noah lightning address");
+  }
+
+  const lnurlEndpoint = new URL(`https://${parsed.domain}/.well-known/lnurlp/${parsed.username}`);
+  const arkInfoResult = await getArkInfo();
+  if (arkInfoResult.isErr()) {
+    throw arkInfoResult.error;
+  }
+  lnurlEndpoint.searchParams.set("ark", arkInfoResult.value.server_pubkey);
+  const lnurlJson = await ky.get(lnurlEndpoint.toString()).json<LnurlpDefaultResponse>();
+
+  if (lnurlJson.tag !== "payRequest" || !lnurlJson.callback) {
+    throw new Error("Invalid LNURL response for Noah payment");
+  }
+
+  const limits = {
+    minSendableMsat: lnurlJson.minSendable,
+    maxSendableMsat: lnurlJson.maxSendable,
+  };
+
+  return lnurlJson.ark
+    ? { method: "ark", destination: lnurlJson.ark, ...limits }
+    : { method: "lightning", ...limits };
+};
+
+export function useNoahPaymentRoute(destination: string | null) {
+  return useQuery({
+    queryKey: ["payment-route", "noah", destination],
+    queryFn: () => {
+      if (!destination) {
+        throw new Error("Noah payment destination is required");
+      }
+
+      return resolveNoahPaymentRoute(destination);
+    },
+    enabled: destination !== null,
+    staleTime: 0,
+    retry: false,
+  });
 }
 
 export function useGenerateOffchainAddress() {
@@ -172,6 +243,7 @@ type SendVariables = {
   resolvedAmountSat: number;
   comment: string | null;
   onchainSource?: OnchainSendSource;
+  noahPaymentRoute?: NoahPaymentRoute;
   btcPrice?: number;
 };
 
@@ -363,10 +435,34 @@ const readLightningPayment = async (
   return result.value;
 };
 
+const sendNoahPayment = async (
+  route: NoahPaymentRoute,
+  destination: string,
+  amountSat: number,
+  comment: string | null,
+): Promise<ArkoorPaymentResult | LightningPayment> => {
+  const amountMsat = amountSat * 1000;
+  if (amountMsat < route.minSendableMsat || amountMsat > route.maxSendableMsat) {
+    throw new Error("Payment amount is outside the supported range for this lightning address");
+  }
+
+  if (route.method === "ark") {
+    log.d("Paying Noah user via Ark direct payment");
+    const result = await sendArkoorPayment(route.destination, amountSat);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    return result.value;
+  }
+
+  log.d("Paying Noah user via Lightning Address");
+  return readLightningPayment(payLightningAddress(destination, amountSat, comment || ""));
+};
+
 export function useSend(destinationType: DestinationTypes) {
   return useMutation<SendResult, Error, SendVariables>({
     mutationFn: async (variables) => {
-      const { destination, amountSat, comment, onchainSource } = variables;
+      const { destination, amountSat, comment, onchainSource, noahPaymentRoute } = variables;
       if (amountSat === undefined && destinationType !== "lightning") {
         throw new Error("Amount is required");
       }
@@ -395,20 +491,24 @@ export function useSend(destinationType: DestinationTypes) {
             throw new Error("Amount is required for LNURL payments");
           }
 
-          if (destination.toLowerCase().endsWith(getLnurlDomain())) {
-            const noahResult = await handleNoahWalletPayment(destination, amountSat, comment);
-            if (noahResult) {
-              if (noahResult.isErr()) {
-                throw noahResult.error;
-              }
-              const data = noahResult.value;
-              if ("payment_hash" in data) {
-                return readLightningPayment(
-                  Promise.resolve(noahResult as Result<LightningPayment, Error>),
-                );
-              }
-              return data;
+          if (isNoahLightningAddress(destination)) {
+            if (noahPaymentRoute) {
+              return sendNoahPayment(noahPaymentRoute, destination, amountSat, comment);
             }
+
+            let route: NoahPaymentRoute;
+            try {
+              route = await resolveNoahPaymentRoute(destination);
+            } catch (routeError) {
+              log.w("Failed to resolve Noah payment route, falling back to standard LNURL", [
+                routeError,
+              ]);
+              return readLightningPayment(
+                payLightningAddress(destination, amountSat, comment || ""),
+              );
+            }
+
+            return sendNoahPayment(route, destination, amountSat, comment);
           }
 
           return readLightningPayment(payLightningAddress(destination, amountSat, comment || ""));
@@ -429,46 +529,4 @@ export function useSend(destinationType: DestinationTypes) {
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
     },
   });
-}
-
-async function handleNoahWalletPayment(
-  destination: string,
-  amountSat: number,
-  comment: string | null,
-): Promise<Result<
-  ArkoorPaymentResult | LightningPayment | NoahOnchainPaymentResult,
-  Error
-> | null> {
-  try {
-    const [user, domain] = destination.split("@");
-    const lnurlEndpoint = `https://${domain}/.well-known/lnurlp/${user}`;
-    const lnurlJson = await ky.get(lnurlEndpoint).json<LnurlpDefaultResponse>();
-
-    if (lnurlJson.tag === "payRequest" && lnurlJson.callback) {
-      const callbackUrl = new URL(lnurlJson.callback);
-      callbackUrl.searchParams.append("amount", (amountSat * 1000).toString());
-      callbackUrl.searchParams.append("wallet", "noahwallet");
-      if (comment) {
-        callbackUrl.searchParams.append("comment", comment);
-      }
-
-      const callbackJson = await ky.get(callbackUrl.toString()).json<LnurlpInvoiceResponse>();
-
-      if (callbackJson.ark) {
-        log.d("Paying via Ark direct payment");
-        return await sendArkoorPayment(callbackJson.ark, amountSat);
-      } else if (callbackJson.pr) {
-        log.d("Paying via Lightning Invoice from LNURL");
-        const lnResult = await payLightningInvoice(callbackJson.pr, amountSat);
-        return lnResult;
-      } else {
-        log.w(
-          "Invalid LNURL callback response for optimized Noah payment, falling back to standard LNURL.",
-        );
-      }
-    }
-  } catch (e) {
-    log.w("Failed optimized Noah payment, falling back to standard LNURL", [e]);
-  }
-  return null;
 }

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -10,7 +10,13 @@ import {
   type DestinationTypes,
   ParsedBip321,
 } from "../lib/sendUtils";
-import { useSend, useSendFeeEstimate, type SendFeeEstimateParams } from "./usePayments";
+import {
+  isNoahLightningAddress,
+  useNoahPaymentRoute,
+  useSend,
+  useSendFeeEstimate,
+  type SendFeeEstimateParams,
+} from "./usePayments";
 import {
   type OnchainWalletFeeEstimate,
   type OnchainSendSource,
@@ -140,6 +146,15 @@ export const useSendScreen = () => {
 
   const finalDestinationType =
     destinationType === "bip321" ? selectedPaymentMethod : destinationType;
+  const cleanedDestination = destination.trim().replace(/^(bitcoin:|lightning:)/i, "");
+  const normalizedLnurlDestination = normalizeLightningAddress(cleanedDestination);
+  const noahPaymentRouteDestination =
+    showConfirmation &&
+    finalDestinationType === "lnurl" &&
+    isNoahLightningAddress(normalizedLnurlDestination)
+      ? normalizedLnurlDestination
+      : null;
+  const noahPaymentRouteQuery = useNoahPaymentRoute(noahPaymentRouteDestination);
 
   const {
     mutate: send,
@@ -229,15 +244,19 @@ export const useSendScreen = () => {
       }
     }
 
-    const cleanedDestination = destination.trim().replace(/^(bitcoin:|lightning:)/i, "");
-
     switch (finalDestinationType) {
       case "ark":
         return { method: "ark", amountSat };
       case "lightning":
-      case "lnurl":
       case "offer":
         return { method: "lightning", amountSat };
+      case "lnurl":
+        if (!noahPaymentRouteDestination) {
+          return { method: "lightning", amountSat };
+        }
+        return noahPaymentRouteQuery.data
+          ? { method: noahPaymentRouteQuery.data.method, amountSat }
+          : null;
       case "onchain":
         return cleanedDestination && resolvedOnchainSource !== null
           ? {
@@ -253,33 +272,17 @@ export const useSendScreen = () => {
   }, [
     amountSat,
     bip321Data,
-    destination,
+    cleanedDestination,
     destinationType,
     finalDestinationType,
+    noahPaymentRouteDestination,
+    noahPaymentRouteQuery.data,
     resolvedOnchainSource,
     selectedPaymentMethod,
     showConfirmation,
   ]);
 
-  const [debouncedFeeEstimateParams, setDebouncedFeeEstimateParams] =
-    useState<SendFeeEstimateParams | null>(null);
-
-  useEffect(() => {
-    if (!feeEstimateParams) {
-      setDebouncedFeeEstimateParams(null);
-      return;
-    }
-
-    const timeout = setTimeout(() => {
-      setDebouncedFeeEstimateParams(feeEstimateParams);
-    }, 350);
-
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [feeEstimateParams]);
-
-  const feeEstimateQuery = useSendFeeEstimate(debouncedFeeEstimateParams);
+  const feeEstimateQuery = useSendFeeEstimate(feeEstimateParams);
 
   const feeEstimateNote = useMemo(() => {
     if (!isOnchainSend || resolvedOnchainSource !== "onchain") {
@@ -325,6 +328,14 @@ export const useSendScreen = () => {
 
     log.w("Failed to estimate send fee", [feeEstimateQuery.error]);
   }, [feeEstimateQuery.error]);
+
+  useEffect(() => {
+    if (!noahPaymentRouteQuery.error) {
+      return;
+    }
+
+    log.w("Failed to resolve Noah payment route", [noahPaymentRouteQuery.error]);
+  }, [noahPaymentRouteQuery.error]);
 
   const toggleCurrency = useCallback(() => {
     if (currency === "SATS") {
@@ -508,7 +519,6 @@ export const useSendScreen = () => {
         btcPrice,
       });
     } else {
-      const cleanedDestination = destination.trim().replace(/^(bitcoin:|lightning:)/i, "");
       const destinationToSend =
         finalDestinationType === "lnurl"
           ? normalizeLightningAddress(cleanedDestination)
@@ -529,6 +539,10 @@ export const useSendScreen = () => {
         comment: comment || null,
         onchainSource:
           finalDestinationType === "onchain" ? (resolvedOnchainSource ?? undefined) : undefined,
+        noahPaymentRoute:
+          finalDestinationType === "lnurl" && noahPaymentRouteDestination
+            ? noahPaymentRouteQuery.data
+            : undefined,
         btcPrice,
       });
     }
@@ -625,6 +639,10 @@ export const useSendScreen = () => {
     setSelectedOnchainSource,
     resolvedOnchainSource,
     isOnchainSourceSelectionRequired,
+    isNoahPaymentRouteResolutionRequired:
+      noahPaymentRouteDestination !== null &&
+      !noahPaymentRouteQuery.data &&
+      !noahPaymentRouteQuery.error,
     onchainWalletBalance,
     offchainWalletBalance,
     showConfirmation,
@@ -632,9 +650,11 @@ export const useSendScreen = () => {
     showSuccess,
     handleCloseSuccess,
     feeEstimate: feeEstimateQuery.data,
-    isEstimatingFee: feeEstimateQuery.isFetching,
-    feeEstimateError: feeEstimateQuery.error,
-    feeEstimateUnavailableText: null,
+    isEstimatingFee: noahPaymentRouteQuery.isFetching || feeEstimateQuery.isFetching,
+    feeEstimateError: noahPaymentRouteQuery.error ?? feeEstimateQuery.error,
+    feeEstimateUnavailableText: noahPaymentRouteQuery.error
+      ? "Unable to determine whether this Noah payment will use Ark or Lightning."
+      : null,
     feeEstimateNote,
     feeEstimateWarning,
   };

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -11,8 +11,7 @@ import {
   ParsedBip321,
 } from "../lib/sendUtils";
 import {
-  isNoahLightningAddress,
-  useNoahPaymentRoute,
+  useLightningAddressPaymentRoute,
   useSend,
   useSendFeeEstimate,
   type SendFeeEstimateParams,
@@ -148,13 +147,11 @@ export const useSendScreen = () => {
     destinationType === "bip321" ? selectedPaymentMethod : destinationType;
   const cleanedDestination = destination.trim().replace(/^(bitcoin:|lightning:)/i, "");
   const normalizedLnurlDestination = normalizeLightningAddress(cleanedDestination);
-  const noahPaymentRouteDestination =
-    showConfirmation &&
-    finalDestinationType === "lnurl" &&
-    isNoahLightningAddress(normalizedLnurlDestination)
-      ? normalizedLnurlDestination
-      : null;
-  const noahPaymentRouteQuery = useNoahPaymentRoute(noahPaymentRouteDestination);
+  const lightningAddressPaymentRouteDestination =
+    showConfirmation && finalDestinationType === "lnurl" ? normalizedLnurlDestination : null;
+  const lightningAddressPaymentRouteQuery = useLightningAddressPaymentRoute(
+    lightningAddressPaymentRouteDestination,
+  );
 
   const {
     mutate: send,
@@ -251,11 +248,8 @@ export const useSendScreen = () => {
       case "offer":
         return { method: "lightning", amountSat };
       case "lnurl":
-        if (!noahPaymentRouteDestination) {
-          return { method: "lightning", amountSat };
-        }
-        return noahPaymentRouteQuery.data
-          ? { method: noahPaymentRouteQuery.data.method, amountSat }
+        return lightningAddressPaymentRouteQuery.data
+          ? { method: lightningAddressPaymentRouteQuery.data.method, amountSat }
           : null;
       case "onchain":
         return cleanedDestination && resolvedOnchainSource !== null
@@ -275,8 +269,7 @@ export const useSendScreen = () => {
     cleanedDestination,
     destinationType,
     finalDestinationType,
-    noahPaymentRouteDestination,
-    noahPaymentRouteQuery.data,
+    lightningAddressPaymentRouteQuery.data,
     resolvedOnchainSource,
     selectedPaymentMethod,
     showConfirmation,
@@ -330,12 +323,14 @@ export const useSendScreen = () => {
   }, [feeEstimateQuery.error]);
 
   useEffect(() => {
-    if (!noahPaymentRouteQuery.error) {
+    if (!lightningAddressPaymentRouteQuery.error) {
       return;
     }
 
-    log.w("Failed to resolve Noah payment route", [noahPaymentRouteQuery.error]);
-  }, [noahPaymentRouteQuery.error]);
+    log.w("Failed to resolve lightning address payment route", [
+      lightningAddressPaymentRouteQuery.error,
+    ]);
+  }, [lightningAddressPaymentRouteQuery.error]);
 
   const toggleCurrency = useCallback(() => {
     if (currency === "SATS") {
@@ -539,9 +534,9 @@ export const useSendScreen = () => {
         comment: comment || null,
         onchainSource:
           finalDestinationType === "onchain" ? (resolvedOnchainSource ?? undefined) : undefined,
-        noahPaymentRoute:
-          finalDestinationType === "lnurl" && noahPaymentRouteDestination
-            ? noahPaymentRouteQuery.data
+        lightningAddressPaymentRoute:
+          finalDestinationType === "lnurl" && lightningAddressPaymentRouteDestination
+            ? lightningAddressPaymentRouteQuery.data
             : undefined,
         btcPrice,
       });
@@ -639,10 +634,10 @@ export const useSendScreen = () => {
     setSelectedOnchainSource,
     resolvedOnchainSource,
     isOnchainSourceSelectionRequired,
-    isNoahPaymentRouteResolutionRequired:
-      noahPaymentRouteDestination !== null &&
-      !noahPaymentRouteQuery.data &&
-      !noahPaymentRouteQuery.error,
+    isLightningAddressPaymentRouteResolutionRequired:
+      lightningAddressPaymentRouteDestination !== null &&
+      !lightningAddressPaymentRouteQuery.data &&
+      !lightningAddressPaymentRouteQuery.error,
     onchainWalletBalance,
     offchainWalletBalance,
     showConfirmation,
@@ -650,10 +645,10 @@ export const useSendScreen = () => {
     showSuccess,
     handleCloseSuccess,
     feeEstimate: feeEstimateQuery.data,
-    isEstimatingFee: noahPaymentRouteQuery.isFetching || feeEstimateQuery.isFetching,
-    feeEstimateError: noahPaymentRouteQuery.error ?? feeEstimateQuery.error,
-    feeEstimateUnavailableText: noahPaymentRouteQuery.error
-      ? "Unable to determine whether this Noah payment will use Ark or Lightning."
+    isEstimatingFee: lightningAddressPaymentRouteQuery.isFetching || feeEstimateQuery.isFetching,
+    feeEstimateError: lightningAddressPaymentRouteQuery.error ?? feeEstimateQuery.error,
+    feeEstimateUnavailableText: lightningAddressPaymentRouteQuery.error
+      ? "Unable to determine whether this payment will use Ark or Lightning."
       : null,
     feeEstimateNote,
     feeEstimateWarning,

--- a/client/src/lib/paymentsApi.ts
+++ b/client/src/lib/paymentsApi.ts
@@ -156,7 +156,9 @@ export const offboardAllArk = async (address: string): Promise<Result<string, Er
   });
 };
 
-const validateArkoorPaymentAddress = async (destination: string): Promise<Result<void, Error>> => {
+export const validateArkoorPaymentAddress = async (
+  destination: string,
+): Promise<Result<void, Error>> => {
   return ResultAsync.fromPromise(validateArkoorAddressNitro(destination), (error) => {
     const message = error instanceof Error ? error.message : String(error);
     return new Error(`Invalid Ark address: ${message}`);

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -74,6 +74,7 @@ const SendScreen = () => {
     selectedOnchainSource,
     setSelectedOnchainSource,
     isOnchainSourceSelectionRequired,
+    isNoahPaymentRouteResolutionRequired,
     onchainWalletBalance,
     offchainWalletBalance,
     handleClear,
@@ -402,7 +403,9 @@ const SendScreen = () => {
           offchainWalletBalance={offchainWalletBalance}
           onConfirm={handleConfirmSend}
           onCancel={handleCancelConfirmation}
-          isConfirmDisabled={isOnchainSourceSelectionRequired}
+          isConfirmDisabled={
+            isOnchainSourceSelectionRequired || isNoahPaymentRouteResolutionRequired
+          }
           isLoading={isSending}
           feeEstimate={feeEstimate}
           isEstimatingFee={isEstimatingFee}

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -74,7 +74,7 @@ const SendScreen = () => {
     selectedOnchainSource,
     setSelectedOnchainSource,
     isOnchainSourceSelectionRequired,
-    isNoahPaymentRouteResolutionRequired,
+    isLightningAddressPaymentRouteResolutionRequired,
     onchainWalletBalance,
     offchainWalletBalance,
     handleClear,
@@ -404,7 +404,7 @@ const SendScreen = () => {
           onConfirm={handleConfirmSend}
           onCancel={handleCancelConfirmation}
           isConfirmDisabled={
-            isOnchainSourceSelectionRequired || isNoahPaymentRouteResolutionRequired
+            isOnchainSourceSelectionRequired || isLightningAddressPaymentRouteResolutionRequired
           }
           isLoading={isSending}
           feeEstimate={feeEstimate}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,8 +25,8 @@ tokio-cron-scheduler = { version = "0.15.1", features = ["english"] }
 serde_json = "1.0.145"
 random_word = { version = "0.5.0", features = ["en"] }
 futures-util = "0.3.30"
-bark-server-rpc = { git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.2.2" }
-ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.2.2" }
+bark-server-rpc = { git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.3.0" }
+ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.3.0" }
 deadpool-redis = { version = "0.22.0", features = ["serde", "rt_tokio_1"] }
 redis = { version = "0.32.7", features = ["aio", "tokio-comp"] }
 
@@ -61,7 +61,7 @@ jsonwebtoken = "9.3.1"
 tower = { version = "0.5.2", features = ["full"] }
 tracing-test = "0.2.5"
 once_cell = "1.19.0"
-ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.2.2", features = [
+ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.3.0", features = [
   "test-util",
 ] }
 

--- a/server/src/ark_client.rs
+++ b/server/src/ark_client.rs
@@ -73,11 +73,14 @@ async fn establish_connection_and_process(
     );
 
     let info = client.get_ark_info(Empty {}).await?.into_inner();
+    let server_pubkey = info.server_pubkey.to_lower_hex_string();
+
+    *app_state.ark_server_pubkey.write().await = Some(server_pubkey.clone());
 
     tracing::info!(
         service = "ark_client",
         event = "ark_info",
-        server_pubkey = %info.server_pubkey.to_lower_hex_string(),
+        server_pubkey = %server_pubkey,
         "received ark server info"
     );
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -32,6 +32,7 @@ pub const K1_TTL_SECONDS: usize = 600;
 pub struct AppStruct {
     pub config: Arc<Config>,
     pub lnurl_domain: String,
+    pub ark_server_pubkey: Arc<tokio::sync::RwLock<Option<String>>>,
     pub db_pool: PgPool,
     pub k1_cache: K1Store,
     pub invoice_store: InvoiceStore,
@@ -63,6 +64,7 @@ pub async fn build_app_state(config: Config) -> anyhow::Result<AppState> {
     Ok(Arc::new(AppStruct {
         config: Arc::new(config.clone()),
         lnurl_domain: config.lnurl_domain.clone(),
+        ark_server_pubkey: Arc::new(tokio::sync::RwLock::new(None)),
         db_pool,
         k1_cache,
         invoice_store,

--- a/server/src/mailbox_worker.rs
+++ b/server/src/mailbox_worker.rs
@@ -534,7 +534,7 @@ impl MailboxTransport for Beta8MailboxTransport {
             });
         }
 
-        let unblinded_id = match decode_hex_bytes("mailbox_id", &mailbox.mailbox_id) {
+        let mailbox_id = match decode_hex_bytes("mailbox_id", &mailbox.mailbox_id) {
             Ok(value) => value,
             Err(reason) => return Ok(MailboxSessionOutcome::InvalidAuth { reason }),
         };
@@ -564,7 +564,7 @@ impl MailboxTransport for Beta8MailboxTransport {
 
                 let read_response = client
                     .read_mailbox(MailboxRequest {
-                        unblinded_id: unblinded_id.clone(),
+                        mailbox_id: mailbox_id.clone(),
                         authorization: Some(authorization.clone()),
                         checkpoint,
                     })
@@ -612,7 +612,7 @@ impl MailboxTransport for Beta8MailboxTransport {
 
             let stream_response = client
                 .subscribe_mailbox(MailboxRequest {
-                    unblinded_id: unblinded_id.clone(),
+                    mailbox_id: mailbox_id.clone(),
                     authorization: Some(authorization.clone()),
                     checkpoint,
                 })

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -75,6 +75,7 @@ const SUPPORT_TICKET_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 pub struct AppStruct {
     pub config: Arc<Config>,
     pub lnurl_domain: String,
+    pub ark_server_pubkey: Arc<tokio::sync::RwLock<Option<String>>>,
     pub db_pool: PgPool,
     pub k1_cache: K1Store,
     pub invoice_store: InvoiceStore,
@@ -176,6 +177,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     let app_state = Arc::new(AppStruct {
         config: Arc::new(config.clone()),
         lnurl_domain: config.lnurl_domain.clone(),
+        ark_server_pubkey: Arc::new(tokio::sync::RwLock::new(None)),
         db_pool: db_pool.clone(),
         k1_cache: k1_cache.clone(),
         invoice_store,

--- a/server/src/routes/public_api_v0.rs
+++ b/server/src/routes/public_api_v0.rs
@@ -249,6 +249,9 @@ pub struct LnurlpDefaultResponse {
     pub tag: String,
     /// The maximum length of a comment that can be included with the payment.
     pub comment_allowed: u16,
+    /// The user's Ark address when requested for a compatible Ark server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ark: Option<String>,
 }
 
 /// Represents the second response in the LNURL-pay protocol.
@@ -269,7 +272,32 @@ pub struct LnurlpInvoiceResponse {
 pub struct LnurlpRequestQuery {
     /// The amount of the payment in millisatoshis.
     amount: Option<u64>,
+    /// The payer's Ark server pubkey, used to negotiate a compatible Ark address.
+    ark: Option<String>,
+    /// Deprecated Noah-specific Ark capability signal.
     wallet: Option<String>,
+}
+
+async fn negotiated_ark_address(
+    state: &AppState,
+    query: &LnurlpRequestQuery,
+    ark_address: Option<&String>,
+) -> Option<String> {
+    let Some(ark_address) = ark_address else {
+        return None;
+    };
+
+    if let Some(requested_server_pubkey) = query.ark.as_deref() {
+        let configured_server_pubkey = state.ark_server_pubkey.read().await;
+        let matches_configured_server = configured_server_pubkey
+            .as_deref()
+            .is_some_and(|pubkey| pubkey.eq_ignore_ascii_case(requested_server_pubkey));
+
+        return matches_configured_server.then(|| ark_address.clone());
+    }
+
+    // Deprecated compatibility path. Remove after Noah clients have migrated to `ark`.
+    (query.wallet.as_deref() == Some("noahwallet")).then(|| ark_address.clone())
 }
 
 /// Handles LNURL-pay requests.
@@ -328,6 +356,7 @@ pub async fn lnurlp_request(
             metadata,
             tag: "payRequest".to_string(),
             comment_allowed: COMMENT_ALLOWED_SIZE,
+            ark: negotiated_ark_address(&state, &query, user.ark_address.as_ref()).await,
         };
         return Ok(Json(
             serde_json::to_value(response).map_err(|e| ApiError::SerializeErr(e.to_string()))?,
@@ -350,14 +379,13 @@ pub async fn lnurlp_request(
         )));
     }
 
-    if let Some(wallet) = &query.wallet
-        && wallet == "noahwallet"
-        && let Some(ark_address) = &user.ark_address
+    if let Some(ark_address) =
+        negotiated_ark_address(&state, &query, user.ark_address.as_ref()).await
     {
         let response = LnurlpInvoiceResponse {
             pr: "".to_string(),
             routes: vec![],
-            ark: Some(ark_address.clone()),
+            ark: Some(ark_address),
         };
         return Ok(Json(
             serde_json::to_value(response).map_err(|e| ApiError::SerializeErr(e.to_string()))?,

--- a/server/src/tests/common.rs
+++ b/server/src/tests/common.rs
@@ -160,6 +160,7 @@ pub async fn setup_test_app() -> (Router, AppState, TestDbGuard) {
 
     let app_state = Arc::new(AppStruct {
         lnurl_domain: "localhost".to_string(),
+        ark_server_pubkey: Arc::new(tokio::sync::RwLock::new(None)),
         db_pool: db_pool.clone(),
         k1_cache: k1_cache.clone(),
         invoice_store,
@@ -242,6 +243,7 @@ pub async fn setup_public_test_app() -> (Router, AppState, TestDbGuard) {
 
     let app_state = Arc::new(AppStruct {
         lnurl_domain: "localhost".to_string(),
+        ark_server_pubkey: Arc::new(tokio::sync::RwLock::new(None)),
         db_pool: db_pool.clone(),
         k1_cache: k1_cache.clone(),
         invoice_store,

--- a/server/src/tests/public_api_v0.rs
+++ b/server/src/tests/public_api_v0.rs
@@ -2,7 +2,7 @@ use crate::db::{
     fiat_rate_repo::FiatRateRepository, mailbox_authorization_repo::MailboxAuthorizationRepository,
     push_token_repo::PushTokenRepository, user_repo::UserRepository,
 };
-use crate::routes::public_api_v0::{GetK1, LnurlpDefaultResponse};
+use crate::routes::public_api_v0::{GetK1, LnurlpDefaultResponse, LnurlpInvoiceResponse};
 use crate::tests::common::{TestUser, create_test_user, setup_public_test_app, setup_test_app};
 use crate::types::{
     ApiErrorResponse, AppVersionCheckPayload, AppVersionInfo, FiatPricesPayload,
@@ -10,18 +10,39 @@ use crate::types::{
 };
 use axum::body::Body;
 use axum::http::{self, Request, StatusCode};
+use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use chrono::Utc;
 use http_body_util::BodyExt;
 use tower::ServiceExt;
+
+fn test_ark_address(server_key_byte: u8) -> (PublicKey, String) {
+    let secp = Secp256k1::new();
+    let server_secret_key = SecretKey::from_slice(&[server_key_byte; 32]).unwrap();
+    let server_pubkey = PublicKey::from_secret_key(&secp, &server_secret_key);
+    let user_secret_key = SecretKey::from_slice(&[0x42; 32]).unwrap();
+    let user_pubkey = PublicKey::from_secret_key(&secp, &user_secret_key);
+    let blinded_id = ark::mailbox::BlindedMailboxIdentifier::from_pubkey(user_pubkey);
+    let address = ark::Address::builder()
+        .testnet(true)
+        .server_pubkey(server_pubkey)
+        .pubkey_policy(user_pubkey)
+        .delivery(ark::address::VtxoDelivery::ServerMailbox { blinded_id })
+        .into_address()
+        .unwrap();
+
+    (server_pubkey, address.to_string())
+}
 
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn test_lnurlp_request_default() {
     let (app, app_state, _guard) = setup_public_test_app().await;
+    let (_, ark_address) = test_ark_address(0x11);
 
-    sqlx::query("INSERT INTO users (pubkey, lightning_address, ark_address) VALUES ($1, $2, NULL)")
+    sqlx::query("INSERT INTO users (pubkey, lightning_address, ark_address) VALUES ($1, $2, $3)")
         .bind("test_pubkey")
         .bind("test@localhost")
+        .bind(ark_address)
         .execute(&app_state.db_pool)
         .await
         .unwrap();
@@ -44,6 +65,180 @@ async fn test_lnurlp_request_default() {
 
     assert_eq!(res.tag, "payRequest");
     assert_eq!(res.callback, "https://localhost/.well-known/lnurlp/test");
+    assert_eq!(res.ark, None);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_lnurlp_request_advertises_address_for_matching_ark_server() {
+    let (app, app_state, _guard) = setup_public_test_app().await;
+    let (server_pubkey, ark_address) = test_ark_address(0x11);
+    *app_state.ark_server_pubkey.write().await = Some(server_pubkey.to_string());
+
+    sqlx::query("INSERT INTO users (pubkey, lightning_address, ark_address) VALUES ($1, $2, $3)")
+        .bind("test_pubkey")
+        .bind("test@localhost")
+        .bind(&ark_address)
+        .execute(&app_state.db_pool)
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(format!("/.well-known/lnurlp/test?ark={server_pubkey}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let res: LnurlpDefaultResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(res.ark.as_deref(), Some(ark_address.as_str()));
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_lnurlp_request_omits_address_for_different_ark_server() {
+    let (app, app_state, _guard) = setup_public_test_app().await;
+    let (server_pubkey, ark_address) = test_ark_address(0x11);
+    let (different_server_pubkey, _) = test_ark_address(0x12);
+    *app_state.ark_server_pubkey.write().await = Some(server_pubkey.to_string());
+
+    sqlx::query("INSERT INTO users (pubkey, lightning_address, ark_address) VALUES ($1, $2, $3)")
+        .bind("test_pubkey")
+        .bind("test@localhost")
+        .bind(ark_address)
+        .execute(&app_state.db_pool)
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(format!(
+                    "/.well-known/lnurlp/test?ark={different_server_pubkey}"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let res: LnurlpDefaultResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(res.ark, None);
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_lnurlp_request_supports_legacy_noah_wallet_parameter() {
+    let (app, app_state, _guard) = setup_public_test_app().await;
+    let (_, ark_address) = test_ark_address(0x11);
+
+    sqlx::query("INSERT INTO users (pubkey, lightning_address, ark_address) VALUES ($1, $2, $3)")
+        .bind("test_pubkey")
+        .bind("test@localhost")
+        .bind(&ark_address)
+        .execute(&app_state.db_pool)
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/.well-known/lnurlp/test?wallet=noahwallet")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let res: LnurlpDefaultResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(res.ark.as_deref(), Some(ark_address.as_str()));
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_lnurlp_invoice_request_returns_matching_ark_address_without_mailbox() {
+    let (app, app_state, _guard) = setup_public_test_app().await;
+    let (server_pubkey, ark_address) = test_ark_address(0x11);
+    *app_state.ark_server_pubkey.write().await = Some(server_pubkey.to_string());
+
+    sqlx::query("INSERT INTO users (pubkey, lightning_address, ark_address) VALUES ($1, $2, $3)")
+        .bind("test_pubkey")
+        .bind("test@localhost")
+        .bind(&ark_address)
+        .execute(&app_state.db_pool)
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(format!(
+                    "/.well-known/lnurlp/test?amount=330000&ark={server_pubkey}"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let res: LnurlpInvoiceResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(res.pr, "");
+    assert_eq!(res.ark.as_deref(), Some(ark_address.as_str()));
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_lnurlp_request_omits_ark_address_when_user_has_none() {
+    let (app, app_state, _guard) = setup_public_test_app().await;
+    let (server_pubkey, _) = test_ark_address(0x11);
+
+    sqlx::query("INSERT INTO users (pubkey, lightning_address, ark_address) VALUES ($1, $2, NULL)")
+        .bind("test_pubkey")
+        .bind("test@localhost")
+        .execute(&app_state.db_pool)
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(format!("/.well-known/lnurlp/test?ark={server_pubkey}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let res: LnurlpDefaultResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(res.ark, None);
 }
 
 #[tracing_test::traced_test]


### PR DESCRIPTION
## Summary

- advertise the client Ark server through `ark=<server_pubkey>` when resolving every Lightning address
- validate returned Ark addresses locally and use the negotiated route for both fee estimation and sending
- retain `wallet=noahwallet` as a temporary backwards-compatible server fallback
- upgrade the server-side Bark dependencies to 0.3.0 and migrate the renamed mailbox request field

## Why

Lightning-address providers may represent recipients on the same Ark server, regardless of which wallet or domain they use. Advertising the payer Ark server lets compatible providers return a direct Ark destination, avoiding an incorrect Lightning fee estimate and unnecessary Lightning routing.

The server only returns an Ark address when the requested pubkey matches its configured Ark server. The client also validates any returned address against its loaded Ark wallet before selecting the Ark route.

## Impact

- compatible Lightning-address payments display the Ark fee estimate and send through the advertised Ark address
- missing, incompatible, or invalid Ark routes continue through standard Lightning payment handling
- existing Noah clients using `wallet=noahwallet` remain supported during the migration window
- Bark server RPC integration now targets 0.3.0

## Validation

- client ESLint
- client TypeScript typecheck
- `cargo check -p server --tests`
- 9 focused LNURL tests
- 10 mailbox-worker tests
- Rust formatting and diff checks