### PR TITLE
Add native settings selectors and simulator registration fallback

### DIFF
--- a/client/src/components/ui/NativeNoahSelectionList.tsx
+++ b/client/src/components/ui/NativeNoahSelectionList.tsx
@@ -1,0 +1,218 @@
+import { Host } from "@expo/ui";
+import {
+  LazyColumn as ComposeLazyColumn,
+  ListItem as ComposeListItem,
+  RadioButton as ComposeRadioButton,
+  Text as ComposeText,
+} from "@expo/ui/jetpack-compose";
+import {
+  Shapes,
+  clip,
+  fillMaxSize,
+  fillMaxWidth,
+  selectable,
+  selectableGroup,
+  testID as composeTestID,
+} from "@expo/ui/jetpack-compose/modifiers";
+import {
+  Button as SwiftButton,
+  HStack as SwiftHStack,
+  Image as SwiftImage,
+  List as SwiftList,
+  Spacer as SwiftSpacer,
+  Text as SwiftText,
+  VStack as SwiftVStack,
+} from "@expo/ui/swift-ui";
+import {
+  accessibilityIdentifier,
+  background,
+  buttonStyle,
+  contentShape,
+  font,
+  foregroundStyle,
+  frame,
+  listRowBackground,
+  listStyle,
+  scrollContentBackground,
+  shapes,
+} from "@expo/ui/swift-ui/modifiers";
+import { Platform, View } from "react-native";
+
+import { useTheme, type ThemeColors } from "~/hooks/useTheme";
+import { COLORS } from "~/lib/styleConstants";
+
+export type NativeNoahSelectionListOption<T extends string> = {
+  value: T;
+  title: string;
+  subtitle: string;
+};
+
+type NativeNoahSelectionListProps<T extends string> = {
+  value: T;
+  options: readonly NativeNoahSelectionListOption<T>[];
+  onValueChange: (value: T) => void;
+  testID?: string;
+};
+
+export function NativeNoahSelectionList<T extends string>({
+  value,
+  options,
+  onValueChange,
+  testID,
+}: NativeNoahSelectionListProps<T>) {
+  const { colors, colorScheme } = useTheme();
+
+  return (
+    <View className="flex-1">
+      <Host
+        seedColor={COLORS.BITCOIN_ORANGE}
+        colorScheme={colorScheme}
+        style={{ flex: 1 }}
+      >
+        {Platform.OS === "android" ? (
+          <AndroidSelectionList
+            value={value}
+            options={options}
+            onValueChange={onValueChange}
+            colors={colors}
+            testID={testID}
+          />
+        ) : (
+          <IOSSelectionList
+            value={value}
+            options={options}
+            onValueChange={onValueChange}
+            colors={colors}
+            testID={testID}
+          />
+        )}
+      </Host>
+    </View>
+  );
+}
+
+function AndroidSelectionList<T extends string>({
+  value,
+  options,
+  onValueChange,
+  colors,
+  testID,
+}: NativeNoahSelectionListProps<T> & { colors: ThemeColors }) {
+  return (
+    <ComposeLazyColumn
+      contentPadding={{ start: 20, top: 24, end: 20, bottom: 32 }}
+      verticalArrangement={{ spacedBy: 8 }}
+      modifiers={[fillMaxSize(), selectableGroup()]}
+    >
+      {options.map((option) => (
+        <ComposeListItem
+          key={option.value}
+          colors={{
+            containerColor: colors.card,
+            contentColor: colors.foreground,
+            supportingContentColor: colors.mutedForeground,
+            trailingContentColor: COLORS.BITCOIN_ORANGE,
+          }}
+          modifiers={[
+            fillMaxWidth(),
+            clip(Shapes.RoundedCorner(16)),
+            selectable(
+              value === option.value,
+              () => onValueChange(option.value),
+              "radioButton",
+            ),
+            ...(testID ? [composeTestID(`${testID}-${option.value}`)] : []),
+          ]}
+        >
+          <ComposeListItem.HeadlineContent>
+            <ComposeText
+              color={colors.foreground}
+              maxLines={1}
+              style={{ fontSize: 16, fontWeight: "600", typography: "bodyLarge" }}
+            >
+              {option.title}
+            </ComposeText>
+          </ComposeListItem.HeadlineContent>
+          <ComposeListItem.SupportingContent>
+            <ComposeText
+              color={colors.mutedForeground}
+              maxLines={2}
+              style={{ fontSize: 14, typography: "bodyMedium" }}
+            >
+              {option.subtitle}
+            </ComposeText>
+          </ComposeListItem.SupportingContent>
+          <ComposeListItem.TrailingContent>
+            <ComposeRadioButton selected={value === option.value} />
+          </ComposeListItem.TrailingContent>
+        </ComposeListItem>
+      ))}
+    </ComposeLazyColumn>
+  );
+}
+
+function IOSSelectionList<T extends string>({
+  value,
+  options,
+  onValueChange,
+  colors,
+  testID,
+}: NativeNoahSelectionListProps<T> & { colors: ThemeColors }) {
+  return (
+    <SwiftList
+      modifiers={[
+        listStyle("insetGrouped"),
+        scrollContentBackground("hidden"),
+        background(colors.background),
+      ]}
+    >
+      {options.map((option) => (
+        <SwiftButton
+          key={option.value}
+          onPress={() => onValueChange(option.value)}
+          modifiers={[
+            buttonStyle("plain"),
+            listRowBackground(colors.card),
+            ...(testID
+              ? [accessibilityIdentifier(`${testID}-${option.value}`)]
+              : []),
+          ]}
+        >
+          <SwiftHStack
+            alignment="center"
+            spacing={12}
+            modifiers={[
+              frame({ maxWidth: Infinity, minHeight: 52, alignment: "leading" }),
+              contentShape(shapes.rectangle()),
+            ]}
+          >
+            <SwiftVStack alignment="leading" spacing={4}>
+              <SwiftText
+                modifiers={[
+                  font({ textStyle: "body", weight: "semibold" }),
+                  foregroundStyle(colors.foreground),
+                ]}
+              >
+                {option.title}
+              </SwiftText>
+              <SwiftText
+                modifiers={[
+                  font({ textStyle: "subheadline" }),
+                  foregroundStyle(colors.mutedForeground),
+                ]}
+              >
+                {option.subtitle}
+              </SwiftText>
+            </SwiftVStack>
+            <SwiftSpacer />
+            <SwiftImage
+              systemName={value === option.value ? "checkmark.circle.fill" : "circle"}
+              size={22}
+              color={value === option.value ? COLORS.BITCOIN_ORANGE : colors.mutedForeground}
+            />
+          </SwiftHStack>
+        </SwiftButton>
+      ))}
+    </SwiftList>
+  );
+}

--- a/client/src/hooks/usePushNotifications.ts
+++ b/client/src/hooks/usePushNotifications.ts
@@ -24,7 +24,7 @@ export const usePushNotifications = (isReady: boolean) => {
         return;
       }
 
-      log.d("Successfully registered for push notifications");
+      log.d("Push notification registration flow completed");
 
       // If backup is enabled, then register with server for backup
       log.d("Is backup enabled?", [isBackupEnabled]);

--- a/client/src/lib/server.ts
+++ b/client/src/lib/server.ts
@@ -73,6 +73,11 @@ export const registerPushNotificationsForServer = async (): Promise<Result<void,
   }
 
   const tokenPayload = tokenResult.value;
+  if (tokenPayload.kind === "device_not_supported") {
+    log.d("Skipping push notification registration on unsupported device");
+    return ok(undefined);
+  }
+
   if (tokenPayload.kind !== "success") {
     const error = new Error(
       `Push notification registration did not complete: ${tokenPayload.kind}`,

--- a/client/src/screens/BitcoinUnitSettingsScreen.tsx
+++ b/client/src/screens/BitcoinUnitSettingsScreen.tsx
@@ -1,27 +1,31 @@
-import React from "react";
-import { Pressable, ScrollView, View } from "react-native";
+import { View } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import Icon from "@react-native-vector-icons/ionicons";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import { Text } from "~/components/ui/text";
 import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
+import { NativeNoahSelectionList } from "~/components/ui/NativeNoahSelectionList";
 import type { SettingsStackParamList } from "~/Navigators";
 import {
   BITCOIN_AMOUNT_UNITS,
   getBitcoinAmountUnitInfo,
   type BitcoinAmountUnit,
 } from "~/lib/bitcoinAmount";
-import { COLORS } from "~/lib/styleConstants";
-import { useIconColor, useThemeColors } from "~/hooks/useTheme";
 import { useProfileStore } from "~/store/profileStore";
 
 type BitcoinUnitNavigationProp = NativeStackNavigationProp<SettingsStackParamList, "BitcoinUnit">;
 
+const BITCOIN_UNIT_OPTIONS = BITCOIN_AMOUNT_UNITS.map((unit) => {
+  const info = getBitcoinAmountUnitInfo(unit);
+  return {
+    value: unit,
+    title: `${info.title} · ${info.value}`,
+    subtitle: info.description,
+  };
+});
+
 const BitcoinUnitSettingsScreen = () => {
   const navigation = useNavigation<BitcoinUnitNavigationProp>();
-  const iconColor = useIconColor();
-  const colors = useThemeColors();
   const bitcoinAmountUnit = useProfileStore((state) => state.bitcoinAmountUnit);
   const setBitcoinAmountUnit = useProfileStore((state) => state.setBitcoinAmountUnit);
 
@@ -32,57 +36,22 @@ const BitcoinUnitSettingsScreen = () => {
 
   return (
     <NoahSafeAreaView className="flex-1 bg-background">
-      <ScrollView
-        className="flex-1"
-        showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ paddingBottom: 32 }}
-      >
-        <View className="px-5 pb-8 pt-4">
-          <View className="flex-row items-center">
-            <NativeNoahBackButton
-              onPress={() => navigation.goBack()}
-              className="mr-3"
-              testID="bitcoin-unit-back-button"
-            />
-            <Text className="text-2xl font-bold text-foreground">Bitcoin Unit</Text>
-          </View>
-
-          <View
-            className="mt-8 overflow-hidden rounded-[18px] border"
-            style={{
-              borderColor: `${colors.mutedForeground}24`,
-              backgroundColor: `${colors.card}CC`,
-            }}
-          >
-            {BITCOIN_AMOUNT_UNITS.map((unit, index) => {
-              const info = getBitcoinAmountUnitInfo(unit);
-              const isSelected = unit === bitcoinAmountUnit;
-
-              return (
-                <Pressable
-                  key={unit}
-                  onPress={() => handleSelectUnit(unit)}
-                  className={`flex-row items-center justify-between px-4 py-4 ${
-                    index < BITCOIN_AMOUNT_UNITS.length - 1 ? "border-b border-border" : ""
-                  }`}
-                >
-                  <View className="min-w-0 flex-1">
-                    <Text className="text-base font-semibold text-foreground">
-                      {info.title} · {info.value}
-                    </Text>
-                    <Text className="mt-1 text-sm text-muted-foreground">{info.description}</Text>
-                  </View>
-                  {isSelected ? (
-                    <Icon name="checkmark-circle" size={24} color={COLORS.BITCOIN_ORANGE} />
-                  ) : (
-                    <Icon name="ellipse-outline" size={24} color={iconColor} />
-                  )}
-                </Pressable>
-              );
-            })}
-          </View>
-        </View>
-      </ScrollView>
+      <View className="flex-row items-center px-5 pt-4">
+        <NativeNoahBackButton
+          onPress={() => navigation.goBack()}
+          className="mr-3"
+          testID="bitcoin-unit-back-button"
+        />
+        <Text className="text-2xl font-bold text-foreground">Bitcoin Unit</Text>
+      </View>
+      <View className="mt-4 flex-1">
+        <NativeNoahSelectionList
+          value={bitcoinAmountUnit}
+          options={BITCOIN_UNIT_OPTIONS}
+          onValueChange={handleSelectUnit}
+          testID="bitcoin-unit-option"
+        />
+      </View>
     </NoahSafeAreaView>
   );
 };

--- a/client/src/screens/CurrencySettingsScreen.tsx
+++ b/client/src/screens/CurrencySettingsScreen.tsx
@@ -1,27 +1,31 @@
-import React from "react";
-import { Pressable, ScrollView, View } from "react-native";
+import { View } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import Icon from "@react-native-vector-icons/ionicons";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import { Text } from "~/components/ui/text";
 import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
+import { NativeNoahSelectionList } from "~/components/ui/NativeNoahSelectionList";
 import type { SettingsStackParamList } from "~/Navigators";
 import {
   getFiatCurrencyInfo,
   SUPPORTED_FIAT_CURRENCIES,
   type FiatCurrencyCode,
 } from "~/lib/fiatCurrency";
-import { COLORS } from "~/lib/styleConstants";
-import { useIconColor, useThemeColors } from "~/hooks/useTheme";
 import { useProfileStore } from "~/store/profileStore";
 
 type CurrencyNavigationProp = NativeStackNavigationProp<SettingsStackParamList, "Currency">;
 
+const CURRENCY_OPTIONS = SUPPORTED_FIAT_CURRENCIES.map((currency) => {
+  const info = getFiatCurrencyInfo(currency);
+  return {
+    value: currency,
+    title: `${info.code} · ${info.name}`,
+    subtitle: info.symbol,
+  };
+});
+
 const CurrencySettingsScreen = () => {
   const navigation = useNavigation<CurrencyNavigationProp>();
-  const iconColor = useIconColor();
-  const colors = useThemeColors();
   const preferredCurrency = useProfileStore((state) => state.preferredCurrency);
   const setPreferredCurrency = useProfileStore((state) => state.setPreferredCurrency);
 
@@ -32,57 +36,22 @@ const CurrencySettingsScreen = () => {
 
   return (
     <NoahSafeAreaView className="flex-1 bg-background">
-      <ScrollView
-        className="flex-1"
-        showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ paddingBottom: 32 }}
-      >
-        <View className="px-5 pb-8 pt-4">
-          <View className="flex-row items-center">
-            <NativeNoahBackButton
-              onPress={() => navigation.goBack()}
-              className="mr-3"
-              testID="currency-settings-back-button"
-            />
-            <Text className="text-2xl font-bold text-foreground">Currency</Text>
-          </View>
-
-          <View
-            className="mt-8 overflow-hidden rounded-[18px] border"
-            style={{
-              borderColor: `${colors.mutedForeground}24`,
-              backgroundColor: `${colors.card}CC`,
-            }}
-          >
-            {SUPPORTED_FIAT_CURRENCIES.map((currency, index) => {
-              const info = getFiatCurrencyInfo(currency);
-              const isSelected = currency === preferredCurrency;
-
-              return (
-                <Pressable
-                  key={currency}
-                  onPress={() => handleSelectCurrency(currency)}
-                  className={`flex-row items-center justify-between px-4 py-4 ${
-                    index < SUPPORTED_FIAT_CURRENCIES.length - 1 ? "border-b border-border" : ""
-                  }`}
-                >
-                  <View className="min-w-0 flex-1">
-                    <Text className="text-base font-semibold text-foreground">
-                      {info.code} · {info.name}
-                    </Text>
-                    <Text className="mt-1 text-sm text-muted-foreground">{info.symbol}</Text>
-                  </View>
-                  {isSelected ? (
-                    <Icon name="checkmark-circle" size={24} color={COLORS.BITCOIN_ORANGE} />
-                  ) : (
-                    <Icon name="ellipse-outline" size={24} color={iconColor} />
-                  )}
-                </Pressable>
-              );
-            })}
-          </View>
-        </View>
-      </ScrollView>
+      <View className="flex-row items-center px-5 pt-4">
+        <NativeNoahBackButton
+          onPress={() => navigation.goBack()}
+          className="mr-3"
+          testID="currency-settings-back-button"
+        />
+        <Text className="text-2xl font-bold text-foreground">Currency</Text>
+      </View>
+      <View className="mt-4 flex-1">
+        <NativeNoahSelectionList
+          value={preferredCurrency}
+          options={CURRENCY_OPTIONS}
+          onValueChange={handleSelectCurrency}
+          testID="currency-option"
+        />
+      </View>
     </NoahSafeAreaView>
   );
 };

--- a/client/src/screens/DebugScreen.tsx
+++ b/client/src/screens/DebugScreen.tsx
@@ -1,10 +1,8 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { View, ScrollView, Pressable } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { SettingsStackParamList } from "../Navigators";
-import Icon from "@react-native-vector-icons/ionicons";
-import { useIconColor } from "../hooks/useTheme";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import { Text } from "~/components/ui/text";
 import { Label } from "~/components/ui/label";
@@ -28,6 +26,10 @@ import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
 import { copyToClipboard } from "~/lib/clipboardUtils";
 import { ConfirmationDialog } from "~/components/ConfirmationDialog";
 import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
+import {
+  NativeNoahPicker,
+  type NativeNoahPickerOption,
+} from "~/components/ui/NativeNoahPicker";
 
 const log = logger("DebugScreen");
 
@@ -118,12 +120,17 @@ const DEBUG_ACTIONS: ActionOption[] = [
   },
 ];
 
+type DebugActionSelection = DebugAction | "none";
+
+const DEBUG_ACTION_OPTIONS: readonly NativeNoahPickerOption<DebugActionSelection>[] = [
+  { value: "none", label: "Choose an action..." },
+  ...DEBUG_ACTIONS.map((action) => ({ value: action.id, label: action.title })),
+];
+
 const DebugScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList>>();
-  const iconColor = useIconColor();
   const { showAlert } = useAlert();
   const [selectedAction, setSelectedAction] = useState<DebugAction | null>(null);
-  const [isActionListOpen, setIsActionListOpen] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isDropDialogOpen, setIsDropDialogOpen] = useState(false);
@@ -322,9 +329,8 @@ const DebugScreen = () => {
     }
   };
 
-  const handleSelectAction = (action: DebugAction) => {
+  const handleSelectAction = (action: DebugAction | null) => {
     setSelectedAction(action);
-    setIsActionListOpen(false);
     setResultState(null);
     setInputValue("");
     setCopied(false);
@@ -360,67 +366,23 @@ const DebugScreen = () => {
       >
         <View className="mb-6 mt-6">
           <Label className="text-foreground text-2xl mb-2">Select Action</Label>
-
-          <Pressable
-            onPress={() => setIsActionListOpen((open) => !open)}
-            className="h-12 flex-row items-center justify-between rounded-md border border-input bg-background px-3"
-          >
+          <NativeNoahPicker
+            value={selectedAction ?? "none"}
+            options={DEBUG_ACTION_OPTIONS}
+            onValueChange={(value) => handleSelectAction(value === "none" ? null : value)}
+            testID="debug-action-picker"
+          />
+          {selectedActionConfig ? (
             <Text
-              className={
-                selectedActionConfig ? "text-foreground text-lg" : "text-muted-foreground text-lg"
-              }
-              numberOfLines={1}
+              className={`mt-2 text-sm ${
+                selectedAction === "dropVtxo"
+                  ? "text-red-700 dark:text-red-300"
+                  : "text-muted-foreground"
+              }`}
             >
-              {selectedActionConfig?.title ?? "Choose an action..."}
+              {selectedActionConfig.description}
             </Text>
-            <Icon
-              name={isActionListOpen ? "chevron-up" : "chevron-down"}
-              size={20}
-              color={iconColor}
-            />
-          </Pressable>
-
-          {isActionListOpen && (
-            <View className="mt-2 overflow-hidden rounded-md border border-border bg-popover">
-              {DEBUG_ACTIONS.map((action, index) => {
-                const isSelected = action.id === selectedAction;
-                const isDangerousAction = action.id === "dropVtxo";
-                return (
-                  <Pressable
-                    key={action.id}
-                    onPress={() => handleSelectAction(action.id)}
-                    className={`px-4 py-3 ${
-                      index < DEBUG_ACTIONS.length - 1 ? "border-b border-border/60" : ""
-                    } ${
-                      isDangerousAction
-                        ? "bg-red-50 dark:bg-red-950/30"
-                        : isSelected
-                          ? "bg-accent/40"
-                          : ""
-                    }`}
-                  >
-                    <View className="flex-row items-start gap-3">
-                      <View className="w-5 items-center pt-1">
-                        {isSelected ? <Icon name="checkmark" size={18} color={iconColor} /> : null}
-                      </View>
-                      <View className="min-w-0 flex-1">
-                        <Text
-                          className={`text-lg font-semibold ${
-                            isDangerousAction ? "text-red-700 dark:text-red-300" : "text-foreground"
-                          }`}
-                        >
-                          {action.title}
-                        </Text>
-                        <Text className="text-muted-foreground mt-1 text-sm">
-                          {action.description}
-                        </Text>
-                      </View>
-                    </View>
-                  </Pressable>
-                );
-              })}
-            </View>
-          )}
+          ) : null}
         </View>
 
         {selectedActionConfig?.requiresInput && (


### PR DESCRIPTION
## Summary

- add a shared native single-selection list backed by SwiftUI on iOS and Material 3 Compose on Android
- migrate Currency and Bitcoin Unit settings to native selection lists
- replace the Debug screen's custom expandable action list with the existing native menu picker
- treat simulator `device_not_supported` push registration as an expected no-op during server re-registration

## Why

The settings selectors were still custom React Native rows and the Debug picker duplicated platform behavior. The simulator registration flow also incorrectly treated unavailable push tokens as a fatal server-registration error.

## Impact

Currency, Bitcoin Unit, and Debug action selection now use native controls and accessibility semantics on both platforms. Simulator server-registration resets can complete without weakening physical-device push errors.

## Verification

- `bun --cwd client check`
- `bun --cwd client lint`
- `bun --cwd client typecheck`

Refs #250
