### PR TITLE
Add single VTXO refresh action

### DIFF
--- a/client/src/components/VtxoRefreshDialog.tsx
+++ b/client/src/components/VtxoRefreshDialog.tsx
@@ -1,0 +1,135 @@
+import { View } from "react-native";
+import type { BarkFeeEstimate } from "react-native-nitro-ark";
+
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
+import { useBtcToFiatRate } from "~/hooks/useMarketData";
+import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
+import { cn } from "~/lib/utils";
+import { useProfileStore } from "~/store/profileStore";
+
+import { ConfirmationDialog } from "./ConfirmationDialog";
+import { Text } from "./ui/text";
+
+const RefreshPlanRow = ({
+  label,
+  value,
+  valueClassName,
+}: {
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) => (
+  <View className="flex-row items-center justify-between py-2.5">
+    <Text className="text-sm text-muted-foreground" numberOfLines={1}>
+      {label}
+    </Text>
+    <Text
+      className={cn(
+        "ml-3 flex-shrink text-right text-sm font-semibold text-foreground",
+        valueClassName,
+      )}
+      numberOfLines={1}
+      adjustsFontSizeToFit
+      minimumFontScale={0.8}
+    >
+      {value}
+    </Text>
+  </View>
+);
+
+type VtxoRefreshDialogProps = {
+  amountSat: number;
+  estimate: BarkFeeEstimate | null;
+  isBusy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  vtxoCount: number;
+};
+
+export function VtxoRefreshDialog({
+  amountSat,
+  estimate,
+  isBusy,
+  onCancel,
+  onConfirm,
+  onOpenChange,
+  open,
+  vtxoCount,
+}: VtxoRefreshDialogProps) {
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
+  const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
+  const { data: btcToFiatRate } = useBtcToFiatRate();
+  const amountAfterFeeSat = Math.max(amountSat - (estimate?.fee_sat ?? 0), 0);
+
+  const formatBitcoinWithFiat = (valueSat: number) => {
+    if (btcToFiatRate === undefined) {
+      return formatBitcoinAmount(valueSat);
+    }
+
+    const fiatValue = formatFiatAmount(
+      satsToFiat(valueSat, btcToFiatRate, fiatCurrency),
+      fiatCurrency,
+    );
+    return `${formatBitcoinAmount(valueSat)} (${fiatValue})`;
+  };
+
+  return (
+    <ConfirmationDialog
+      title={vtxoCount === 1 ? "Refresh VTXO?" : "Refresh VTXOs?"}
+      description={
+        vtxoCount === 1
+          ? "This refreshes this VTXO in a delegated Ark round."
+          : "This refreshes the selected VTXOs in a delegated Ark round."
+      }
+      confirmText="Refresh"
+      cancelText="Cancel"
+      confirmVariant="default"
+      open={open}
+      onOpenChange={onOpenChange}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      isConfirmDisabled={isBusy || !estimate}
+      contentClassName="w-[92%] rounded-2xl border-border bg-background p-5"
+      headerClassName="gap-2"
+      titleClassName="text-2xl font-bold text-foreground"
+      descriptionClassName="text-base leading-6 text-muted-foreground"
+      footerClassName="mt-1 gap-3 space-x-0"
+      cancelClassName="h-12 rounded-xl border-border bg-background"
+      actionClassName="h-12 rounded-xl"
+    >
+      {estimate ? (
+        <View className="gap-3">
+          <View className="rounded-xl border border-border/70 bg-card/80 p-4">
+            <Text className="text-sm font-medium text-muted-foreground">Amount selected</Text>
+            <Text
+              className="mt-1 text-3xl font-bold text-foreground"
+              numberOfLines={1}
+              adjustsFontSizeToFit
+              minimumFontScale={0.72}
+            >
+              {formatBitcoinWithFiat(amountSat)}
+            </Text>
+          </View>
+
+          <View className="rounded-xl border border-border/70 bg-card/60 px-3 py-1">
+            <RefreshPlanRow label="VTXOs selected" value={vtxoCount.toLocaleString()} />
+            <View className="h-px bg-border/70" />
+            <RefreshPlanRow
+              label="Refresh fee"
+              value={formatBitcoinWithFiat(estimate.fee_sat)}
+              valueClassName="text-red-500"
+            />
+            <View className="h-px bg-border/70" />
+            <RefreshPlanRow
+              label="Amount after fee"
+              value={formatBitcoinWithFiat(amountAfterFeeSat)}
+              valueClassName="text-green-500"
+            />
+          </View>
+        </View>
+      ) : null}
+    </ConfirmationDialog>
+  );
+}

--- a/client/src/screens/VTXODetailScreen.tsx
+++ b/client/src/screens/VTXODetailScreen.tsx
@@ -8,14 +8,23 @@ import { useIconColor } from "../hooks/useTheme";
 import { copyToClipboard } from "../lib/clipboardUtils";
 import { useState } from "react";
 import { COLORS } from "~/lib/styleConstants";
-import type { BarkVtxo } from "react-native-nitro-ark";
+import type { BarkFeeEstimate, BarkVtxo } from "react-native-nitro-ark";
 import { useGetBlockHeight } from "~/hooks/useMarketData";
 import { getMempoolTxUrl } from "~/constants";
 import type { SettingsStackParamList } from "~/Navigators";
-import { useGetExpiringVtxos, useGetVtxos, useRefreshExpiringVtxos } from "~/hooks/useWallet";
+import {
+  useEstimateRefreshFee,
+  useGetExpiringVtxos,
+  useGetVtxos,
+  useRefreshSelectedVtxos,
+  useWalletSync,
+} from "~/hooks/useWallet";
 import { StatusBannerStrip } from "~/components/StatusBannerStrip";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
+import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
+import { VtxoRefreshDialog } from "~/components/VtxoRefreshDialog";
+import { useAlert } from "~/contexts/AlertProvider";
 
 type VTXOWithStatus = BarkVtxo & {
   isExpiring: boolean;
@@ -97,11 +106,16 @@ const VTXODetailScreen = () => {
   const route = useRoute();
   const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList>>();
   const formatBitcoinAmount = useBitcoinAmountFormatter();
+  const { showAlert } = useAlert();
+  const [refreshEstimate, setRefreshEstimate] = useState<BarkFeeEstimate | null>(null);
+  const [isRefreshDialogOpen, setIsRefreshDialogOpen] = useState(false);
   const { data: blockHeight } = useGetBlockHeight();
   const { vtxo: routeVtxo } = route.params as { vtxo: VTXOWithStatus };
   const { data: allVtxos = [] } = useGetVtxos();
   const { data: expiringVtxos } = useGetExpiringVtxos();
-  const refreshExpiringVtxos = useRefreshExpiringVtxos();
+  const estimateRefreshFee = useEstimateRefreshFee();
+  const refreshSelectedVtxos = useRefreshSelectedVtxos();
+  const walletSync = useWalletSync();
   const latestVtxo = allVtxos.find((item) => item.point === routeVtxo.point);
   const currentVtxo = latestVtxo ?? routeVtxo;
   const isLatestExpiring = expiringVtxos?.some((item) => item.point === currentVtxo.point);
@@ -114,7 +128,10 @@ const VTXODetailScreen = () => {
   const isExpired =
     vtxo.state !== "Locked" &&
     (blockHeight !== undefined ? vtxo.expiry_height <= blockHeight : vtxo.isExpired);
-  const canRefresh = vtxo.state !== "Locked" && (vtxo.isExpiring || isExpired);
+  const needsRefresh = vtxo.state !== "Locked" && (vtxo.isExpiring || isExpired);
+  const canRefresh = vtxo.state !== "Locked";
+  const isRefreshBusy =
+    estimateRefreshFee.isPending || refreshSelectedVtxos.isPending || walletSync.isPending;
   const statusLabel =
     vtxo.state === "Locked"
       ? "Locked"
@@ -148,6 +165,35 @@ const VTXODetailScreen = () => {
     return vtxo.isExpiring ? COLORS.BITCOIN_ORANGE : "#22c55e";
   };
 
+  const handleRefreshPress = () => {
+    setRefreshEstimate(null);
+    estimateRefreshFee.mutate([vtxo.id], {
+      onSuccess: (estimate) => {
+        setRefreshEstimate(estimate);
+        setIsRefreshDialogOpen(true);
+      },
+    });
+  };
+
+  const handleConfirmRefresh = () => {
+    walletSync.mutate(undefined, {
+      onSuccess: () => {
+        refreshSelectedVtxos.mutate([vtxo.id], {
+          onSuccess: () => {
+            setIsRefreshDialogOpen(false);
+            setRefreshEstimate(null);
+          },
+        });
+      },
+      onError: (error) => {
+        showAlert({
+          title: "Sync failed",
+          description: error instanceof Error ? error.message : String(error),
+        });
+      },
+    });
+  };
+
   return (
     <NoahSafeAreaView className="flex-1 bg-background">
       <View className="p-4 flex-1">
@@ -165,7 +211,7 @@ const VTXODetailScreen = () => {
           showsVerticalScrollIndicator={false}
           contentContainerStyle={{ paddingBottom: 50 }}
         >
-          {canRefresh ? (
+          {needsRefresh ? (
             <StatusBannerStrip
               className="mb-4"
               title={isExpired ? "VTXO expired" : "VTXO expiring soon"}
@@ -178,11 +224,6 @@ const VTXODetailScreen = () => {
                 />
               }
               tone={isExpired ? "failed" : "info"}
-              actionLabel="Refresh"
-              actionBusyLabel="Refreshing"
-              actionTextStyle={{ color: COLORS.BITCOIN_ORANGE }}
-              isActionLoading={refreshExpiringVtxos.isPending}
-              onActionPress={() => refreshExpiringVtxos.mutate()}
             />
           ) : null}
 
@@ -234,8 +275,44 @@ const VTXODetailScreen = () => {
             />
             <VTXODetailRow label="Server Public Key" value={vtxo.server_pubkey} copyable />
           </View>
+
+          {canRefresh ? (
+            <NativeNoahButton
+              label="Refresh VTXO"
+              loadingLabel="Estimating fee..."
+              onPress={handleRefreshPress}
+              disabled={refreshSelectedVtxos.isPending || walletSync.isPending}
+              isLoading={estimateRefreshFee.isPending}
+              fullWidth
+              size="lg"
+              className="mt-2 mb-4"
+              testID="vtxo-detail-refresh-button"
+            />
+          ) : null}
         </ScrollView>
       </View>
+
+      <VtxoRefreshDialog
+        amountSat={vtxo.amount}
+        estimate={refreshEstimate}
+        isBusy={isRefreshBusy}
+        open={isRefreshDialogOpen}
+        onOpenChange={(open) => {
+          if (refreshSelectedVtxos.isPending || walletSync.isPending) {
+            return;
+          }
+          setIsRefreshDialogOpen(open);
+          if (!open) {
+            setRefreshEstimate(null);
+          }
+        }}
+        onConfirm={handleConfirmRefresh}
+        onCancel={() => {
+          setIsRefreshDialogOpen(false);
+          setRefreshEstimate(null);
+        }}
+        vtxoCount={1}
+      />
     </NoahSafeAreaView>
   );
 };

--- a/client/src/screens/VTXODetailScreen.tsx
+++ b/client/src/screens/VTXODetailScreen.tsx
@@ -111,7 +111,7 @@ const VTXODetailScreen = () => {
   const [isRefreshDialogOpen, setIsRefreshDialogOpen] = useState(false);
   const { data: blockHeight } = useGetBlockHeight();
   const { vtxo: routeVtxo } = route.params as { vtxo: VTXOWithStatus };
-  const { data: allVtxos = [] } = useGetVtxos();
+  const { data: allVtxos = [], isSuccess: hasLoadedVtxos } = useGetVtxos();
   const { data: expiringVtxos } = useGetExpiringVtxos();
   const estimateRefreshFee = useEstimateRefreshFee();
   const refreshSelectedVtxos = useRefreshSelectedVtxos();
@@ -129,7 +129,8 @@ const VTXODetailScreen = () => {
     vtxo.state !== "Locked" &&
     (blockHeight !== undefined ? vtxo.expiry_height <= blockHeight : vtxo.isExpired);
   const needsRefresh = vtxo.state !== "Locked" && (vtxo.isExpiring || isExpired);
-  const canRefresh = vtxo.state !== "Locked";
+  const canRefresh =
+    hasLoadedVtxos && latestVtxo !== undefined && latestVtxo.state !== "Locked";
   const isRefreshBusy =
     estimateRefreshFee.isPending || refreshSelectedVtxos.isPending || walletSync.isPending;
   const statusLabel =

--- a/client/src/screens/VTXOsScreen.tsx
+++ b/client/src/screens/VTXOsScreen.tsx
@@ -18,18 +18,16 @@ import {
   useWalletSync,
 } from "~/hooks/useWallet";
 import { type BarkFeeEstimate, type BarkVtxo } from "react-native-nitro-ark";
-import { useBtcToFiatRate, useGetBlockHeight } from "~/hooks/useMarketData";
+import { useGetBlockHeight } from "~/hooks/useMarketData";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
-import { ConfirmationDialog } from "~/components/ConfirmationDialog";
-import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
-import { useProfileStore } from "~/store/profileStore";
 import { cn } from "~/lib/utils";
 import { useBottomTabBarHeight } from "react-native-bottom-tabs";
 import { PLATFORM } from "~/constants";
 import { useAlert } from "~/contexts/AlertProvider";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
+import { VtxoRefreshDialog } from "~/components/VtxoRefreshDialog";
 
 const EXPIRED_COLOR = "#ef4444";
 const EXPIRING_COLOR = "#f97316";
@@ -43,35 +41,10 @@ type VtxoFilter = "all" | "active" | "expiring" | "expired" | "locked";
 
 const filters: VtxoFilter[] = ["all", "active", "expiring", "expired", "locked"];
 
-const RefreshPlanRow = ({
-  label,
-  value,
-  valueClassName,
-}: {
-  label: string;
-  value: string;
-  valueClassName?: string;
-}) => (
-  <View className="flex-row items-center justify-between py-2.5">
-    <Text className="text-sm text-muted-foreground" numberOfLines={1}>
-      {label}
-    </Text>
-    <Text
-      className={cn("ml-3 flex-shrink text-right text-sm font-semibold text-foreground", valueClassName)}
-      numberOfLines={1}
-      adjustsFontSizeToFit
-      minimumFontScale={0.8}
-    >
-      {value}
-    </Text>
-  </View>
-);
-
 const VTXOsScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList>>();
   const iconColor = useIconColor();
   const formatBitcoinAmount = useBitcoinAmountFormatter();
-  const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
   const bottomTabBarHeight = useBottomTabBarHeight();
   const { bottom: safeBottomInset } = useSafeAreaInsets();
   const { showAlert } = useAlert();
@@ -84,7 +57,6 @@ const VTXOsScreen = () => {
   const { data: allVtxos = [], isLoading: isLoadingAll } = useGetVtxos();
   const { data: expiringVtxos = [], isLoading: isLoadingExpiring } = useGetExpiringVtxos();
   const { data: blockHeight, isLoading: isLoadingBlockHeight } = useGetBlockHeight();
-  const { data: btcToFiatRate } = useBtcToFiatRate();
   const estimateRefreshFee = useEstimateRefreshFee();
   const refreshSelectedVtxos = useRefreshSelectedVtxos();
   const walletSync = useWalletSync();
@@ -126,8 +98,8 @@ const VTXOsScreen = () => {
   const selectedVtxos = vtxosWithStatus.filter((vtxo) => selectedVtxoIds.has(vtxo.id));
   const selectedAmountSat = selectedVtxos.reduce((total, vtxo) => total + vtxo.amount, 0);
   const selectedVtxoIdList = selectedVtxos.map((vtxo) => vtxo.id);
-  const selectedAfterFeeSat = Math.max(selectedAmountSat - (refreshEstimate?.fee_sat ?? 0), 0);
-  const isBusy = estimateRefreshFee.isPending || refreshSelectedVtxos.isPending || walletSync.isPending;
+  const isBusy =
+    estimateRefreshFee.isPending || refreshSelectedVtxos.isPending || walletSync.isPending;
   const hasSelectableVtxos = vtxosWithStatus.some((vtxo) => vtxo.state !== "Locked");
 
   const getVtxoIcon = (vtxo: VTXOWithStatus) => {
@@ -172,23 +144,6 @@ const VTXOsScreen = () => {
       default:
         return null;
     }
-  };
-
-  const formatFiatValue = (amountSat: number) => {
-    if (btcToFiatRate === undefined) {
-      return "Unavailable";
-    }
-
-    return formatFiatAmount(satsToFiat(amountSat, btcToFiatRate, fiatCurrency), fiatCurrency);
-  };
-
-  const formatBitcoinWithFiat = (amountSat: number) => {
-    const fiatValue = formatFiatValue(amountSat);
-    if (fiatValue === "Unavailable") {
-      return formatBitcoinAmount(amountSat);
-    }
-
-    return `${formatBitcoinAmount(amountSat)} (${fiatValue})`;
   };
 
   const clearSelection = () => {
@@ -503,12 +458,10 @@ const VTXOsScreen = () => {
           )}
         </View>
 
-        <ConfirmationDialog
-          title="Refresh VTXOs?"
-          description="This refreshes the selected VTXOs in a delegated Ark round."
-          confirmText="Refresh"
-          cancelText="Cancel"
-          confirmVariant="default"
+        <VtxoRefreshDialog
+          amountSat={selectedAmountSat}
+          estimate={refreshEstimate}
+          isBusy={walletSync.isPending || refreshSelectedVtxos.isPending}
           open={isRefreshDialogOpen}
           onOpenChange={(open) => {
             if (walletSync.isPending || refreshSelectedVtxos.isPending) {
@@ -524,50 +477,8 @@ const VTXOsScreen = () => {
             setIsRefreshDialogOpen(false);
             setRefreshEstimate(null);
           }}
-          isConfirmDisabled={walletSync.isPending || refreshSelectedVtxos.isPending || !refreshEstimate}
-          contentClassName="w-[92%] rounded-2xl border-border bg-background p-5"
-          headerClassName="gap-2"
-          titleClassName="text-2xl font-bold text-foreground"
-          descriptionClassName="text-base leading-6 text-muted-foreground"
-          footerClassName="mt-1 gap-3 space-x-0"
-          cancelClassName="h-12 rounded-xl border-border bg-background"
-          actionClassName="h-12 rounded-xl"
-        >
-          {refreshEstimate ? (
-            <View className="gap-3">
-              <View className="rounded-xl border border-border/70 bg-card/80 p-4">
-                <Text className="text-sm font-medium text-muted-foreground">Amount selected</Text>
-                <Text
-                  className="mt-1 text-3xl font-bold text-foreground"
-                  numberOfLines={1}
-                  adjustsFontSizeToFit
-                  minimumFontScale={0.72}
-                >
-                  {formatBitcoinWithFiat(selectedAmountSat)}
-                </Text>
-              </View>
-
-              <View className="rounded-xl border border-border/70 bg-card/60 px-3 py-1">
-                <RefreshPlanRow
-                  label="VTXOs selected"
-                  value={selectedVtxos.length.toLocaleString()}
-                />
-                <View className="h-px bg-border/70" />
-                <RefreshPlanRow
-                  label="Refresh fee"
-                  value={formatBitcoinWithFiat(refreshEstimate.fee_sat)}
-                  valueClassName="text-red-500"
-                />
-                <View className="h-px bg-border/70" />
-                <RefreshPlanRow
-                  label="Amount after fee"
-                  value={formatBitcoinWithFiat(selectedAfterFeeSat)}
-                  valueClassName="text-green-500"
-                />
-              </View>
-            </View>
-          ) : null}
-        </ConfirmationDialog>
+          vtxoCount={selectedVtxos.length}
+        />
       </NoahSafeAreaView>
     </GestureHandlerRootView>
   );


### PR DESCRIPTION
## Summary

- add a full-width native refresh action to the VTXO detail screen
- estimate the fee for only the displayed VTXO before asking for confirmation
- share the fee breakdown dialog with the existing multi-select refresh flow
- keep locked VTXOs non-refreshable and retain expiry warnings as informational status

## Why

Refreshing from the detail screen previously called the broad expiring-VTXO maintenance flow without showing fees. Users can now refresh the VTXO they are viewing with the same amount, fee, and post-fee confirmation they see in the selection workflow.

## Validation

- `bun run lint`
- `bun run typecheck`
- commit hook: `bun --cwd client check`
