### PR TITLE
Add configurable Esplora endpoint

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -79,6 +79,9 @@ jobs:
       - name: ✨ Lint code
         run: nix develop .# --command bash -c "bun client lint"
 
+      - name: 🧪 Run unit tests
+        run: nix develop .# --command bash -c "bun client test:unit"
+
       - name: 🔍 Typecheck code
         run: nix develop .# --command bash -c "bun client typecheck"
 

--- a/client/metro.config.js
+++ b/client/metro.config.js
@@ -17,8 +17,11 @@ config.resolver.extraNodeModules = {
   "~": projectRoot,
 };
 
-// Prevent "Nitro linked twice" error in monorepo by excluding duplicate copies
-config.resolver.blockList = [/node_modules\/.*\/node_modules\/react-native-nitro-modules\/.*/];
+// Prevent duplicate Nitro linkage and keep unit tests out of production bundles
+config.resolver.blockList = [
+  /node_modules\/.*\/node_modules\/react-native-nitro-modules\/.*/,
+  /[/\\]tests[/\\].*/,
+];
 
 module.exports = withUniwindConfig(config, {
   cssEntryFile: "./global.css",

--- a/client/nitromodules/noah-tools/android/src/main/java/com/margelo/nitro/noahtools/NoahPushService.kt
+++ b/client/nitromodules/noah-tools/android/src/main/java/com/margelo/nitro/noahtools/NoahPushService.kt
@@ -475,6 +475,29 @@ class NoahPushService : PushService() {
         }
     }
 
+    private fun readEsploraFromStorage(context: Context, appVariant: String): String? {
+        return try {
+            val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+
+            val prefs = EncryptedSharedPreferences.create(
+                "noah_native_secrets",
+                masterKeyAlias,
+                context,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+
+            prefs.getString("esplora_$appVariant", null)
+        } catch (e: Exception) {
+            NoahToolsLogging.performNativeLog(
+                "warn",
+                "NoahPushService",
+                "Unable to read custom Esplora endpoint: ${e.message}"
+            )
+            null
+        }
+    }
+
     private fun loadBarkConfig(context: Context, appVariant: String, configConstructor: Constructor<*>): Any? {
         val configJson = readConfigJson(context) ?: return null
         val variantJson = configJson.optJSONObject(appVariant)
@@ -490,7 +513,8 @@ class NoahPushService : PushService() {
                 variantJson.requireInt("vtxoRefreshExpiryThreshold"),
                 variantJson.requireLong("fallbackFeeRate"),
                 null,
-                variantJson.optNullableString("esplora"),
+                readEsploraFromStorage(context, appVariant)
+                    ?: variantJson.optNullableString("esplora"),
                 variantJson.optNullableString("bitcoind"),
                 variantJson.optNullableString("bitcoindCookie"),
                 variantJson.optNullableString("bitcoindUser"),

--- a/client/nitromodules/noah-tools/android/src/main/java/com/margelo/nitro/noahtools/NoahTools.kt
+++ b/client/nitromodules/noah-tools/android/src/main/java/com/margelo/nitro/noahtools/NoahTools.kt
@@ -352,4 +352,54 @@ class NoahTools : HybridNoahToolsSpec() {
         }
     }
 
+    override fun storeNativeEsploraEndpoint(endpoint: String): Promise<Unit> {
+        return Promise.async {
+            val context = NitroModules.applicationContext ?: return@async
+            val variant = when (context.packageName) {
+                "com.noahwallet.regtest" -> "regtest"
+                "com.noahwallet.signet" -> "signet"
+                else -> "mainnet"
+            }
+
+            try {
+                val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+                val prefs = EncryptedSharedPreferences.create(
+                    "noah_native_secrets",
+                    masterKeyAlias,
+                    context,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+                )
+                prefs.edit().putString("esplora_$variant", endpoint).apply()
+            } catch (e: Exception) {
+                throw Exception("Failed to store native Esplora endpoint: ${e.message}", e)
+            }
+        }
+    }
+
+    override fun clearNativeEsploraEndpoint(): Promise<Unit> {
+        return Promise.async {
+            val context = NitroModules.applicationContext ?: return@async
+            val variant = when (context.packageName) {
+                "com.noahwallet.regtest" -> "regtest"
+                "com.noahwallet.signet" -> "signet"
+                else -> "mainnet"
+            }
+
+            try {
+                val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+                val prefs = EncryptedSharedPreferences.create(
+                    "noah_native_secrets",
+                    masterKeyAlias,
+                    context,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+                )
+                prefs.edit().remove("esplora_$variant").apply()
+            } catch (e: Exception) {
+                throw Exception("Failed to clear native Esplora endpoint: ${e.message}", e)
+            }
+        }
+    }
+
 }

--- a/client/nitromodules/noah-tools/ios/NoahTools.swift
+++ b/client/nitromodules/noah-tools/ios/NoahTools.swift
@@ -189,6 +189,20 @@ class NoahTools: HybridNoahToolsSpec {
         promise.resolve()
         return promise
     }
+
+    func storeNativeEsploraEndpoint(endpoint: String) throws -> Promise<Void> {
+        // This is Android-only, no-op on iOS
+        let promise = Promise<Void>()
+        promise.resolve()
+        return promise
+    }
+
+    func clearNativeEsploraEndpoint() throws -> Promise<Void> {
+        // This is Android-only, no-op on iOS
+        let promise = Promise<Void>()
+        promise.resolve()
+        return promise
+    }
 }
 
 // Include the extensions from other files

--- a/client/nitromodules/noah-tools/nitrogen/generated/android/c++/JHybridNoahToolsSpec.cpp
+++ b/client/nitromodules/noah-tools/nitrogen/generated/android/c++/JHybridNoahToolsSpec.cpp
@@ -411,5 +411,35 @@ namespace margelo::nitro::noahtools {
       return __promise;
     }();
   }
+  std::shared_ptr<Promise<void>> JHybridNoahToolsSpec::storeNativeEsploraEndpoint(const std::string& endpoint) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* endpoint */)>("storeNativeEsploraEndpoint");
+    auto __result = method(_javaPart, jni::make_jstring(endpoint));
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
+  std::shared_ptr<Promise<void>> JHybridNoahToolsSpec::clearNativeEsploraEndpoint() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("clearNativeEsploraEndpoint");
+    auto __result = method(_javaPart);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
 
 } // namespace margelo::nitro::noahtools

--- a/client/nitromodules/noah-tools/nitrogen/generated/android/c++/JHybridNoahToolsSpec.hpp
+++ b/client/nitromodules/noah-tools/nitrogen/generated/android/c++/JHybridNoahToolsSpec.hpp
@@ -84,6 +84,8 @@ namespace margelo::nitro::noahtools {
     void setUnifiedPushDistributor(const std::optional<std::variant<nitro::NullType, std::string>>& distributorId) override;
     std::shared_ptr<Promise<void>> storeNativeMnemonic(const std::string& mnemonic) override;
     std::shared_ptr<Promise<void>> clearNativeMnemonic() override;
+    std::shared_ptr<Promise<void>> storeNativeEsploraEndpoint(const std::string& endpoint) override;
+    std::shared_ptr<Promise<void>> clearNativeEsploraEndpoint() override;
 
   private:
     jni::global_ref<JHybridNoahToolsSpec::JavaPart> _javaPart;

--- a/client/nitromodules/noah-tools/nitrogen/generated/android/kotlin/com/margelo/nitro/noahtools/HybridNoahToolsSpec.kt
+++ b/client/nitromodules/noah-tools/nitrogen/generated/android/kotlin/com/margelo/nitro/noahtools/HybridNoahToolsSpec.kt
@@ -150,6 +150,14 @@ abstract class HybridNoahToolsSpec: HybridObject() {
   @Keep
   abstract fun clearNativeMnemonic(): Promise<Unit>
 
+  @DoNotStrip
+  @Keep
+  abstract fun storeNativeEsploraEndpoint(endpoint: String): Promise<Unit>
+
+  @DoNotStrip
+  @Keep
+  abstract fun clearNativeEsploraEndpoint(): Promise<Unit>
+
   // Default implementation of `HybridObject.toString()`
   override fun toString(): String {
     return "[HybridObject NoahTools]"

--- a/client/nitromodules/noah-tools/nitrogen/generated/ios/c++/HybridNoahToolsSpecSwift.hpp
+++ b/client/nitromodules/noah-tools/nitrogen/generated/ios/c++/HybridNoahToolsSpecSwift.hpp
@@ -307,6 +307,22 @@ namespace margelo::nitro::noahtools {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline std::shared_ptr<Promise<void>> storeNativeEsploraEndpoint(const std::string& endpoint) override {
+      auto __result = _swiftPart.storeNativeEsploraEndpoint(endpoint);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::shared_ptr<Promise<void>> clearNativeEsploraEndpoint() override {
+      auto __result = _swiftPart.clearNativeEsploraEndpoint();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
 
   private:
     NoahTools::HybridNoahToolsSpec_cxx _swiftPart;

--- a/client/nitromodules/noah-tools/nitrogen/generated/ios/swift/HybridNoahToolsSpec.swift
+++ b/client/nitromodules/noah-tools/nitrogen/generated/ios/swift/HybridNoahToolsSpec.swift
@@ -43,6 +43,8 @@ public protocol HybridNoahToolsSpec_protocol: HybridObject {
   func setUnifiedPushDistributor(distributorId: Variant_NullType_String?) throws -> Void
   func storeNativeMnemonic(mnemonic: String) throws -> Promise<Void>
   func clearNativeMnemonic() throws -> Promise<Void>
+  func storeNativeEsploraEndpoint(endpoint: String) throws -> Promise<Void>
+  func clearNativeEsploraEndpoint() throws -> Promise<Void>
 }
 
 public extension HybridNoahToolsSpec_protocol {

--- a/client/nitromodules/noah-tools/nitrogen/generated/ios/swift/HybridNoahToolsSpec_cxx.swift
+++ b/client/nitromodules/noah-tools/nitrogen/generated/ios/swift/HybridNoahToolsSpec_cxx.swift
@@ -643,4 +643,42 @@ open class HybridNoahToolsSpec_cxx {
       return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
     }
   }
+
+  @inline(__always)
+  public final func storeNativeEsploraEndpoint(endpoint: std.string) -> bridge.Result_std__shared_ptr_Promise_void___ {
+    do {
+      let __result = try self.__implementation.storeNativeEsploraEndpoint(endpoint: String(endpoint))
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
+    }
+  }
+
+  @inline(__always)
+  public final func clearNativeEsploraEndpoint() -> bridge.Result_std__shared_ptr_Promise_void___ {
+    do {
+      let __result = try self.__implementation.clearNativeEsploraEndpoint()
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
+    }
+  }
 }

--- a/client/nitromodules/noah-tools/nitrogen/generated/shared/c++/HybridNoahToolsSpec.cpp
+++ b/client/nitromodules/noah-tools/nitrogen/generated/shared/c++/HybridNoahToolsSpec.cpp
@@ -44,6 +44,8 @@ namespace margelo::nitro::noahtools {
       prototype.registerHybridMethod("setUnifiedPushDistributor", &HybridNoahToolsSpec::setUnifiedPushDistributor);
       prototype.registerHybridMethod("storeNativeMnemonic", &HybridNoahToolsSpec::storeNativeMnemonic);
       prototype.registerHybridMethod("clearNativeMnemonic", &HybridNoahToolsSpec::clearNativeMnemonic);
+      prototype.registerHybridMethod("storeNativeEsploraEndpoint", &HybridNoahToolsSpec::storeNativeEsploraEndpoint);
+      prototype.registerHybridMethod("clearNativeEsploraEndpoint", &HybridNoahToolsSpec::clearNativeEsploraEndpoint);
     });
   }
 

--- a/client/nitromodules/noah-tools/nitrogen/generated/shared/c++/HybridNoahToolsSpec.hpp
+++ b/client/nitromodules/noah-tools/nitrogen/generated/shared/c++/HybridNoahToolsSpec.hpp
@@ -95,6 +95,8 @@ namespace margelo::nitro::noahtools {
       virtual void setUnifiedPushDistributor(const std::optional<std::variant<nitro::NullType, std::string>>& distributorId) = 0;
       virtual std::shared_ptr<Promise<void>> storeNativeMnemonic(const std::string& mnemonic) = 0;
       virtual std::shared_ptr<Promise<void>> clearNativeMnemonic() = 0;
+      virtual std::shared_ptr<Promise<void>> storeNativeEsploraEndpoint(const std::string& endpoint) = 0;
+      virtual std::shared_ptr<Promise<void>> clearNativeEsploraEndpoint() = 0;
 
     protected:
       // Hybrid Setup

--- a/client/nitromodules/noah-tools/src/NoahTools.nitro.ts
+++ b/client/nitromodules/noah-tools/src/NoahTools.nitro.ts
@@ -103,4 +103,6 @@ export interface NoahTools extends HybridObject<{ ios: "swift"; android: "kotlin
   setUnifiedPushDistributor(distributorId: string | null): void;
   storeNativeMnemonic(mnemonic: string): Promise<void>;
   clearNativeMnemonic(): Promise<void>;
+  storeNativeEsploraEndpoint(endpoint: string): Promise<void>;
+  clearNativeEsploraEndpoint(): Promise<void>;
 }

--- a/client/nitromodules/noah-tools/src/index.tsx
+++ b/client/nitromodules/noah-tools/src/index.tsx
@@ -184,4 +184,12 @@ export function clearNativeMnemonic(): Promise<void> {
   return NoahToolsHybridObject.clearNativeMnemonic();
 }
 
+export function storeNativeEsploraEndpoint(endpoint: string): Promise<void> {
+  return NoahToolsHybridObject.storeNativeEsploraEndpoint(endpoint);
+}
+
+export function clearNativeEsploraEndpoint(): Promise<void> {
+  return NoahToolsHybridObject.clearNativeEsploraEndpoint();
+}
+
 export type { HttpResponse } from "./NoahTools.nitro";

--- a/client/package.json
+++ b/client/package.json
@@ -44,8 +44,9 @@
     "nitrogen": "bun --cwd nitromodules/noah-tools nitrogen",
     "format": "prettier --write .",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "test:unit": "bun test tests/unit",
     "typecheck": "tsc --noEmit",
-    "check": "bun run lint && bun run typecheck",
+    "check": "bun run lint && bun run test:unit && bun run typecheck",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "maestro:test": "maestro test --debug-output maestro-debug-output .maestro"

--- a/client/src/Navigators.tsx
+++ b/client/src/Navigators.tsx
@@ -39,6 +39,7 @@ import QRHubScreen from "~/screens/QRHubScreen";
 import ProfileScreen from "~/screens/ProfileScreen";
 import CurrencySettingsScreen from "~/screens/CurrencySettingsScreen";
 import BitcoinUnitSettingsScreen from "~/screens/BitcoinUnitSettingsScreen";
+import EsploraSettingsScreen from "~/screens/EsploraSettingsScreen";
 import WalletLoader from "~/components/WalletLoader";
 import { useWalletStore } from "~/store/walletStore";
 import { useServerStore } from "~/store/serverStore";
@@ -75,6 +76,7 @@ export type SettingsStackParamList = {
   Profile: undefined;
   Currency: undefined;
   BitcoinUnit: undefined;
+  Esplora: undefined;
   Mnemonic: { fromOnboarding: boolean };
   Logs: undefined;
   EmailVerification: { fromSettings?: boolean } | undefined;
@@ -139,6 +141,11 @@ const SettingsStackNav = () => (
     <Stack.Screen
       name="BitcoinUnit"
       component={BitcoinUnitSettingsScreen}
+      options={{ animation: "default" }}
+    />
+    <Stack.Screen
+      name="Esplora"
+      component={EsploraSettingsScreen}
       options={{ animation: "default" }}
     />
     <Stack.Screen name="Mnemonic" component={MnemonicScreen} options={{ animation: "default" }} />

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -81,7 +81,7 @@ export const getLnurlDomain = (): string => {
   }
 };
 
-type WalletCreationOptions = Omit<BarkCreateOpts, "mnemonic">;
+export type WalletCreationOptions = Omit<BarkCreateOpts, "mnemonic">;
 
 export const SIGNET_CONFIG: WalletCreationOptions = {
   regtest: false,
@@ -155,7 +155,7 @@ export const msatToSatoshi = (msat: number) => msat / 1000;
 export const mempoolPriceEndpoint = `${getServerEndpoint()}/v0/prices`;
 export const mempoolHistoricalPriceEndpoint = `${getServerEndpoint()}/v0/historical-price`;
 
-export const getBlockheightEndpoint = () => {
+export const getDefaultBlockheightEndpoint = () => {
   switch (APP_VARIANT) {
     case "mainnet":
       return "https://mempool.second.tech/api/blocks/tip/height";
@@ -164,20 +164,6 @@ export const getBlockheightEndpoint = () => {
     case "regtest":
       return `http://${REGTEST_URL}:18443`;
   }
-};
-
-export const getEsploraApiBaseUrl = (): string | null => {
-  if (APP_VARIANT === "regtest") {
-    return null;
-  }
-
-  const esplora = ACTIVE_WALLET_CONFIG.config?.esplora;
-  if (!esplora) {
-    return null;
-  }
-
-  const withProtocol = /^https?:\/\//.test(esplora) ? esplora : `https://${esplora}`;
-  return withProtocol.replace(/\/+$/, "");
 };
 
 export const getMempoolTxUrl = (anchorPoint: string): string | null => {

--- a/client/src/hooks/useEsplora.ts
+++ b/client/src/hooks/useEsplora.ts
@@ -1,0 +1,23 @@
+import { useMutation } from "@tanstack/react-query";
+import { useBackgroundJobCoordination } from "~/hooks/useBackgroundJobCoordination";
+import { switchEsploraEndpoint } from "~/lib/walletApi";
+import { queryClient } from "~/queryClient";
+
+export const useSwitchEsploraEndpoint = () => {
+  const { safelyExecuteWhenReady } = useBackgroundJobCoordination();
+
+  return useMutation({
+    mutationFn: async (endpointOverride: string | null) => {
+      return safelyExecuteWhenReady(async () => {
+        const result = await switchEsploraEndpoint(endpointOverride);
+        if (result.isErr()) {
+          throw result.error;
+        }
+        return result.value;
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries();
+    },
+  });
+};

--- a/client/src/hooks/useMarketData.ts
+++ b/client/src/hooks/useMarketData.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { getBlockheightEndpoint, REGTEST_CONFIG } from "~/constants";
+import { REGTEST_CONFIG } from "~/constants";
+import { getBlockheightEndpoint } from "~/lib/esplora";
 import ky from "ky";
 import logger from "~/lib/log";
 
@@ -10,6 +11,7 @@ import { APP_VARIANT } from "~/config";
 import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { getFiatPrices, getHistoricalFiatPrice } from "~/lib/api";
 import { useProfileStore } from "~/store/profileStore";
+import { useEsploraStore } from "~/store/esploraStore";
 
 const HISTORICAL_RATE_CACHE_MAX_SIZE = 200;
 type HistoricalRateLookup = {
@@ -82,7 +84,7 @@ export const getBlockHeight = async (): Promise<Result<number, Error>> => {
 
   const result = await ResultAsync.fromPromise(
     ky.get(url).text(),
-    (e) => new Error(`Failed to fetch blockheight from mempool.space: ${e}`),
+    (e) => new Error(`Failed to fetch blockheight from Esplora: ${e}`),
   ).andThen((data) => {
     const height = parseInt(data, 10);
     if (!isNaN(height)) {
@@ -95,8 +97,10 @@ export const getBlockHeight = async (): Promise<Result<number, Error>> => {
 };
 
 export function useGetBlockHeight() {
+  const endpointOverride = useEsploraStore((state) => state.endpointOverride);
+
   return useQuery({
-    queryKey: ["getBlockHeight"],
+    queryKey: ["getBlockHeight", endpointOverride],
     queryFn: async () => {
       const result = await getBlockHeight();
       if (result.isErr()) {

--- a/client/src/hooks/useTransactions.ts
+++ b/client/src/hooks/useTransactions.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { validateBitcoinAddress } from "bip-321";
 import ky from "ky";
-import { getEsploraApiBaseUrl } from "~/constants";
+import { getEsploraApiBaseUrl } from "~/lib/esplora";
 import { history, onchainTransactions } from "~/lib/paymentsApi";
 import { loadWalletIfNeeded } from "~/lib/walletApi";
 import { useWalletStore } from "~/store/walletStore";
@@ -13,6 +13,7 @@ import { getHistoricalBtcToFiatRate } from "~/hooks/useMarketData";
 import logger from "~/lib/log";
 import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { useProfileStore } from "~/store/profileStore";
+import { useEsploraStore } from "~/store/esploraStore";
 import {
   BARK_SUBSYSTEM,
   type BarkSubsystemId,
@@ -435,11 +436,12 @@ const fetchAndTransformTransactions = async (
 export const useTransactions = (options?: { enabled?: boolean }) => {
   const { isInitialized, isWalletLoaded, isWalletSuspended } = useWalletStore();
   const preferredCurrency = useProfileStore((state) => state.preferredCurrency);
+  const endpointOverride = useEsploraStore((state) => state.endpointOverride);
   const enabled =
     (options?.enabled ?? true) && isInitialized && isWalletLoaded && !isWalletSuspended;
 
   return useQuery({
-    queryKey: ["transactions", preferredCurrency],
+    queryKey: ["transactions", preferredCurrency, endpointOverride],
     queryFn: () => fetchAndTransformTransactions(preferredCurrency),
     enabled,
     staleTime: 30 * 1000,

--- a/client/src/hooks/useWallet.ts
+++ b/client/src/hooks/useWallet.ts
@@ -26,6 +26,7 @@ import { deregister } from "../lib/api";
 import { queryClient } from "~/queryClient";
 import { useTransactionStore } from "../store/transactionStore";
 import { useBackupStore } from "~/store/backupStore";
+import { useEsploraStore } from "~/store/esploraStore";
 import { ResultAsync } from "neverthrow";
 import logger from "~/lib/log";
 
@@ -367,6 +368,7 @@ export function useDeleteWallet() {
       useWalletStore.getState().reset();
       useServerStore.getState().resetRegistration();
       useBackupStore.getState().reset();
+      useEsploraStore.getState().reset();
 
       // Clear query cache
       queryClient.clear();

--- a/client/src/lib/esplora.ts
+++ b/client/src/lib/esplora.ts
@@ -8,12 +8,17 @@ import {
 import { APP_VARIANT } from "~/config";
 import { useEsploraStore } from "~/store/esploraStore";
 import {
+  getEsploraGenesisHashUrl,
   getEsploraTipHeightUrl,
   normalizeEsploraEndpoint,
-  parseEsploraTipHeight,
+  validateEsploraGenesisHash,
 } from "~/lib/esploraUrl";
 
 const ESPLORA_VALIDATION_TIMEOUT_MS = 5000;
+const ESPLORA_GENESIS_HASHES = {
+  mainnet: "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+  signet: "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
+} as const;
 
 export const getDefaultEsploraEndpoint = (): string | null => {
   if (APP_VARIANT === "regtest") {
@@ -65,10 +70,14 @@ export const validateEsploraEndpoint = async (value: string): Promise<Result<str
     return err(normalizedResult.error);
   }
 
+  if (APP_VARIANT === "regtest") {
+    return err(new Error("Regtest wallets use Bitcoin Core instead of Esplora."));
+  }
+
   const endpoint = normalizedResult.value;
   const responseResult = await ResultAsync.fromPromise(
     ky
-      .get(getEsploraTipHeightUrl(endpoint), {
+      .get(getEsploraGenesisHashUrl(endpoint), {
         retry: 0,
         timeout: ESPLORA_VALIDATION_TIMEOUT_MS,
       })
@@ -80,9 +89,12 @@ export const validateEsploraEndpoint = async (value: string): Promise<Result<str
     return err(responseResult.error);
   }
 
-  const heightResult = parseEsploraTipHeight(responseResult.value);
-  if (heightResult.isErr()) {
-    return err(heightResult.error);
+  const genesisHashResult = validateEsploraGenesisHash(
+    responseResult.value,
+    ESPLORA_GENESIS_HASHES[APP_VARIANT],
+  );
+  if (genesisHashResult.isErr()) {
+    return err(genesisHashResult.error);
   }
 
   return ok(endpoint);

--- a/client/src/lib/esplora.ts
+++ b/client/src/lib/esplora.ts
@@ -1,0 +1,89 @@
+import ky from "ky";
+import { err, ok, ResultAsync, type Result } from "neverthrow";
+import {
+  ACTIVE_WALLET_CONFIG,
+  getDefaultBlockheightEndpoint,
+  type WalletCreationOptions,
+} from "~/constants";
+import { APP_VARIANT } from "~/config";
+import { useEsploraStore } from "~/store/esploraStore";
+import {
+  getEsploraTipHeightUrl,
+  normalizeEsploraEndpoint,
+  parseEsploraTipHeight,
+} from "~/lib/esploraUrl";
+
+const ESPLORA_VALIDATION_TIMEOUT_MS = 5000;
+
+export const getDefaultEsploraEndpoint = (): string | null => {
+  if (APP_VARIANT === "regtest") {
+    return null;
+  }
+
+  const configuredEndpoint = ACTIVE_WALLET_CONFIG.config?.esplora;
+  if (!configuredEndpoint) {
+    return null;
+  }
+
+  return normalizeEsploraEndpoint(configuredEndpoint).unwrapOr(null);
+};
+
+export const getEffectiveEsploraEndpoint = (): string | null =>
+  useEsploraStore.getState().endpointOverride ?? getDefaultEsploraEndpoint();
+
+export const getEsploraApiBaseUrl = getEffectiveEsploraEndpoint;
+
+export const getActiveWalletConfig = (
+  esploraEndpoint = getEffectiveEsploraEndpoint(),
+): WalletCreationOptions => {
+  const config = ACTIVE_WALLET_CONFIG.config;
+  if (!config) {
+    return { ...ACTIVE_WALLET_CONFIG };
+  }
+
+  return {
+    ...ACTIVE_WALLET_CONFIG,
+    config: {
+      ...config,
+      ...(APP_VARIANT !== "regtest" && esploraEndpoint ? { esplora: esploraEndpoint } : {}),
+    },
+  };
+};
+
+export const getBlockheightEndpoint = (): string => {
+  const endpointOverride = useEsploraStore.getState().endpointOverride;
+  if (APP_VARIANT !== "regtest" && endpointOverride) {
+    return getEsploraTipHeightUrl(endpointOverride);
+  }
+
+  return getDefaultBlockheightEndpoint();
+};
+
+export const validateEsploraEndpoint = async (value: string): Promise<Result<string, Error>> => {
+  const normalizedResult = normalizeEsploraEndpoint(value);
+  if (normalizedResult.isErr()) {
+    return err(normalizedResult.error);
+  }
+
+  const endpoint = normalizedResult.value;
+  const responseResult = await ResultAsync.fromPromise(
+    ky
+      .get(getEsploraTipHeightUrl(endpoint), {
+        retry: 0,
+        timeout: ESPLORA_VALIDATION_TIMEOUT_MS,
+      })
+      .text(),
+    (error) => new Error(`Unable to reach the Esplora endpoint: ${String(error)}`),
+  );
+
+  if (responseResult.isErr()) {
+    return err(responseResult.error);
+  }
+
+  const heightResult = parseEsploraTipHeight(responseResult.value);
+  if (heightResult.isErr()) {
+    return err(heightResult.error);
+  }
+
+  return ok(endpoint);
+};

--- a/client/src/lib/esploraUrl.test.js
+++ b/client/src/lib/esploraUrl.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getEsploraTipHeightUrl,
+  normalizeEsploraEndpoint,
+  parseEsploraTipHeight,
+} from "./esploraUrl";
+
+describe("normalizeEsploraEndpoint", () => {
+  test("normalizes a bare host and trailing slash", () => {
+    expect(normalizeEsploraEndpoint(" mempool.space/api/ ")._unsafeUnwrap()).toBe(
+      "https://mempool.space/api",
+    );
+  });
+
+  test("accepts a tip URL and stores its Esplora base URL", () => {
+    expect(
+      normalizeEsploraEndpoint("https://mempool.space/api/blocks/tip/height")._unsafeUnwrap(),
+    ).toBe("https://mempool.space/api");
+    expect(
+      normalizeEsploraEndpoint("https://mempool.space/api/blocks/tip/hash")._unsafeUnwrap(),
+    ).toBe("https://mempool.space/api");
+  });
+
+  test("rejects credentials and query strings", () => {
+    expect(normalizeEsploraEndpoint("https://user:pass@example.com/api").isErr()).toBe(true);
+    expect(normalizeEsploraEndpoint("https://example.com/api?token=secret").isErr()).toBe(true);
+  });
+});
+
+describe("Esplora tip height", () => {
+  test("builds the probe URL", () => {
+    expect(getEsploraTipHeightUrl("https://mempool.space/api/")).toBe(
+      "https://mempool.space/api/blocks/tip/height",
+    );
+  });
+
+  test("parses an integer height and rejects other responses", () => {
+    expect(parseEsploraTipHeight(" 900000\n")._unsafeUnwrap()).toBe(900000);
+    expect(parseEsploraTipHeight("not-a-height").isErr()).toBe(true);
+    expect(parseEsploraTipHeight("1.5").isErr()).toBe(true);
+  });
+});

--- a/client/src/lib/esploraUrl.test.js
+++ b/client/src/lib/esploraUrl.test.js
@@ -1,9 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import {
+  getEsploraGenesisHashUrl,
   getEsploraTipHeightUrl,
   normalizeEsploraEndpoint,
-  parseEsploraTipHeight,
+  parseEsploraBlockHash,
+  validateEsploraGenesisHash,
 } from "./esploraUrl";
+
+const MAINNET_GENESIS_HASH =
+  "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+const SIGNET_GENESIS_HASH =
+  "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6";
 
 describe("normalizeEsploraEndpoint", () => {
   test("normalizes a bare host and trailing slash", () => {
@@ -12,12 +19,15 @@ describe("normalizeEsploraEndpoint", () => {
     );
   });
 
-  test("accepts a tip URL and stores its Esplora base URL", () => {
+  test("accepts supported Esplora URLs and stores their base URL", () => {
     expect(
       normalizeEsploraEndpoint("https://mempool.space/api/blocks/tip/height")._unsafeUnwrap(),
     ).toBe("https://mempool.space/api");
     expect(
       normalizeEsploraEndpoint("https://mempool.space/api/blocks/tip/hash")._unsafeUnwrap(),
+    ).toBe("https://mempool.space/api");
+    expect(
+      normalizeEsploraEndpoint("https://mempool.space/api/block-height/0")._unsafeUnwrap(),
     ).toBe("https://mempool.space/api");
   });
 
@@ -27,16 +37,26 @@ describe("normalizeEsploraEndpoint", () => {
   });
 });
 
-describe("Esplora tip height", () => {
-  test("builds the probe URL", () => {
+describe("Esplora URLs", () => {
+  test("builds tip-height and genesis-hash URLs", () => {
     expect(getEsploraTipHeightUrl("https://mempool.space/api/")).toBe(
       "https://mempool.space/api/blocks/tip/height",
     );
+    expect(getEsploraGenesisHashUrl("https://mempool.space/api/")).toBe(
+      "https://mempool.space/api/block-height/0",
+    );
   });
 
-  test("parses an integer height and rejects other responses", () => {
-    expect(parseEsploraTipHeight(" 900000\n")._unsafeUnwrap()).toBe(900000);
-    expect(parseEsploraTipHeight("not-a-height").isErr()).toBe(true);
-    expect(parseEsploraTipHeight("1.5").isErr()).toBe(true);
+  test("parses a block hash and rejects other responses", () => {
+    expect(parseEsploraBlockHash(` ${SIGNET_GENESIS_HASH.toUpperCase()}\n`)._unsafeUnwrap()).toBe(
+      SIGNET_GENESIS_HASH,
+    );
+    expect(parseEsploraBlockHash("not-a-hash").isErr()).toBe(true);
+    expect(parseEsploraBlockHash("0".repeat(63)).isErr()).toBe(true);
+  });
+
+  test("accepts the expected genesis hash and rejects another network", () => {
+    expect(validateEsploraGenesisHash(SIGNET_GENESIS_HASH, SIGNET_GENESIS_HASH).isOk()).toBe(true);
+    expect(validateEsploraGenesisHash(MAINNET_GENESIS_HASH, SIGNET_GENESIS_HASH).isErr()).toBe(true);
   });
 });

--- a/client/src/lib/esploraUrl.ts
+++ b/client/src/lib/esploraUrl.ts
@@ -1,6 +1,10 @@
 import { err, ok, type Result } from "neverthrow";
 
-const TIP_ENDPOINT_SUFFIXES = ["/blocks/tip/height", "/blocks/tip/hash"] as const;
+const ESPLORA_ENDPOINT_SUFFIXES = [
+  "/blocks/tip/height",
+  "/blocks/tip/hash",
+  "/block-height/0",
+] as const;
 
 export const normalizeEsploraEndpoint = (value: string): Result<string, Error> => {
   const trimmed = value.trim();
@@ -29,7 +33,7 @@ export const normalizeEsploraEndpoint = (value: string): Result<string, Error> =
     return err(new Error("The Esplora endpoint cannot include a query string or fragment."));
   }
 
-  const matchedSuffix = TIP_ENDPOINT_SUFFIXES.find((suffix) =>
+  const matchedSuffix = ESPLORA_ENDPOINT_SUFFIXES.find((suffix) =>
     url.pathname.replace(/\/+$/, "").endsWith(suffix),
   );
   if (matchedSuffix) {
@@ -42,16 +46,30 @@ export const normalizeEsploraEndpoint = (value: string): Result<string, Error> =
 export const getEsploraTipHeightUrl = (endpoint: string): string =>
   `${endpoint.replace(/\/+$/, "")}/blocks/tip/height`;
 
-export const parseEsploraTipHeight = (value: string): Result<number, Error> => {
-  const trimmed = value.trim();
-  if (!/^\d+$/.test(trimmed)) {
-    return err(new Error("The endpoint returned an invalid block height."));
+export const getEsploraGenesisHashUrl = (endpoint: string): string =>
+  `${endpoint.replace(/\/+$/, "")}/block-height/0`;
+
+export const parseEsploraBlockHash = (value: string): Result<string, Error> => {
+  const normalized = value.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(normalized)) {
+    return err(new Error("The endpoint returned an invalid block hash."));
   }
 
-  const height = Number(trimmed);
-  if (!Number.isSafeInteger(height)) {
-    return err(new Error("The endpoint returned an invalid block height."));
+  return ok(normalized);
+};
+
+export const validateEsploraGenesisHash = (
+  value: string,
+  expectedGenesisHash: string,
+): Result<void, Error> => {
+  const hashResult = parseEsploraBlockHash(value);
+  if (hashResult.isErr()) {
+    return err(hashResult.error);
   }
 
-  return ok(height);
+  if (hashResult.value !== expectedGenesisHash) {
+    return err(new Error("The Esplora endpoint is for a different Bitcoin network."));
+  }
+
+  return ok(undefined);
 };

--- a/client/src/lib/esploraUrl.ts
+++ b/client/src/lib/esploraUrl.ts
@@ -1,0 +1,57 @@
+import { err, ok, type Result } from "neverthrow";
+
+const TIP_ENDPOINT_SUFFIXES = ["/blocks/tip/height", "/blocks/tip/hash"] as const;
+
+export const normalizeEsploraEndpoint = (value: string): Result<string, Error> => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return err(new Error("Enter an Esplora API endpoint."));
+  }
+
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+  let url: URL;
+  try {
+    url = new URL(withProtocol);
+  } catch {
+    return err(new Error("Enter a valid Esplora API URL."));
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return err(new Error("The Esplora endpoint must use HTTP or HTTPS."));
+  }
+
+  if (url.username || url.password) {
+    return err(new Error("The Esplora endpoint cannot include credentials."));
+  }
+
+  if (url.search || url.hash) {
+    return err(new Error("The Esplora endpoint cannot include a query string or fragment."));
+  }
+
+  const matchedSuffix = TIP_ENDPOINT_SUFFIXES.find((suffix) =>
+    url.pathname.replace(/\/+$/, "").endsWith(suffix),
+  );
+  if (matchedSuffix) {
+    url.pathname = url.pathname.replace(/\/+$/, "").slice(0, -matchedSuffix.length) || "/";
+  }
+
+  return ok(url.toString().replace(/\/+$/, ""));
+};
+
+export const getEsploraTipHeightUrl = (endpoint: string): string =>
+  `${endpoint.replace(/\/+$/, "")}/blocks/tip/height`;
+
+export const parseEsploraTipHeight = (value: string): Result<number, Error> => {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return err(new Error("The endpoint returned an invalid block height."));
+  }
+
+  const height = Number(trimmed);
+  if (!Number.isSafeInteger(height)) {
+    return err(new Error("The endpoint returned an invalid block height."));
+  }
+
+  return ok(height);
+};

--- a/client/src/lib/walletApi.ts
+++ b/client/src/lib/walletApi.ts
@@ -592,6 +592,7 @@ export const clearStaleKeychain = async (): Promise<Result<void, Error>> => {
     log.w("Failed to clear native Esplora endpoint", [nativeEsploraResetResult.error]);
     return err(nativeEsploraResetResult.error);
   }
+  useEsploraStore.getState().reset();
 
   const tokenResetResult = await resetServerAuthToken();
   if (tokenResetResult.isErr()) {

--- a/client/src/lib/walletApi.ts
+++ b/client/src/lib/walletApi.ts
@@ -54,8 +54,21 @@ import {
 } from "./crypto";
 import { err, ok, Result, ResultAsync } from "neverthrow";
 import logger from "~/lib/log";
-import { clearNativeMnemonic, storeNativeMnemonic } from "noah-tools";
+import {
+  clearNativeEsploraEndpoint,
+  clearNativeMnemonic,
+  storeNativeEsploraEndpoint,
+  storeNativeMnemonic,
+} from "noah-tools";
 import { useWalletStore } from "~/store/walletStore";
+import { APP_VARIANT } from "~/config";
+import {
+  getActiveWalletConfig,
+  getDefaultEsploraEndpoint,
+  getEffectiveEsploraEndpoint,
+  validateEsploraEndpoint,
+} from "~/lib/esplora";
+import { useEsploraStore } from "~/store/esploraStore";
 
 const log = logger("walletApi");
 
@@ -81,7 +94,7 @@ const createWalletFromMnemonic = async (mnemonic: string): Promise<Result<void, 
   }
 
   const createResult = await ResultAsync.fromPromise(
-    createWalletNitro(ARK_DATA_PATH, { ...ACTIVE_WALLET_CONFIG, mnemonic }),
+    createWalletNitro(ARK_DATA_PATH, { ...getActiveWalletConfig(), mnemonic }),
     (e) => e as Error,
   );
 
@@ -158,11 +171,12 @@ export const restoreWallet = async (mnemonic: string): Promise<Result<boolean, E
 
 export const loadWalletWithMnemonic = async (
   mnemonic: string,
+  esploraEndpoint = getEffectiveEsploraEndpoint(),
 ): Promise<Result<boolean, Error>> => {
   const loadResult = await ResultAsync.fromPromise(
     loadWalletNitro(ARK_DATA_PATH, {
       mnemonic,
-      ...ACTIVE_WALLET_CONFIG,
+      ...getActiveWalletConfig(esploraEndpoint),
     }),
     (e) => e as Error,
   );
@@ -172,6 +186,143 @@ export const loadWalletWithMnemonic = async (
   }
 
   return ok(true);
+};
+
+const persistNativeEsploraOverride = async (
+  endpointOverride: string | null,
+): Promise<Result<void, Error>> => {
+  return ResultAsync.fromPromise(
+    endpointOverride ? storeNativeEsploraEndpoint(endpointOverride) : clearNativeEsploraEndpoint(),
+    (error) => error as Error,
+  );
+};
+
+const reloadWalletWithEsplora = async (
+  mnemonic: string,
+  endpoint: string,
+): Promise<Result<boolean, Error>> => {
+  const closeAttempt = await ResultAsync.fromPromise(closeWalletIfLoaded(), (error) =>
+    error instanceof Error ? error : new Error(String(error)),
+  );
+  if (closeAttempt.isErr()) {
+    return err(closeAttempt.error);
+  }
+
+  const closeResult = closeAttempt.value;
+  if (closeResult.isErr()) {
+    return err(closeResult.error);
+  }
+  if (!closeResult.value) {
+    return err(new Error("Failed to close the wallet while changing the Esplora endpoint."));
+  }
+
+  return loadWalletWithMnemonic(mnemonic, endpoint);
+};
+
+export interface EsploraSwitchResult {
+  endpoint: string;
+  isDefault: boolean;
+}
+
+export const switchEsploraEndpoint = async (
+  requestedOverride: string | null,
+): Promise<Result<EsploraSwitchResult, Error>> => {
+  if (APP_VARIANT === "regtest") {
+    return err(new Error("Regtest wallets use Bitcoin Core instead of Esplora."));
+  }
+
+  const defaultEndpoint = getDefaultEsploraEndpoint();
+  if (!defaultEndpoint) {
+    return err(new Error("No default Esplora endpoint is configured."));
+  }
+
+  const validationResult = await validateEsploraEndpoint(requestedOverride ?? defaultEndpoint);
+  if (validationResult.isErr()) {
+    return err(validationResult.error);
+  }
+
+  const targetEndpoint = validationResult.value;
+  const targetOverride =
+    requestedOverride === null || targetEndpoint === defaultEndpoint ? null : targetEndpoint;
+  const previousOverride = useEsploraStore.getState().endpointOverride;
+  const previousEndpoint = getEffectiveEsploraEndpoint();
+
+  if (!previousEndpoint) {
+    return err(new Error("No current Esplora endpoint is configured."));
+  }
+
+  if (targetEndpoint === previousEndpoint) {
+    const nativeResult = await persistNativeEsploraOverride(targetOverride);
+    if (nativeResult.isErr()) {
+      return err(nativeResult.error);
+    }
+    useEsploraStore.getState().setEndpointOverride(targetOverride);
+    return ok({ endpoint: targetEndpoint, isDefault: targetOverride === null });
+  }
+
+  const isLoadedResult = await ResultAsync.fromPromise(
+    isWalletLoadedNitro(),
+    (error) => error as Error,
+  );
+  if (isLoadedResult.isErr()) {
+    return err(isLoadedResult.error);
+  }
+
+  const wasWalletLoaded = isLoadedResult.value;
+  let mnemonic: string | null = null;
+
+  if (wasWalletLoaded) {
+    const mnemonicResult = await getMnemonic();
+    if (mnemonicResult.isErr()) {
+      return err(mnemonicResult.error);
+    }
+    mnemonic = mnemonicResult.value;
+    if (!mnemonic) {
+      return err(new Error("No wallet mnemonic is available to reload the wallet."));
+    }
+
+    const candidateLoadResult = await reloadWalletWithEsplora(mnemonic, targetEndpoint);
+    if (candidateLoadResult.isErr()) {
+      const rollbackResult = await reloadWalletWithEsplora(mnemonic, previousEndpoint);
+      if (rollbackResult.isErr()) {
+        useWalletStore.getState().setWalletUnloaded();
+        return err(
+          new Error(
+            `Failed to load the wallet with the new Esplora endpoint and failed to restore the previous configuration: ${rollbackResult.error.message}`,
+          ),
+        );
+      }
+      return err(
+        new Error(
+          `Failed to load the wallet with the new Esplora endpoint: ${candidateLoadResult.error.message}`,
+        ),
+      );
+    }
+  }
+
+  const nativeResult = await persistNativeEsploraOverride(targetOverride);
+  if (nativeResult.isErr()) {
+    await persistNativeEsploraOverride(previousOverride);
+    if (wasWalletLoaded && mnemonic) {
+      const rollbackResult = await reloadWalletWithEsplora(mnemonic, previousEndpoint);
+      if (rollbackResult.isErr()) {
+        useWalletStore.getState().setWalletUnloaded();
+        return err(
+          new Error(
+            `Failed to save the Esplora endpoint for background operations and failed to restore the previous wallet configuration: ${rollbackResult.error.message}`,
+          ),
+        );
+      }
+    }
+    return err(
+      new Error(
+        `Failed to save the Esplora endpoint for background operations: ${nativeResult.error.message}`,
+      ),
+    );
+  }
+
+  useEsploraStore.getState().setEndpointOverride(targetOverride);
+  return ok({ endpoint: targetEndpoint, isDefault: targetOverride === null });
 };
 
 const loadWalletFromStorage = async (): Promise<Result<boolean, Error>> => {
@@ -431,6 +582,15 @@ export const clearStaleKeychain = async (): Promise<Result<void, Error>> => {
       log.w("Failed to clear stale native mnemonic", [nativeResetResult.error]);
       return err(nativeResetResult.error);
     }
+  }
+
+  const nativeEsploraResetResult = await ResultAsync.fromPromise(
+    clearNativeEsploraEndpoint(),
+    (e) => e as Error,
+  );
+  if (nativeEsploraResetResult.isErr()) {
+    log.w("Failed to clear native Esplora endpoint", [nativeEsploraResetResult.error]);
+    return err(nativeEsploraResetResult.error);
   }
 
   const tokenResetResult = await resetServerAuthToken();

--- a/client/src/screens/ArkInfoScreen.tsx
+++ b/client/src/screens/ArkInfoScreen.tsx
@@ -14,11 +14,12 @@ import { useThemeColors } from "~/hooks/useTheme";
 import type { SettingsStackParamList } from "~/Navigators";
 import {
   ACTIVE_WALLET_CONFIG,
-  getBlockheightEndpoint,
   mempoolHistoricalPriceEndpoint,
   mempoolPriceEndpoint,
 } from "~/constants";
 import { APP_VARIANT } from "~/config";
+import { getBlockheightEndpoint, getDefaultEsploraEndpoint } from "~/lib/esplora";
+import { useEsploraStore } from "~/store/esploraStore";
 
 type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, "ArkInfo">;
 
@@ -182,12 +183,12 @@ const buildSections = (arkInfo: BarkArkInfo) => [
   },
 ];
 
-const buildConfigurationSections = () => [
+const buildConfigurationSections = (esploraEndpoint: string | null) => [
   {
     title: "Wallet endpoints",
     rows: compactRows([
       { label: "Ark server", value: ACTIVE_WALLET_CONFIG.config?.ark, copyable: true },
-      { label: "Esplora API", value: ACTIVE_WALLET_CONFIG.config?.esplora, copyable: true },
+      { label: "Esplora API", value: esploraEndpoint, copyable: true },
       { label: "Bitcoind RPC", value: ACTIVE_WALLET_CONFIG.config?.bitcoind, copyable: true },
     ]),
   },
@@ -205,10 +206,12 @@ const buildConfigurationSections = () => [
 const ArkInfoScreen = () => {
   const navigation = useNavigation<NavigationProp>();
   const colors = useThemeColors();
+  const endpointOverride = useEsploraStore((state) => state.endpointOverride);
+  const esploraEndpoint = endpointOverride ?? getDefaultEsploraEndpoint();
   const { data: arkInfo, isLoading, isError, error, refetch, isFetching } = useArkInfo();
   const sections = arkInfo
-    ? [...buildSections(arkInfo), ...buildConfigurationSections()]
-    : buildConfigurationSections();
+    ? [...buildSections(arkInfo), ...buildConfigurationSections(esploraEndpoint)]
+    : buildConfigurationSections(esploraEndpoint);
 
   return (
     <NoahSafeAreaView className="flex-1 bg-background">

--- a/client/src/screens/EsploraSettingsScreen.tsx
+++ b/client/src/screens/EsploraSettingsScreen.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+import { Keyboard, ScrollView, View } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { AlertTriangle, CheckCircle } from "lucide-react-native";
+import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
+import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
+import { NativeNoahSecondaryButton } from "~/components/ui/NativeNoahSecondaryButton";
+import { Text } from "~/components/ui/text";
+import { useSwitchEsploraEndpoint } from "~/hooks/useEsplora";
+import { getDefaultEsploraEndpoint } from "~/lib/esplora";
+import type { SettingsStackParamList } from "~/Navigators";
+import { useEsploraStore } from "~/store/esploraStore";
+
+type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, "Esplora">;
+
+const EsploraSettingsScreen = () => {
+  const navigation = useNavigation<NavigationProp>();
+  const endpointOverride = useEsploraStore((state) => state.endpointOverride);
+  const defaultEndpoint = getDefaultEsploraEndpoint() ?? "";
+  const effectiveEndpoint = endpointOverride ?? defaultEndpoint;
+  const [endpointInput, setEndpointInput] = useState(effectiveEndpoint);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const switchEndpoint = useSwitchEsploraEndpoint();
+
+  const clearStatus = () => {
+    setSuccessMessage(null);
+    switchEndpoint.reset();
+  };
+
+  const handleApply = () => {
+    if (switchEndpoint.isPending || !endpointInput.trim()) {
+      return;
+    }
+    Keyboard.dismiss();
+    clearStatus();
+    switchEndpoint.mutate(endpointInput, {
+      onSuccess: ({ endpoint, isDefault }) => {
+        setEndpointInput(endpoint);
+        setSuccessMessage(
+          isDefault
+            ? "The wallet is using Noah's default Esplora endpoint."
+            : "The wallet is now using the new Esplora endpoint.",
+        );
+      },
+    });
+  };
+
+  const handleReset = () => {
+    if (switchEndpoint.isPending || !endpointOverride) {
+      return;
+    }
+    Keyboard.dismiss();
+    clearStatus();
+    switchEndpoint.mutate(null, {
+      onSuccess: ({ endpoint }) => {
+        setEndpointInput(endpoint);
+        setSuccessMessage("The wallet is now using Noah's default Esplora endpoint.");
+      },
+    });
+  };
+
+  return (
+    <NoahSafeAreaView className="flex-1 bg-background">
+      <View className="flex-row items-center px-5 pt-4">
+        <NativeNoahBackButton
+          onPress={() => navigation.goBack()}
+          className="mr-3"
+          testID="esplora-settings-back-button"
+        />
+        <Text className="text-2xl font-bold text-foreground">Esplora API</Text>
+      </View>
+
+      <ScrollView
+        className="flex-1 px-5"
+        contentContainerStyle={{ paddingBottom: 32 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View className="mt-6 rounded-2xl border border-border bg-card p-4">
+          <Text className="text-sm font-semibold uppercase tracking-[2px] text-muted-foreground">
+            Active endpoint
+          </Text>
+          <Text className="mt-2 text-base font-semibold text-foreground">{effectiveEndpoint}</Text>
+          <Text className="mt-1 text-sm text-muted-foreground">
+            {endpointOverride ? "Custom endpoint" : "Noah default"}
+          </Text>
+        </View>
+
+        <View className="mt-6 gap-2">
+          <Label className="text-base text-foreground">Esplora API base URL</Label>
+          <Input
+            value={endpointInput}
+            onChangeText={(value) => {
+              setEndpointInput(value);
+              clearStatus();
+            }}
+            placeholder="https://mempool.space/api"
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="url"
+            returnKeyType="done"
+            editable={!switchEndpoint.isPending}
+            className="h-12"
+            onSubmitEditing={handleApply}
+            testID="esplora-endpoint-input"
+          />
+          <Text className="text-sm leading-5 text-muted-foreground">
+            Noah will test /blocks/tip/height before changing the wallet configuration. You may also
+            paste the full tip-height or tip-hash URL.
+          </Text>
+        </View>
+
+        {successMessage ? (
+          <Alert icon={CheckCircle} className="mt-5">
+            <AlertTitle>Endpoint updated</AlertTitle>
+            <AlertDescription>{successMessage}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {switchEndpoint.error ? (
+          <Alert icon={AlertTriangle} variant="destructive" className="mt-5">
+            <AlertTitle>Endpoint not changed</AlertTitle>
+            <AlertDescription>{switchEndpoint.error.message}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <View className="mt-6 gap-3">
+          <NativeNoahButton
+            label="Test & Use Endpoint"
+            loadingLabel="Testing Endpoint..."
+            isLoading={switchEndpoint.isPending}
+            disabled={!endpointInput.trim()}
+            onPress={handleApply}
+            fullWidth
+            testID="apply-esplora-endpoint"
+          />
+          <NativeNoahSecondaryButton
+            label="Reset to Noah Default"
+            disabled={!endpointOverride || switchEndpoint.isPending}
+            onPress={handleReset}
+            fullWidth
+            testID="reset-esplora-endpoint"
+          />
+        </View>
+
+        <View className="mt-7 rounded-2xl border border-border bg-card p-4">
+          <Text className="font-semibold text-foreground">Default endpoint</Text>
+          <Text className="mt-2 text-sm text-muted-foreground">{defaultEndpoint}</Text>
+          <Text className="mt-3 text-sm leading-5 text-muted-foreground">
+            A custom Esplora server can observe the Bitcoin addresses and transactions requested by
+            this wallet. Only use a server you trust.
+          </Text>
+        </View>
+      </ScrollView>
+    </NoahSafeAreaView>
+  );
+};
+
+export default EsploraSettingsScreen;

--- a/client/src/screens/EsploraSettingsScreen.tsx
+++ b/client/src/screens/EsploraSettingsScreen.tsx
@@ -109,8 +109,8 @@ const EsploraSettingsScreen = () => {
             testID="esplora-endpoint-input"
           />
           <Text className="text-sm leading-5 text-muted-foreground">
-            Noah will test /blocks/tip/height before changing the wallet configuration. You may also
-            paste the full tip-height or tip-hash URL.
+            Noah will test /block-height/0 and verify the Bitcoin network before changing the wallet
+            configuration. You may also paste the full test or tip URL.
           </Text>
         </View>
 

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -49,12 +49,16 @@ import {
   TelegramBrandIcon,
   TELEGRAM_SUPPORT_URL,
 } from "~/components/BrandIcons";
+import { APP_VARIANT } from "~/config";
+import { getDefaultEsploraEndpoint } from "~/lib/esplora";
+import { useEsploraStore } from "~/store/esploraStore";
 
 type Setting = {
   id:
     | "profile"
     | "currency"
     | "bitcoinUnit"
+    | "esplora"
     | "showMnemonic"
     | "showLogs"
     | "resetRegistration"
@@ -98,6 +102,8 @@ const SettingsScreen = () => {
   const preferredCurrencyInfo = getFiatCurrencyInfo(preferredCurrency);
   const bitcoinAmountUnit = useProfileStore((state) => state.bitcoinAmountUnit);
   const bitcoinAmountUnitInfo = getBitcoinAmountUnitInfo(bitcoinAmountUnit);
+  const endpointOverride = useEsploraStore((state) => state.endpointOverride);
+  const effectiveEsploraEndpoint = endpointOverride ?? getDefaultEsploraEndpoint();
   const {
     data: autoBoardThreshold,
     isError: isAutoBoardThresholdError,
@@ -231,6 +237,8 @@ const SettingsScreen = () => {
       navigation.navigate("Currency");
     } else if (item.id === "bitcoinUnit") {
       navigation.navigate("BitcoinUnit");
+    } else if (item.id === "esplora") {
+      navigation.navigate("Esplora");
     } else if (item.id === "showMnemonic") {
       navigation.navigate("Mnemonic", { fromOnboarding: false });
     } else if (item.id === "showLogs") {
@@ -317,6 +325,16 @@ const SettingsScreen = () => {
       description: "Automatically or manually backup your wallet after encrypting it.",
       isPressable: true,
     });
+
+    if (APP_VARIANT !== "regtest") {
+      walletData.push({
+        id: "esplora",
+        title: "Esplora API",
+        value: endpointOverride ? "Custom" : "Noah default",
+        description: effectiveEsploraEndpoint ?? "Not configured",
+        isPressable: true,
+      });
+    }
 
     if (shouldUseUnifiedPush()) {
       walletData.push({

--- a/client/src/store/esploraStore.ts
+++ b/client/src/store/esploraStore.ts
@@ -1,0 +1,60 @@
+import { create } from "zustand";
+import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
+import logger from "~/lib/log";
+import { mmkv } from "~/lib/mmkv";
+
+const log = logger("esploraStore");
+
+const zustandStorage: StateStorage = {
+  setItem: (name, value) => {
+    try {
+      return mmkv.set(name, value);
+    } catch (error) {
+      log.w("Esplora storage setItem failed:", [error]);
+    }
+  },
+  getItem: (name) => {
+    try {
+      return mmkv.getString(name) ?? null;
+    } catch (error) {
+      log.w("Esplora storage getItem failed:", [error]);
+      return null;
+    }
+  },
+  removeItem: (name) => {
+    try {
+      return mmkv.remove(name);
+    } catch (error) {
+      log.w("Esplora storage removeItem failed:", [error]);
+    }
+  },
+};
+
+interface EsploraState {
+  endpointOverride: string | null;
+  setEndpointOverride: (endpoint: string | null) => void;
+  reset: () => void;
+}
+
+export const useEsploraStore = create<EsploraState>()(
+  persist(
+    (set) => ({
+      endpointOverride: null,
+      setEndpointOverride: (endpointOverride) => set({ endpointOverride }),
+      reset: () => set({ endpointOverride: null }),
+    }),
+    {
+      name: "esplora-storage",
+      storage: createJSONStorage(() => zustandStorage),
+      partialize: (state) => ({ endpointOverride: state.endpointOverride }),
+      merge: (persistedState, currentState) => {
+        const state = persistedState as Partial<EsploraState> | null;
+        return {
+          ...currentState,
+          endpointOverride:
+            typeof state?.endpointOverride === "string" ? state.endpointOverride : null,
+        };
+      },
+    },
+  ),
+);

--- a/client/tests/unit/esploraUrl.test.js
+++ b/client/tests/unit/esploraUrl.test.js
@@ -5,7 +5,7 @@ import {
   normalizeEsploraEndpoint,
   parseEsploraBlockHash,
   validateEsploraGenesisHash,
-} from "./esploraUrl";
+} from "../../src/lib/esploraUrl";
 
 const MAINNET_GENESIS_HASH =
   "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";


### PR DESCRIPTION
## Summary

- add a persisted Esplora API override in wallet settings while preserving the existing mainnet and signet defaults
- validate candidate endpoints through `/blocks/tip/height` before changing wallet configuration
- close and reload the native wallet with rollback if the new endpoint or native background persistence fails
- route native wallet operations, block-height requests, transaction metadata, and Android UnifiedPush background loading through the effective endpoint
- regenerate the NoahTools Nitro bindings for native endpoint persistence

## User impact

Users can select a trusted Esplora server from Settings → Wallet → Esplora API, verify it before use, and reset to Noah's default at any time. Regtest continues to use Bitcoin Core unchanged.

## Validation

- `bun test src/lib/esploraUrl.test.js`
- `just check`
- `bun run nitrogen`
- live tip-height probes against mempool.space and the existing Noah mainnet and signet Esplora defaults

Native Android and iOS builds remain covered by the existing GitHub Actions pipelines.
