### PR TITLE
Centralize wallet config and update NitroArk

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
         "react-native-gesture-handler": "~2.32.0",
         "react-native-keychain": "^10.0.0",
         "react-native-mmkv": "^4.3.1",
-        "react-native-nitro-ark": "0.0.131",
+        "react-native-nitro-ark": "0.0.132",
         "react-native-nitro-modules": "0.35.6",
         "react-native-qrcode-svg": "^6.3.21",
         "react-native-quick-base64": "^3.0.0",
@@ -1537,7 +1537,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@4.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg=="],
 
-    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.131", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-85+nHCrbc3B4EJm41ut3aGjTYbFYXi64T4XRcI5mk+6FcoEkv1j4kR7b2zDffElcDDR1StrXRAOsZiqbZfUCEQ=="],
+    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.132", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-4X8drLfmNibIdnPUgV7/x+ahHj2xQH7ialX0jY9BpWFUI7CNnjIN0Iw11GngerjtDBfQ1eHHHjedDWoKiTSgRw=="],
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.35.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g=="],
 

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -281,7 +281,7 @@ PODS:
     - ReactNativeDependencies
     - Yoga
   - MMKVCore (2.4.0)
-  - NitroArk (0.0.131):
+  - NitroArk (0.0.132):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -3264,7 +3264,7 @@ SPEC CHECKSUMS:
   hermes-engine: 10ad1fccd364c7e3d9c1de19a7edb1bdd632c6b4
   MapLibreReactNative: 5df4460492c6c8af365fc6107f48f0e922d915ad
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: 3fedb9f2fc57b4fee97a708706e6639cb7f77280
+  NitroArk: 5e7c04d85ef676903479058498091cbbf524b847
   NitroMmkv: 1ff46eceb958298b1d7c013a6314432438b77a62
   NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
   NoahTools: efecfcff1688c6e63b9acb210286badaa3eaac36

--- a/client/package.json
+++ b/client/package.json
@@ -105,7 +105,7 @@
     "react-native-gesture-handler": "~2.32.0",
     "react-native-keychain": "^10.0.0",
     "react-native-mmkv": "^4.3.1",
-    "react-native-nitro-ark": "0.0.131",
+    "react-native-nitro-ark": "0.0.132",
     "react-native-nitro-modules": "0.35.6",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-quick-base64": "^3.0.0",

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,4 +1,3 @@
-import type { BarkCreateOpts } from "react-native-nitro-ark";
 import RNFSTurbo from "react-native-fs-turbo";
 import { APP_VARIANT } from "./config";
 import { decode } from "light-bolt11-decoder";
@@ -26,12 +25,6 @@ export const CACHES_DIRECTORY_PATH = RNFSTurbo.CachesDirectoryPath;
 // Emulators are excluded in this check and only real devices matter.
 export const shouldUseUnifiedPush = () =>
   PLATFORM === "android" && Device.isDevice && !isGooglePlayServicesAvailable();
-
-const REGTEST_URL = process.env.EXPO_PUBLIC_REGTEST_URL
-  ? process.env.EXPO_PUBLIC_REGTEST_URL
-  : PLATFORM === "android"
-    ? "10.0.2.2"
-    : "localhost";
 
 const REGTEST_SERVER_URL = process.env.EXPO_PUBLIC_REGTEST_SERVER_URL
   ? process.env.EXPO_PUBLIC_REGTEST_SERVER_URL
@@ -81,71 +74,6 @@ export const getLnurlDomain = (): string => {
   }
 };
 
-export type WalletCreationOptions = Omit<BarkCreateOpts, "mnemonic">;
-
-export const SIGNET_CONFIG: WalletCreationOptions = {
-  regtest: false,
-  signet: true,
-  bitcoin: false,
-  config: {
-    esplora: "https://esplora.signet.2nd.dev",
-    ark: "https://ark.signet.2nd.dev",
-    vtxo_refresh_expiry_threshold: 48,
-    fallback_fee_rate: 10000,
-    htlc_recv_claim_delta: 18,
-    vtxo_exit_margin: 12,
-    round_tx_required_confirmations: 1,
-  },
-};
-
-export const REGTEST_CONFIG: WalletCreationOptions = {
-  regtest: true,
-  signet: false,
-  bitcoin: false,
-  config: {
-    bitcoind: `http://${REGTEST_URL}:18443`,
-    ark: `http://${REGTEST_URL}:3535`,
-    bitcoind_user: "second",
-    bitcoind_pass: "ark",
-    vtxo_refresh_expiry_threshold: 24,
-    fallback_fee_rate: 10000,
-    htlc_recv_claim_delta: 18,
-    vtxo_exit_margin: 12,
-    round_tx_required_confirmations: 1,
-  },
-};
-
-export const PRODUCTION_CONFIG: WalletCreationOptions = {
-  regtest: false,
-  signet: false,
-  bitcoin: true,
-  config: {
-    esplora: "https://mempool.second.tech/api",
-    ark: "https://ark.second.tech",
-    vtxo_refresh_expiry_threshold: 288,
-    fallback_fee_rate: 10000,
-    htlc_recv_claim_delta: 18,
-    vtxo_exit_margin: 12,
-    round_tx_required_confirmations: 2,
-  },
-};
-
-const getActiveWalletConfig = (): WalletCreationOptions => {
-  switch (APP_VARIANT) {
-    case "regtest":
-      return REGTEST_CONFIG;
-    case "signet":
-      return SIGNET_CONFIG;
-    case "mainnet":
-      return PRODUCTION_CONFIG;
-    default:
-      // Default to signet for development builds that aren't launched via a profile
-      return SIGNET_CONFIG;
-  }
-};
-
-export const ACTIVE_WALLET_CONFIG = getActiveWalletConfig();
-
 export const decodeBolt11 = (invoice: string) => {
   return Result.fromThrowable(decode)(invoice).unwrapOr(null);
 };
@@ -154,17 +82,6 @@ export const msatToSatoshi = (msat: number) => msat / 1000;
 
 export const mempoolPriceEndpoint = `${getServerEndpoint()}/v0/prices`;
 export const mempoolHistoricalPriceEndpoint = `${getServerEndpoint()}/v0/historical-price`;
-
-export const getDefaultBlockheightEndpoint = () => {
-  switch (APP_VARIANT) {
-    case "mainnet":
-      return "https://mempool.second.tech/api/blocks/tip/height";
-    case "signet":
-      return "https://mempool.space/signet/api/blocks/tip/height";
-    case "regtest":
-      return `http://${REGTEST_URL}:18443`;
-  }
-};
 
 export const getMempoolTxUrl = (anchorPoint: string): string | null => {
   const txid = anchorPoint.split(":")[0];

--- a/client/src/hooks/useMarketData.ts
+++ b/client/src/hooks/useMarketData.ts
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { REGTEST_CONFIG } from "~/constants";
 import { getBlockheightEndpoint } from "~/lib/esplora";
 import ky from "ky";
 import logger from "~/lib/log";
@@ -12,6 +11,7 @@ import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { getFiatPrices, getHistoricalFiatPrice } from "~/lib/api";
 import { useProfileStore } from "~/store/profileStore";
 import { useEsploraStore } from "~/store/esploraStore";
+import { getWalletRpcAuth } from "~/lib/walletConfig";
 
 const HISTORICAL_RATE_CACHE_MAX_SIZE = 200;
 type HistoricalRateLookup = {
@@ -58,10 +58,7 @@ export const getBlockHeight = async (): Promise<Result<number, Error>> => {
   const url = getBlockheightEndpoint();
 
   if (APP_VARIANT === "regtest") {
-    const auth = {
-      username: REGTEST_CONFIG.config?.bitcoind_user,
-      password: REGTEST_CONFIG.config?.bitcoind_pass,
-    };
+    const auth = getWalletRpcAuth();
 
     return ResultAsync.fromPromise(
       ky

--- a/client/src/hooks/useWidget.ts
+++ b/client/src/hooks/useWidget.ts
@@ -5,8 +5,8 @@ import { APP_VARIANT } from "~/config";
 import logger from "~/lib/log";
 import { getVtxos, fetchOnchainBalance, fetchOffchainBalance } from "~/lib/walletApi";
 import { getBlockHeight } from "~/hooks/useMarketData";
-import { ACTIVE_WALLET_CONFIG } from "~/constants";
 import { calculateBalances, type BalanceData } from "~/lib/balanceUtils";
+import { getWalletRefreshExpiryThreshold } from "~/lib/walletConfig";
 
 const log = logger("useWidget");
 
@@ -110,7 +110,7 @@ export async function updateWidget(balanceData?: BalanceData): Promise<void> {
       }
     }
 
-    const expiryThreshold = ACTIVE_WALLET_CONFIG.config?.vtxo_refresh_expiry_threshold || 288;
+    const expiryThreshold = getWalletRefreshExpiryThreshold();
 
     updateWidgetData(
       totalBalance,

--- a/client/src/lib/esplora.ts
+++ b/client/src/lib/esplora.ts
@@ -1,10 +1,5 @@
 import ky from "ky";
 import { err, ok, ResultAsync, type Result } from "neverthrow";
-import {
-  ACTIVE_WALLET_CONFIG,
-  getDefaultBlockheightEndpoint,
-  type WalletCreationOptions,
-} from "~/constants";
 import { APP_VARIANT } from "~/config";
 import { useEsploraStore } from "~/store/esploraStore";
 import {
@@ -13,6 +8,7 @@ import {
   normalizeEsploraEndpoint,
   validateEsploraGenesisHash,
 } from "~/lib/esploraUrl";
+import { getDefaultBlockheightEndpoint, getDefaultEsploraEndpoint } from "~/lib/walletConfig";
 
 const ESPLORA_VALIDATION_TIMEOUT_MS = 5000;
 const ESPLORA_GENESIS_HASHES = {
@@ -20,40 +16,10 @@ const ESPLORA_GENESIS_HASHES = {
   signet: "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
 } as const;
 
-export const getDefaultEsploraEndpoint = (): string | null => {
-  if (APP_VARIANT === "regtest") {
-    return null;
-  }
-
-  const configuredEndpoint = ACTIVE_WALLET_CONFIG.config?.esplora;
-  if (!configuredEndpoint) {
-    return null;
-  }
-
-  return normalizeEsploraEndpoint(configuredEndpoint).unwrapOr(null);
-};
-
 export const getEffectiveEsploraEndpoint = (): string | null =>
   useEsploraStore.getState().endpointOverride ?? getDefaultEsploraEndpoint();
 
 export const getEsploraApiBaseUrl = getEffectiveEsploraEndpoint;
-
-export const getActiveWalletConfig = (
-  esploraEndpoint = getEffectiveEsploraEndpoint(),
-): WalletCreationOptions => {
-  const config = ACTIVE_WALLET_CONFIG.config;
-  if (!config) {
-    return { ...ACTIVE_WALLET_CONFIG };
-  }
-
-  return {
-    ...ACTIVE_WALLET_CONFIG,
-    config: {
-      ...config,
-      ...(APP_VARIANT !== "regtest" && esploraEndpoint ? { esplora: esploraEndpoint } : {}),
-    },
-  };
-};
 
 export const getBlockheightEndpoint = (): string => {
   const endpointOverride = useEsploraStore.getState().endpointOverride;

--- a/client/src/lib/walletApi.ts
+++ b/client/src/lib/walletApi.ts
@@ -41,7 +41,6 @@ import {
   ARK_DATA_PATH,
   CACHES_DIRECTORY_PATH,
   DOCUMENT_DIRECTORY_PATH,
-  ACTIVE_WALLET_CONFIG,
   shouldUseUnifiedPush,
 } from "../constants";
 import {
@@ -62,13 +61,13 @@ import {
 } from "noah-tools";
 import { useWalletStore } from "~/store/walletStore";
 import { APP_VARIANT } from "~/config";
-import {
-  getActiveWalletConfig,
-  getDefaultEsploraEndpoint,
-  getEffectiveEsploraEndpoint,
-  validateEsploraEndpoint,
-} from "~/lib/esplora";
+import { getEffectiveEsploraEndpoint, validateEsploraEndpoint } from "~/lib/esplora";
 import { useEsploraStore } from "~/store/esploraStore";
+import {
+  getDefaultEsploraEndpoint,
+  getEffectiveWalletConfig,
+  getWalletRefreshExpiryThreshold,
+} from "~/lib/walletConfig";
 
 const log = logger("walletApi");
 
@@ -94,7 +93,10 @@ const createWalletFromMnemonic = async (mnemonic: string): Promise<Result<void, 
   }
 
   const createResult = await ResultAsync.fromPromise(
-    createWalletNitro(ARK_DATA_PATH, { ...getActiveWalletConfig(), mnemonic }),
+    createWalletNitro(ARK_DATA_PATH, {
+      ...getEffectiveWalletConfig(getEffectiveEsploraEndpoint()),
+      mnemonic,
+    }),
     (e) => e as Error,
   );
 
@@ -176,7 +178,7 @@ export const loadWalletWithMnemonic = async (
   const loadResult = await ResultAsync.fromPromise(
     loadWalletNitro(ARK_DATA_PATH, {
       mnemonic,
-      ...getActiveWalletConfig(esploraEndpoint),
+      ...getEffectiveWalletConfig(esploraEndpoint),
     }),
     (e) => e as Error,
   );
@@ -534,7 +536,7 @@ export const dropVtxo = async (vtxoId: string): Promise<Result<void, Error>> => 
 
 export const getExpiringVtxos = async () => {
   return ResultAsync.fromPromise(
-    getExpiringVtxosNitro(ACTIVE_WALLET_CONFIG.config?.vtxo_refresh_expiry_threshold || 288),
+    getExpiringVtxosNitro(getWalletRefreshExpiryThreshold()),
     (e) => e as Error,
   );
 };

--- a/client/src/lib/walletConfig.ts
+++ b/client/src/lib/walletConfig.ts
@@ -1,0 +1,145 @@
+import Constants from "expo-constants";
+import type { BarkConfigOpts, BarkCreateOpts } from "react-native-nitro-ark";
+import { Platform } from "react-native";
+import { APP_VARIANT } from "~/config";
+import { normalizeEsploraEndpoint } from "~/lib/esploraUrl";
+
+export type AppVariant = "mainnet" | "signet" | "regtest";
+export type WalletCreationOptions = Omit<BarkCreateOpts, "mnemonic">;
+
+type BaseWalletConfig = Omit<WalletCreationOptions, "config"> & {
+  config: BarkConfigOpts;
+};
+
+const REGTEST_HOST = process.env.EXPO_PUBLIC_REGTEST_URL
+  ? process.env.EXPO_PUBLIC_REGTEST_URL
+  : Platform.OS === "android"
+    ? "10.0.2.2"
+    : "localhost";
+
+const WALLET_CONFIGS: Record<AppVariant, BaseWalletConfig> = {
+  mainnet: {
+    regtest: false,
+    signet: false,
+    bitcoin: true,
+    config: {
+      esplora: "https://mempool.second.tech/api",
+      ark: "https://ark.second.tech",
+      vtxo_refresh_expiry_threshold: 288,
+      fallback_fee_rate: 10000,
+      htlc_recv_claim_delta: 18,
+      vtxo_exit_margin: 12,
+      round_tx_required_confirmations: 2,
+    },
+  },
+  signet: {
+    regtest: false,
+    signet: true,
+    bitcoin: false,
+    config: {
+      esplora: "https://esplora.signet.2nd.dev",
+      ark: "https://ark.signet.2nd.dev",
+      vtxo_refresh_expiry_threshold: 48,
+      fallback_fee_rate: 10000,
+      htlc_recv_claim_delta: 18,
+      vtxo_exit_margin: 12,
+      round_tx_required_confirmations: 1,
+    },
+  },
+  regtest: {
+    regtest: true,
+    signet: false,
+    bitcoin: false,
+    config: {
+      bitcoind: `http://${REGTEST_HOST}:18443`,
+      ark: `http://${REGTEST_HOST}:3535`,
+      bitcoind_user: "second",
+      bitcoind_pass: "ark",
+      vtxo_refresh_expiry_threshold: 24,
+      fallback_fee_rate: 10000,
+      htlc_recv_claim_delta: 18,
+      vtxo_exit_margin: 12,
+      round_tx_required_confirmations: 1,
+    },
+  },
+};
+
+export const buildArkUserAgent = (
+  appVariant: AppVariant,
+  platform: string,
+  version: string,
+): string => `noah-${appVariant}-${platform}/${version}`;
+
+export const getBaseWalletConfig = (appVariant: AppVariant = APP_VARIANT): BaseWalletConfig =>
+  WALLET_CONFIGS[appVariant];
+
+export const getDefaultEsploraEndpoint = (appVariant: AppVariant = APP_VARIANT): string | null => {
+  if (appVariant === "regtest") {
+    return null;
+  }
+
+  const configuredEndpoint = getBaseWalletConfig(appVariant).config.esplora;
+  if (!configuredEndpoint) {
+    return null;
+  }
+
+  return normalizeEsploraEndpoint(configuredEndpoint).unwrapOr(null);
+};
+
+export const getEffectiveWalletConfig = (
+  esploraEndpoint?: string | null,
+  appVariant: AppVariant = APP_VARIANT,
+): WalletCreationOptions => {
+  const walletOptions = getBaseWalletConfig(appVariant);
+  const endpoint =
+    esploraEndpoint === undefined ? getDefaultEsploraEndpoint(appVariant) : esploraEndpoint;
+
+  return {
+    ...walletOptions,
+    config: {
+      ...walletOptions.config,
+      user_agent: buildArkUserAgent(
+        appVariant,
+        Platform.OS,
+        Constants.expoConfig?.version ?? "unknown",
+      ),
+      ...(appVariant !== "regtest" && endpoint ? { esplora: endpoint } : {}),
+    },
+  };
+};
+
+export const getWalletEndpoints = (
+  esploraEndpoint?: string | null,
+  appVariant: AppVariant = APP_VARIANT,
+) => {
+  const config = getEffectiveWalletConfig(esploraEndpoint, appVariant).config;
+
+  return {
+    ark: config?.ark,
+    esplora: config?.esplora,
+    bitcoind: config?.bitcoind,
+  };
+};
+
+export const getWalletRefreshExpiryThreshold = (appVariant: AppVariant = APP_VARIANT): number =>
+  getBaseWalletConfig(appVariant).config.vtxo_refresh_expiry_threshold;
+
+export const getWalletRpcAuth = (appVariant: AppVariant = APP_VARIANT) => {
+  const config = getBaseWalletConfig(appVariant).config;
+
+  return {
+    username: config.bitcoind_user,
+    password: config.bitcoind_pass,
+  };
+};
+
+export const getDefaultBlockheightEndpoint = (appVariant: AppVariant = APP_VARIANT): string => {
+  switch (appVariant) {
+    case "mainnet":
+      return "https://mempool.second.tech/api/blocks/tip/height";
+    case "signet":
+      return "https://mempool.space/signet/api/blocks/tip/height";
+    case "regtest":
+      return `http://${REGTEST_HOST}:18443`;
+  }
+};

--- a/client/src/screens/ArkInfoScreen.tsx
+++ b/client/src/screens/ArkInfoScreen.tsx
@@ -13,14 +13,11 @@ import { copyToClipboard } from "~/lib/clipboardUtils";
 import { COLORS } from "~/lib/styleConstants";
 import { useThemeColors } from "~/hooks/useTheme";
 import type { SettingsStackParamList } from "~/Navigators";
-import {
-  ACTIVE_WALLET_CONFIG,
-  mempoolHistoricalPriceEndpoint,
-  mempoolPriceEndpoint,
-} from "~/constants";
+import { mempoolHistoricalPriceEndpoint, mempoolPriceEndpoint } from "~/constants";
 import { APP_VARIANT } from "~/config";
-import { getBlockheightEndpoint, getDefaultEsploraEndpoint } from "~/lib/esplora";
+import { getBlockheightEndpoint } from "~/lib/esplora";
 import { useEsploraStore } from "~/store/esploraStore";
+import { getDefaultEsploraEndpoint, getWalletEndpoints } from "~/lib/walletConfig";
 
 type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, "ArkInfo">;
 
@@ -217,33 +214,37 @@ const buildConfigurationSections = (
   esploraEndpoint: string | null,
   hasEsploraOverride: boolean,
   onEditEsplora: () => void,
-) => [
-  {
-    title: "Wallet endpoints",
-    rows: compactRows([
-      { label: "Ark server", value: ACTIVE_WALLET_CONFIG.config?.ark, copyable: true },
-      {
-        label: hasEsploraOverride ? "Esplora API · Custom" : "Esplora API · Noah default",
-        value: esploraEndpoint,
-        actionLabel: "Edit",
-        onPress: onEditEsplora,
-        accessibilityLabel: "Edit Esplora API endpoint",
-        accessibilityHint: "Opens the endpoint editor.",
-        testID: "edit-esplora-endpoint",
-      },
-      { label: "Bitcoind RPC", value: ACTIVE_WALLET_CONFIG.config?.bitcoind, copyable: true },
-    ]),
-  },
-  {
-    title: "Explorer APIs",
-    rows: compactRows([
-      { label: "Block height API", value: getBlockheightEndpoint(), copyable: true },
-      { label: "Mempool explorer", value: getMempoolExplorerBaseUrl(), copyable: true },
-      { label: "Price API", value: mempoolPriceEndpoint, copyable: true },
-      { label: "Historical price API", value: mempoolHistoricalPriceEndpoint, copyable: true },
-    ]),
-  },
-];
+) => {
+  const walletEndpoints = getWalletEndpoints(esploraEndpoint);
+
+  return [
+    {
+      title: "Wallet endpoints",
+      rows: compactRows([
+        { label: "Ark server", value: walletEndpoints.ark, copyable: true },
+        {
+          label: hasEsploraOverride ? "Esplora API · Custom" : "Esplora API · Noah default",
+          value: walletEndpoints.esplora,
+          actionLabel: "Edit",
+          onPress: onEditEsplora,
+          accessibilityLabel: "Edit Esplora API endpoint",
+          accessibilityHint: "Opens the endpoint editor.",
+          testID: "edit-esplora-endpoint",
+        },
+        { label: "Bitcoind RPC", value: walletEndpoints.bitcoind, copyable: true },
+      ]),
+    },
+    {
+      title: "Explorer APIs",
+      rows: compactRows([
+        { label: "Block height API", value: getBlockheightEndpoint(), copyable: true },
+        { label: "Mempool explorer", value: getMempoolExplorerBaseUrl(), copyable: true },
+        { label: "Price API", value: mempoolPriceEndpoint, copyable: true },
+        { label: "Historical price API", value: mempoolHistoricalPriceEndpoint, copyable: true },
+      ]),
+    },
+  ];
+};
 
 const ArkInfoScreen = () => {
   const navigation = useNavigation<NavigationProp>();

--- a/client/src/screens/EsploraSettingsScreen.tsx
+++ b/client/src/screens/EsploraSettingsScreen.tsx
@@ -12,7 +12,7 @@ import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
 import { NativeNoahSecondaryButton } from "~/components/ui/NativeNoahSecondaryButton";
 import { Text } from "~/components/ui/text";
 import { useSwitchEsploraEndpoint } from "~/hooks/useEsplora";
-import { getDefaultEsploraEndpoint } from "~/lib/esplora";
+import { getDefaultEsploraEndpoint } from "~/lib/walletConfig";
 import type { SettingsStackParamList } from "~/Navigators";
 import { useEsploraStore } from "~/store/esploraStore";
 

--- a/client/tests/unit/walletConfig.test.js
+++ b/client/tests/unit/walletConfig.test.js
@@ -1,0 +1,136 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+const originalRegtestUrl = process.env.EXPO_PUBLIC_REGTEST_URL;
+delete process.env.EXPO_PUBLIC_REGTEST_URL;
+
+mock.module("expo-constants", () => ({
+  default: { expoConfig: { version: "0.1.4" } },
+}));
+mock.module("noah-tools", () => ({
+  getAppVariant: () => "signet",
+}));
+mock.module("react-native", () => ({
+  Platform: { OS: "android" },
+}));
+
+const {
+  buildArkUserAgent,
+  getBaseWalletConfig,
+  getDefaultBlockheightEndpoint,
+  getDefaultEsploraEndpoint,
+  getEffectiveWalletConfig,
+  getWalletEndpoints,
+  getWalletRefreshExpiryThreshold,
+  getWalletRpcAuth,
+} = await import("../../src/lib/walletConfig");
+
+afterAll(() => {
+  if (originalRegtestUrl === undefined) {
+    delete process.env.EXPO_PUBLIC_REGTEST_URL;
+  } else {
+    process.env.EXPO_PUBLIC_REGTEST_URL = originalRegtestUrl;
+  }
+});
+
+describe("base wallet configuration", () => {
+  test("keeps the mainnet settings together", () => {
+    expect(getBaseWalletConfig("mainnet")).toEqual({
+      regtest: false,
+      signet: false,
+      bitcoin: true,
+      config: {
+        esplora: "https://mempool.second.tech/api",
+        ark: "https://ark.second.tech",
+        vtxo_refresh_expiry_threshold: 288,
+        fallback_fee_rate: 10000,
+        htlc_recv_claim_delta: 18,
+        vtxo_exit_margin: 12,
+        round_tx_required_confirmations: 2,
+      },
+    });
+  });
+
+  test("keeps the signet settings together", () => {
+    expect(getBaseWalletConfig("signet")).toEqual({
+      regtest: false,
+      signet: true,
+      bitcoin: false,
+      config: {
+        esplora: "https://esplora.signet.2nd.dev",
+        ark: "https://ark.signet.2nd.dev",
+        vtxo_refresh_expiry_threshold: 48,
+        fallback_fee_rate: 10000,
+        htlc_recv_claim_delta: 18,
+        vtxo_exit_margin: 12,
+        round_tx_required_confirmations: 1,
+      },
+    });
+  });
+
+  test("keeps the Android regtest settings together", () => {
+    expect(getBaseWalletConfig("regtest")).toEqual({
+      regtest: true,
+      signet: false,
+      bitcoin: false,
+      config: {
+        bitcoind: "http://10.0.2.2:18443",
+        ark: "http://10.0.2.2:3535",
+        bitcoind_user: "second",
+        bitcoind_pass: "ark",
+        vtxo_refresh_expiry_threshold: 24,
+        fallback_fee_rate: 10000,
+        htlc_recv_claim_delta: 18,
+        vtxo_exit_margin: 12,
+        round_tx_required_confirmations: 1,
+      },
+    });
+  });
+});
+
+describe("effective wallet configuration", () => {
+  test("adds the app identity and current Esplora endpoint without mutating the base", () => {
+    const baseConfig = getBaseWalletConfig("signet");
+    const result = getEffectiveWalletConfig("https://override.example.com", "signet");
+
+    expect(result.config?.user_agent).toBe("noah-signet-android/0.1.4");
+    expect(result.config?.esplora).toBe("https://override.example.com");
+    expect(baseConfig.config).not.toHaveProperty("user_agent");
+    expect(baseConfig.config?.esplora).toBe("https://esplora.signet.2nd.dev");
+  });
+
+  test("does not apply an Esplora endpoint to regtest", () => {
+    const result = getEffectiveWalletConfig("https://override.example.com", "regtest");
+
+    expect(result.config?.user_agent).toBe("noah-regtest-android/0.1.4");
+    expect(result.config?.esplora).toBeUndefined();
+  });
+});
+
+describe("wallet configuration accessors", () => {
+  test("formats the Ark user agent", () => {
+    expect(buildArkUserAgent("signet", "android", "0.1.4")).toBe(
+      "noah-signet-android/0.1.4",
+    );
+  });
+
+  test("returns wallet endpoints, thresholds, and RPC credentials", () => {
+    expect(getDefaultEsploraEndpoint("signet")).toBe("https://esplora.signet.2nd.dev");
+    expect(getWalletEndpoints(null, "mainnet")).toEqual({
+      ark: "https://ark.second.tech",
+      esplora: "https://mempool.second.tech/api",
+      bitcoind: undefined,
+    });
+    expect(getWalletRefreshExpiryThreshold("regtest")).toBe(24);
+    expect(getWalletRpcAuth("regtest")).toEqual({ username: "second", password: "ark" });
+  });
+
+  test("preserves the existing default block-height endpoints", () => {
+    expect(getDefaultBlockheightEndpoint("mainnet")).toBe(
+      "https://mempool.second.tech/api/blocks/tip/height",
+    );
+    expect(getDefaultBlockheightEndpoint("signet")).toBe(
+      "https://mempool.space/signet/api/blocks/tip/height",
+    );
+    expect(getDefaultBlockheightEndpoint("regtest")).toBe("http://10.0.2.2:18443");
+  });
+});


### PR DESCRIPTION
## Summary

- update `react-native-nitro-ark` and the iOS pod lock from `0.0.131` to `0.0.132`
- centralize all foreground NitroArk profiles and derived accessors in `walletConfig.ts`
- send an Ark user agent such as `noah-signet-android/0.1.4` when creating or loading wallets
- migrate wallet, Esplora, widget, market-data, and settings consumers away from raw config constants
- add characterization tests for every network profile and runtime config composition

## Why

Wallet configuration was split between `constants.ts`, `esplora.ts`, and several consumers that read raw fields directly. This made the effective configuration difficult to follow and easy to drift. The new module provides one foreground source of truth and one builder for the options passed to NitroArk.

## Impact

Wallet creation, restore, startup loading, and Esplora-triggered reloads now receive the variant/platform/version user agent. Existing mainnet, signet, regtest, Esplora override, refresh threshold, and RPC behavior is preserved. The separate Android UnifiedPush JSON path is intentionally unchanged.

## Validation

- `nix develop --command just check` — lint, TypeScript, and 23 unit tests pass
- `nix develop --command just ios-prebuild` — CocoaPods completes with NitroArk `0.0.132`
