### PR TITLE
Add server Ark user agent

### DIFF
--- a/server/src/ark_client.rs
+++ b/server/src/ark_client.rs
@@ -1,5 +1,6 @@
 use crate::{
     AppState,
+    config::ARK_USER_AGENT,
     notification_coordinator::{NotificationCoordinator, NotificationRequest},
     types::NotificationRequestData,
 };
@@ -61,6 +62,7 @@ async fn establish_connection_and_process(
     let connection = ServerConnection::builder()
         .address(ark_server_url)
         .network(network)
+        .user_agent(ARK_USER_AGENT)
         .connect()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to connect: {e:#}"))?;

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -3,6 +3,8 @@ use bitcoin::Network;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
 
+pub const ARK_USER_AGENT: &str = concat!("noah-server/", env!("CARGO_PKG_VERSION"));
+
 /// Configuration for the Noah server
 ///
 /// All config fields are set via environment variables:

--- a/server/src/mailbox_worker.rs
+++ b/server/src/mailbox_worker.rs
@@ -29,6 +29,7 @@ use uuid::Uuid;
 
 use crate::{
     AppState,
+    config::ARK_USER_AGENT,
     db::mailbox_authorization_repo::{ActiveMailboxAuthorization, MailboxAuthorizationRepository},
     errors::ApiError,
     push::{PushNotificationData, send_expo_push_notification, send_push_notification},
@@ -552,6 +553,7 @@ impl MailboxTransport for Beta8MailboxTransport {
             let mut client: MailboxServiceClient<_> = ServerConnection::builder()
                 .address(&app_state.config.ark_server_url)
                 .network(network)
+                .user_agent(ARK_USER_AGENT)
                 .connect()
                 .await?
                 .mailbox_client;


### PR DESCRIPTION
## Summary

- define a shared Ark user agent using the Noah server package version
- pass it to the main Ark RPC connection
- pass it to the mailbox RPC connection

## Why

The Bark RPC client otherwise reports its default Bark identity. This identifies server-side Noah traffic as `noah-server/<version>` consistently across both Ark connection paths.

## Impact

Ark requests from the Noah server and mailbox worker now include the Noah server user agent. No runtime configuration or dependency update is required.

## Validation

- `cargo fmt --all --check`
- `cargo check -p server`
- `cargo test -p server` (305 tests passed across library and binary targets)
- client pre-commit checks: lint, 23 unit tests, and TypeScript