### PR TITLE
Refresh device metadata after app updates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "clsx": "^2.1.1",
         "eslint-plugin-react-compiler": "^19.1.0-rc.2",
         "expo": "~57.0.4",
+        "expo-application": "~57.0.0",
         "expo-asset": "~57.0.3",
         "expo-build-properties": "~57.0.3",
         "expo-clipboard": "~57.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -75,6 +75,7 @@
     "clsx": "^2.1.1",
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
     "expo": "~57.0.4",
+    "expo-application": "~57.0.0",
     "expo-asset": "~57.0.3",
     "expo-build-properties": "~57.0.3",
     "expo-clipboard": "~57.0.0",

--- a/client/src/AppServices.tsx
+++ b/client/src/AppServices.tsx
@@ -4,7 +4,7 @@ import { useServerRegistration } from "~/hooks/useServerRegistration";
 import { usePushNotifications } from "~/hooks/usePushNotifications";
 import { useMailboxAuthorization } from "~/hooks/useMailboxAuthorization";
 import { useBackupCoordinator } from "~/hooks/useBackupCoordinator";
-import { reportLastLogin } from "~/lib/api";
+import { reportLastLoginForServer } from "~/lib/server";
 import logger from "~/lib/log";
 import { AutoBoardingService } from "~/components/AutoBoardingService";
 
@@ -26,7 +26,7 @@ const AppServices = memo(() => {
 
   useEffect(() => {
     if (isReady) {
-      reportLastLogin().then((result) => {
+      reportLastLoginForServer().then((result) => {
         if (result.isErr()) {
           log.w("Failed to report last login", [result.error]);
         }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -38,6 +38,7 @@ import {
   UpdateProfilePayload,
   UploadUrlResponse,
   ReportJobStatusPayload,
+  ReportLastLoginPayload,
   DefaultSuccessPayload,
   SubmitInvoicePayload,
   RegisterPayload,
@@ -519,7 +520,8 @@ export const listBackupObjectsForRestore = async (payload: {
 
 export const deregister = () => post<object, DefaultSuccessPayload>("/deregister", {});
 
-export const reportLastLogin = () => post<object, DefaultSuccessPayload>("/report_last_login", {});
+export const reportLastLogin = (payload: ReportLastLoginPayload = {}) =>
+  post<ReportLastLoginPayload, DefaultSuccessPayload>("/report_last_login", payload);
 
 export const checkAppVersion = async (
   clientVersion: string,

--- a/client/src/lib/deviceInfo.ts
+++ b/client/src/lib/deviceInfo.ts
@@ -1,0 +1,43 @@
+import * as Application from "expo-application";
+import Constants from "expo-constants";
+import * as Device from "expo-device";
+
+import type { DeviceInfo } from "~/types/serverTypes";
+
+export const DEVICE_INFO_REFRESH_INTERVAL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const getCurrentDeviceInfo = (): DeviceInfo => ({
+  device_manufacturer: Device.manufacturer,
+  device_model: Device.modelName,
+  os_name: Device.osName,
+  os_version: Device.osVersion,
+  app_version: Application.nativeApplicationVersion ?? Constants.expoConfig?.version ?? null,
+  app_build: Application.nativeBuildVersion,
+});
+
+export const getDeviceInfoFingerprint = (deviceInfo: DeviceInfo): string =>
+  JSON.stringify([
+    deviceInfo.device_manufacturer,
+    deviceInfo.device_model,
+    deviceInfo.os_name,
+    deviceInfo.os_version,
+    deviceInfo.app_version,
+    deviceInfo.app_build,
+  ]);
+
+export const shouldReportDeviceInfo = (
+  deviceInfo: DeviceInfo,
+  lastReportedFingerprint: string | null,
+  lastReportedAt: number | null,
+  now = Date.now(),
+): boolean => {
+  if (lastReportedFingerprint !== getDeviceInfoFingerprint(deviceInfo)) {
+    return true;
+  }
+
+  if (lastReportedAt === null || lastReportedAt > now) {
+    return true;
+  }
+
+  return now - lastReportedAt >= DEVICE_INFO_REFRESH_INTERVAL_MS;
+};

--- a/client/src/lib/server.ts
+++ b/client/src/lib/server.ts
@@ -1,11 +1,9 @@
-import { authorizeMailbox, registerWithServer } from "~/lib/api";
-import * as Device from "expo-device";
+import { authorizeMailbox, registerWithServer, reportLastLogin } from "~/lib/api";
 import logger from "~/lib/log";
 import { useServerStore } from "~/store/serverStore";
 import { useProfileStore } from "~/store/profileStore";
 import { type Result, err, ok } from "neverthrow";
 import { RegisterResponse } from "~/types/serverTypes";
-import Constants from "expo-constants";
 import { peakAddress } from "~/lib/paymentsApi";
 import {
   registerForPushNotificationsAsync,
@@ -13,9 +11,18 @@ import {
   registerUnifiedPushTokenWithServer,
 } from "~/lib/pushNotifications";
 import { getMailboxAuthorization, loadWalletIfNeeded } from "~/lib/walletApi";
+import {
+  getCurrentDeviceInfo,
+  getDeviceInfoFingerprint,
+  shouldReportDeviceInfo,
+} from "~/lib/deviceInfo";
 
 const log = logger("server");
 export const MAILBOX_AUTH_TTL_SECS = 89 * 24 * 60 * 60;
+
+const recordDeviceInfoReport = (fingerprint: string) => {
+  useServerStore.getState().setDeviceReportState(fingerprint, Date.now());
+};
 
 const applyServerRegistrationResult = (response: RegisterResponse) => {
   const { setRegisteredWithServer, setEmailAddress, setEmailVerified } = useServerStore.getState();
@@ -38,16 +45,12 @@ export const performServerRegistration = async (
     return err(addressResult.error);
   }
   const ark_address = addressResult.value.address;
+  const deviceInfo = getCurrentDeviceInfo();
+  const deviceInfoFingerprint = getDeviceInfoFingerprint(deviceInfo);
 
   // Register with server and pass user device information.
   const result = await registerWithServer({
-    device_info: {
-      app_version: Constants.expoConfig?.version || null,
-      os_name: Device.osName,
-      os_version: Device.osVersion,
-      device_model: Device.modelName,
-      device_manufacturer: Device.manufacturer,
-    },
+    device_info: deviceInfo,
     ln_address,
     ark_address,
   });
@@ -57,9 +60,31 @@ export const performServerRegistration = async (
     return result;
   }
 
+  recordDeviceInfoReport(deviceInfoFingerprint);
   log.d("Successfully registered with server", [result.value.is_email_verified]);
   if (options?.updateStore ?? true) {
     applyServerRegistrationResult(result.value);
+  }
+
+  return result;
+};
+
+export const reportLastLoginForServer = async () => {
+  const {
+    isRegisteredWithServer,
+    lastReportedDeviceFingerprint,
+    lastDeviceReportAt,
+    setDeviceReportState,
+  } = useServerStore.getState();
+
+  const deviceInfo = getCurrentDeviceInfo();
+  const shouldIncludeDeviceInfo =
+    isRegisteredWithServer &&
+    shouldReportDeviceInfo(deviceInfo, lastReportedDeviceFingerprint, lastDeviceReportAt);
+
+  const result = await reportLastLogin(shouldIncludeDeviceInfo ? { device_info: deviceInfo } : {});
+  if (result.isOk() && shouldIncludeDeviceInfo) {
+    setDeviceReportState(getDeviceInfoFingerprint(deviceInfo), Date.now());
   }
 
   return result;

--- a/client/src/screens/FeedbackScreen.tsx
+++ b/client/src/screens/FeedbackScreen.tsx
@@ -1,5 +1,3 @@
-import Constants from "expo-constants";
-import * as Device from "expo-device";
 import { File } from "expo-file-system";
 import * as ImagePicker from "expo-image-picker";
 import { TextInput as ExpoTextInput, type TextInputRef } from "@expo/ui";
@@ -31,6 +29,7 @@ import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
 import { Text } from "~/components/ui/text";
 import { useTheme } from "~/hooks/useTheme";
 import { submitSupportTicket } from "~/lib/api";
+import { getCurrentDeviceInfo } from "~/lib/deviceInfo";
 import Logger from "~/lib/log";
 import { COLORS } from "~/lib/styleConstants";
 import type { SupportTicketAttachment } from "~/types/serverTypes";
@@ -140,13 +139,7 @@ const FeedbackScreen = () => {
       name: trimmedName,
       email: email.trim() || null,
       attachment,
-      device_info: {
-        app_version: Constants.expoConfig?.version || null,
-        os_name: Device.osName,
-        os_version: Device.osVersion,
-        device_model: Device.modelName,
-        device_manufacturer: Device.manufacturer,
-      },
+      device_info: getCurrentDeviceInfo(),
     });
 
     if (result.isErr()) {

--- a/client/src/store/serverStore.ts
+++ b/client/src/store/serverStore.ts
@@ -46,6 +46,8 @@ interface ServerState {
   isEmailPromptDismissed: boolean;
   mailboxAuthorizationExpiry: number | null;
   isMailboxAuthorizationEnabled: boolean;
+  lastReportedDeviceFingerprint: string | null;
+  lastDeviceReportAt: number | null;
   setRegisteredWithServer: (
     isRegistered: boolean,
     lightningAddress: string | null,
@@ -58,6 +60,7 @@ interface ServerState {
   setEmailPromptDismissed: (dismissed: boolean) => void;
   setMailboxAuthorizationExpiry: (expiry: number | null) => void;
   setMailboxAuthorizationEnabled: (enabled: boolean) => void;
+  setDeviceReportState: (fingerprint: string, reportedAt: number) => void;
   resetRegistration: () => void;
 }
 
@@ -72,6 +75,8 @@ export const useServerStore = create<ServerState>()(
       isEmailPromptDismissed: false,
       mailboxAuthorizationExpiry: null,
       isMailboxAuthorizationEnabled: true,
+      lastReportedDeviceFingerprint: null,
+      lastDeviceReportAt: null,
       setRegisteredWithServer: (isRegistered, lightningAddress, isBackupEnabled) =>
         set({ isRegisteredWithServer: isRegistered, lightningAddress, isBackupEnabled }),
       setLightningAddress: (lightningAddress) => set({ lightningAddress }),
@@ -83,6 +88,8 @@ export const useServerStore = create<ServerState>()(
         set({ mailboxAuthorizationExpiry }),
       setMailboxAuthorizationEnabled: (isMailboxAuthorizationEnabled) =>
         set({ isMailboxAuthorizationEnabled }),
+      setDeviceReportState: (lastReportedDeviceFingerprint, lastDeviceReportAt) =>
+        set({ lastReportedDeviceFingerprint, lastDeviceReportAt }),
       resetRegistration: () =>
         set({
           isRegisteredWithServer: false,
@@ -92,6 +99,8 @@ export const useServerStore = create<ServerState>()(
           isEmailVerified: false,
           isEmailPromptDismissed: false,
           mailboxAuthorizationExpiry: null,
+          lastReportedDeviceFingerprint: null,
+          lastDeviceReportAt: null,
         }),
     }),
     {

--- a/client/src/types/serverTypes.ts
+++ b/client/src/types/serverTypes.ts
@@ -72,9 +72,9 @@ export type DeleteBackupObjectPayload = { backup_id: string, };
 export type DeleteBackupPayload = { backup_version: number, };
 
 /**
- * Defines device information captured during registration.
+ * Defines device information reported by the client.
  */
-export type DeviceInfo = { device_manufacturer: string | null, device_model: string | null, os_name: string | null, os_version: string | null, app_version: string | null, };
+export type DeviceInfo = { device_manufacturer: string | null, device_model: string | null, os_name: string | null, os_version: string | null, app_version: string | null, app_build: string | null, };
 
 export type DownloadUrlResponse = { download_url: string, backup_size: number, };
 
@@ -195,6 +195,8 @@ is_email_verified: boolean,
 user_status: UserStatus, };
 
 export type ReportJobStatusPayload = { notification_k1: string, report_type: ReportType, status: ReportStatus, error_message: string | null, };
+
+export type ReportLastLoginPayload = { device_info?: DeviceInfo, };
 
 export type ReportStatus = "pending" | "success" | "failure" | "timeout";
 

--- a/client/tests/unit/deviceInfo.test.js
+++ b/client/tests/unit/deviceInfo.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("expo-application", () => ({
+  nativeApplicationVersion: "0.1.4",
+  nativeBuildVersion: "27",
+}));
+mock.module("expo-constants", () => ({
+  default: { expoConfig: { version: "0.1.4" } },
+}));
+mock.module("expo-device", () => ({
+  manufacturer: "Apple",
+  modelName: "iPhone 12 Pro",
+  osName: "iOS",
+  osVersion: "26.5",
+}));
+
+const {
+  DEVICE_INFO_REFRESH_INTERVAL_MS,
+  getCurrentDeviceInfo,
+  getDeviceInfoFingerprint,
+  shouldReportDeviceInfo,
+} = await import("../../src/lib/deviceInfo");
+
+const now = Date.UTC(2026, 6, 16);
+const deviceInfo = getCurrentDeviceInfo();
+
+describe("device information reporting", () => {
+  test("collects app, build, OS, and hardware details", () => {
+    expect(deviceInfo).toEqual({
+      device_manufacturer: "Apple",
+      device_model: "iPhone 12 Pro",
+      os_name: "iOS",
+      os_version: "26.5",
+      app_version: "0.1.4",
+      app_build: "27",
+    });
+  });
+
+  test("does not report unchanged recent details", () => {
+    expect(
+      shouldReportDeviceInfo(
+        deviceInfo,
+        getDeviceInfoFingerprint(deviceInfo),
+        now - 1_000,
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  test("reports after app, build, or OS changes", () => {
+    const previousVersions = [
+      { ...deviceInfo, app_version: "0.1.3" },
+      { ...deviceInfo, app_build: "26" },
+      { ...deviceInfo, os_version: "26.4" },
+    ];
+
+    for (const previousDeviceInfo of previousVersions) {
+      expect(
+        shouldReportDeviceInfo(
+          deviceInfo,
+          getDeviceInfoFingerprint(previousDeviceInfo),
+          now - 1_000,
+          now,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("reports again when a failed attempt left no successful state", () => {
+    expect(shouldReportDeviceInfo(deviceInfo, null, null, now)).toBe(true);
+    expect(shouldReportDeviceInfo(deviceInfo, null, null, now + 1_000)).toBe(true);
+  });
+
+  test("refreshes unchanged details after 30 days", () => {
+    expect(
+      shouldReportDeviceInfo(
+        deviceInfo,
+        getDeviceInfoFingerprint(deviceInfo),
+        now - DEVICE_INFO_REFRESH_INTERVAL_MS,
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  test("repairs a report timestamp that is in the future", () => {
+    expect(
+      shouldReportDeviceInfo(
+        deviceInfo,
+        getDeviceInfoFingerprint(deviceInfo),
+        now + 1_000,
+        now,
+      ),
+    ).toBe(true);
+  });
+});

--- a/server/migrations/0019_add_device_app_build.sql
+++ b/server/migrations/0019_add_device_app_build.sql
@@ -1,0 +1,2 @@
+ALTER TABLE devices
+ADD COLUMN app_build TEXT;

--- a/server/src/bin/loadtest.rs
+++ b/server/src/bin/loadtest.rs
@@ -47,6 +47,7 @@ struct DeviceInfo {
     os_name: Option<String>,
     os_version: Option<String>,
     app_version: Option<String>,
+    app_build: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -144,6 +145,7 @@ async fn register_test_user(
             os_name: Some("Android".to_string()),
             os_version: Some("14".to_string()),
             app_version: Some("1.0.0".to_string()),
+            app_build: Some("1".to_string()),
         }),
     };
 

--- a/server/src/db/device_repo.rs
+++ b/server/src/db/device_repo.rs
@@ -17,14 +17,23 @@ impl DeviceRepository {
         device_info: &DeviceInfo,
     ) -> Result<()> {
         sqlx::query(
-            "INSERT INTO devices (pubkey, device_manufacturer, device_model, os_name, os_version, app_version)
-             VALUES ($1, $2, $3, $4, $5, $6)
+            "INSERT INTO devices (
+                 pubkey,
+                 device_manufacturer,
+                 device_model,
+                 os_name,
+                 os_version,
+                 app_version,
+                 app_build
+             )
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
              ON CONFLICT(pubkey) DO UPDATE SET
                  device_manufacturer = excluded.device_manufacturer,
                  device_model = excluded.device_model,
                  os_name = excluded.os_name,
                  os_version = excluded.os_version,
                  app_version = excluded.app_version,
+                 app_build = COALESCE(excluded.app_build, devices.app_build),
                  updated_at = now()",
         )
         .bind(pubkey)
@@ -33,8 +42,50 @@ impl DeviceRepository {
         .bind(device_info.os_name.clone())
         .bind(device_info.os_version.clone())
         .bind(device_info.app_version.clone())
+        .bind(device_info.app_build.clone())
         .execute(&mut **tx)
         .await?;
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub async fn find_by_pubkey(pool: &sqlx::PgPool, pubkey: &str) -> Result<Option<DeviceInfo>> {
+        let row = sqlx::query_as::<
+            _,
+            (
+                Option<String>,
+                Option<String>,
+                Option<String>,
+                Option<String>,
+                Option<String>,
+                Option<String>,
+            ),
+        >(
+            "SELECT
+                 device_manufacturer,
+                 device_model,
+                 os_name,
+                 os_version,
+                 app_version,
+                 app_build
+             FROM devices
+             WHERE pubkey = $1",
+        )
+        .bind(pubkey)
+        .fetch_optional(pool)
+        .await?;
+
+        Ok(row.map(
+            |(device_manufacturer, device_model, os_name, os_version, app_version, app_build)| {
+                DeviceInfo {
+                    device_manufacturer,
+                    device_model,
+                    os_name,
+                    os_version,
+                    app_version,
+                    app_build,
+                }
+            },
+        ))
     }
 }

--- a/server/src/routes/gated_api_v0.rs
+++ b/server/src/routes/gated_api_v0.rs
@@ -1,4 +1,5 @@
 use crate::db::backup_repo::BackupRepository;
+use crate::db::device_repo::DeviceRepository;
 use crate::db::heartbeat_repo::HeartbeatRepository;
 use crate::db::job_status_repo::JobStatusRepository;
 use crate::db::mailbox_authorization_repo::MailboxAuthorizationRepository;
@@ -13,8 +14,8 @@ use crate::types::{
     DefaultSuccessPayload, DeleteBackupObjectPayload, DeleteBackupPayload, DownloadUrlResponse,
     GetBackupObjectDownloadPayload, GetDownloadUrlPayload, HeartbeatResponsePayload,
     InitiateBackupUploadPayload, InitiateBackupUploadResponse, LightningAddressSuggestionsPayload,
-    LightningAddressSuggestionsResponse, ReportJobStatusPayload, ReportStatus,
-    SubmitInvoicePayload, SubmitSupportTicketPayload, SubmitSupportTicketResponse,
+    LightningAddressSuggestionsResponse, ReportJobStatusPayload, ReportLastLoginPayload,
+    ReportStatus, SubmitInvoicePayload, SubmitSupportTicketPayload, SubmitSupportTicketResponse,
     UpdateProfilePayload, UserInfoResponse, UserStatus,
 };
 use crate::{
@@ -796,9 +797,16 @@ pub async fn heartbeat_response(
 pub async fn report_last_login(
     State(state): State<AppState>,
     Extension(auth_payload): Extension<AuthenticatedUser>,
+    Json(payload): Json<ReportLastLoginPayload>,
 ) -> anyhow::Result<Json<DefaultSuccessPayload>, ApiError> {
     let user_repo = UserRepository::new(&state.db_pool);
     user_repo.update_last_login(&auth_payload.key).await?;
+
+    if let Some(device_info) = payload.device_info {
+        let mut tx = state.db_pool.begin().await?;
+        DeviceRepository::upsert(&mut tx, &auth_payload.key, &device_info).await?;
+        tx.commit().await?;
+    }
 
     Ok(Json(DefaultSuccessPayload { success: true }))
 }

--- a/server/src/tests/gated_user_tests.rs
+++ b/server/src/tests/gated_user_tests.rs
@@ -6,6 +6,7 @@ use serde_json::json;
 use tower::ServiceExt;
 
 use crate::db::backup_repo::BackupRepository;
+use crate::db::device_repo::DeviceRepository;
 use crate::db::heartbeat_repo::HeartbeatRepository;
 use crate::db::job_status_repo::JobStatusRepository;
 use crate::db::mailbox_authorization_repo::MailboxAuthorizationRepository;
@@ -1220,7 +1221,7 @@ async fn test_report_last_login() {
                     http::header::AUTHORIZATION,
                     format!("Bearer {}", access_token),
                 )
-                .body(Body::empty())
+                .body(Body::from("{}"))
                 .unwrap(),
         )
         .await
@@ -1234,6 +1235,99 @@ async fn test_report_last_login() {
         .await
         .unwrap();
     assert!(updated_last_login.is_some());
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_report_last_login_upserts_device_info() {
+    let (app, app_state, _guard) = setup_test_app().await;
+
+    let user = TestUser::new();
+    let pubkey = user.pubkey().to_string();
+    let access_token = user.access_token(&app_state);
+
+    let mut tx = app_state.db_pool.begin().await.unwrap();
+    UserRepository::create(&mut tx, &pubkey, "deviceuser@localhost", None)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/report_last_login")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "device_info": {
+                            "device_manufacturer": "Apple",
+                            "device_model": "iPhone 12 Pro",
+                            "os_name": "iOS",
+                            "os_version": "26.5",
+                            "app_version": "0.1.3",
+                            "app_build": "26"
+                        }
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let initial_device = DeviceRepository::find_by_pubkey(&app_state.db_pool, &pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(initial_device.app_version.as_deref(), Some("0.1.3"));
+    assert_eq!(initial_device.app_build.as_deref(), Some("26"));
+    assert_eq!(initial_device.os_version.as_deref(), Some("26.5"));
+
+    let update_response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/report_last_login")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {}", access_token),
+                )
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "device_info": {
+                            "device_manufacturer": "Apple",
+                            "device_model": "iPhone 12 Pro",
+                            "os_name": "iOS",
+                            "os_version": "26.6",
+                            "app_version": "0.1.4",
+                            "app_build": "27"
+                        }
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(update_response.status(), StatusCode::OK);
+
+    let updated_device = DeviceRepository::find_by_pubkey(&app_state.db_pool, &pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(updated_device.app_version.as_deref(), Some("0.1.4"));
+    assert_eq!(updated_device.app_build.as_deref(), Some("27"));
+    assert_eq!(updated_device.os_version.as_deref(), Some("26.6"));
 }
 
 #[tracing_test::traced_test]
@@ -1267,7 +1361,7 @@ async fn test_report_last_login_updates_timestamp() {
                     http::header::AUTHORIZATION,
                     format!("Bearer {}", access_token),
                 )
-                .body(Body::empty())
+                .body(Body::from("{}"))
                 .unwrap(),
         )
         .await
@@ -1296,7 +1390,7 @@ async fn test_report_last_login_updates_timestamp() {
                     http::header::AUTHORIZATION,
                     format!("Bearer {}", access_token),
                 )
-                .body(Body::empty())
+                .body(Body::from("{}"))
                 .unwrap(),
         )
         .await

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -145,7 +145,7 @@ impl std::str::FromStr for UserStatus {
     }
 }
 
-/// Defines device information captured during registration.
+/// Defines device information reported by the client.
 #[derive(Serialize, Deserialize, TS, Debug, Clone)]
 #[ts(export, export_to = "../../client/src/types/serverTypes.ts")]
 pub struct DeviceInfo {
@@ -154,6 +154,7 @@ pub struct DeviceInfo {
     pub os_name: Option<String>,
     pub os_version: Option<String>,
     pub app_version: Option<String>,
+    pub app_build: Option<String>,
 }
 
 /// Defines the payload for a user registration request.
@@ -606,6 +607,14 @@ pub struct ReportJobStatusPayload {
 #[ts(export, export_to = "../../client/src/types/serverTypes.ts")]
 pub struct DefaultSuccessPayload {
     pub success: bool,
+}
+
+#[derive(Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../../client/src/types/serverTypes.ts")]
+pub struct ReportLastLoginPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub device_info: Option<DeviceInfo>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, TS)]

--- a/server/src/zoho.rs
+++ b/server/src/zoho.rs
@@ -502,6 +502,7 @@ fn append_device_info(description: &mut String, device_info: &DeviceInfo) {
         "App version",
         device_info.app_version.as_deref(),
     );
+    append_optional_description_row(description, "App build", device_info.app_build.as_deref());
 }
 
 fn append_optional_description_row(description: &mut String, label: &str, value: Option<&str>) {
@@ -641,6 +642,7 @@ mod tests {
                 os_name: Some("iOS".to_string()),
                 os_version: Some("26.5".to_string()),
                 app_version: Some("0.1.3".to_string()),
+                app_build: Some("26".to_string()),
             }),
         };
         let auth_user = AuthenticatedUser {


### PR DESCRIPTION
## Summary

- attach device metadata to the existing launch-time last-login request only when the app/build/OS/device fingerprint changes
- persist the last successful fingerprint and refresh unchanged metadata after 30 days as a self-healing backstop
- add native build tracking, an optional server payload, and a database upsert/migration
- keep normal launches at the existing empty `{}` last-login payload

## Root cause

Device metadata was only written during server registration. The persisted registration flag survives app upgrades, so users could continue launching newer builds while their `devices` row remained on the version seen during initial registration.

## Validation

- `just check-all`
- `cargo test`
- `cargo test test_report_last_login_upserts_device_info`

Closes #283
