### PR TITLE
Fix standalone BOLT12 offer payments

### DIFF
--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -541,7 +541,7 @@ export const useSendScreen = () => {
       showAlert({
         title: "Invalid Destination",
         description:
-          "Please enter a valid Bitcoin address, BOLT11 invoice, Lightning Address, or Ark public key.",
+          "Please enter a valid Bitcoin address, BOLT11 invoice, BOLT12 offer, Lightning Address, or Ark public key.",
       });
       return;
     }

--- a/client/src/lib/sendUtils.ts
+++ b/client/src/lib/sendUtils.ts
@@ -11,6 +11,7 @@ import logger from "./log";
 import { isNetworkMatch } from "./utils";
 
 const log = logger("sendUtils");
+const BOLT12_OFFER_REGEX = /^lno1[02-9ac-hj-np-z]+$/i;
 
 export type DestinationTypes =
   | "onchain"
@@ -38,6 +39,30 @@ export type ParsedDestination = {
 
 const LIGHTNING_PREFIX_REGEX = /^lightning:/i;
 
+const isBolt12OfferDestination = (offer: string): boolean => {
+  const chunks = offer.split("+");
+  const firstChunk = chunks.shift();
+  if (!firstChunk || /\s/.test(firstChunk)) {
+    return false;
+  }
+
+  let normalizedOffer = firstChunk;
+  for (const chunk of chunks) {
+    const trimmedChunk = chunk.trimStart();
+    if (!trimmedChunk || /\s/.test(trimmedChunk)) {
+      return false;
+    }
+    normalizedOffer += trimmedChunk;
+  }
+
+  const hasUniformCase =
+    normalizedOffer === normalizedOffer.toLowerCase() ||
+    normalizedOffer === normalizedOffer.toUpperCase();
+
+  // BOLT12 uses checksum-less Bech32. Bark performs the authoritative TLV and semantic validation.
+  return hasUniformCase && BOLT12_OFFER_REGEX.test(normalizedOffer);
+};
+
 export const normalizeLightningAddress = (address: string): string => address.trim().toLowerCase();
 
 export const normalizeLightningAddressDestination = (destination: string): string => {
@@ -58,7 +83,13 @@ export const isValidDestination = (dest: string): boolean => {
   if (dest.toLowerCase().startsWith("bitcoin:")) {
     const expectedNetwork = APP_VARIANT;
     const result = parseBIP321(dest, expectedNetwork);
-    return result.valid && result.paymentMethods.length > 0;
+    return (
+      result.valid &&
+      result.paymentMethods.some(
+        (method) =>
+          method.valid || (method.type === "offer" && isBolt12OfferDestination(method.value)),
+      )
+    );
   }
 
   const cleanedDest = dest.trim().replace(LIGHTNING_PREFIX_REGEX, "");
@@ -72,6 +103,10 @@ export const isValidDestination = (dest: string): boolean => {
   // Check Lightning invoice (BOLT11)
   const lnResult = validateLightningInvoice(cleanedDest);
   if (lnResult.valid && isNetworkMatch(lnResult.network, "lightning")) {
+    return true;
+  }
+
+  if (isBolt12OfferDestination(cleanedDest)) {
     return true;
   }
 
@@ -120,7 +155,9 @@ export const parseBip321Uri = (uri: string): ParsedDestination => {
 
     // Extract payment methods
     for (const method of result.paymentMethods) {
-      if (!method.valid) continue;
+      const isValidMethod =
+        method.valid || (method.type === "offer" && isBolt12OfferDestination(method.value));
+      if (!isValidMethod) continue;
 
       switch (method.type) {
         case "onchain":
@@ -136,6 +173,14 @@ export const parseBip321Uri = (uri: string): ParsedDestination => {
           bip321.offer = method.value;
           break;
       }
+    }
+
+    if (Object.keys(bip321).length === 0) {
+      return {
+        destinationType: null,
+        isAmountEditable: true,
+        error: result.errors.join(", ") || "No valid payment methods found",
+      };
     }
 
     const parsedAmount = typeof result.amount === "number" ? btcToSats(result.amount) : null;
@@ -224,6 +269,13 @@ export const parseDestination = (destination: string): ParsedDestination => {
         isAmountEditable: true,
       };
     }
+  }
+
+  if (isBolt12OfferDestination(cleanedDestination)) {
+    return {
+      destinationType: "offer",
+      isAmountEditable: true,
+    };
   }
 
   const btcResult = validateBitcoinAddress(cleanedDestination);

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -325,7 +325,7 @@ const SendScreen = () => {
                       <TextInput
                         ref={destinationInputRef}
                         className="min-h-9 flex-1 text-base text-foreground"
-                        placeholder="Address, invoice, or lightning address"
+                        placeholder="Address, invoice, offer, or lightning address"
                         placeholderTextColor={colors.mutedForeground}
                         keyboardType="email-address"
                         autoCorrect={false}

--- a/client/tests/unit/sendUtils.test.js
+++ b/client/tests/unit/sendUtils.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, mock, test } from "bun:test";
+
+globalThis.__DEV__ = false;
+
+mock.module("noah-tools", () => ({
+  getAppVariant: () => "mainnet",
+  isGooglePlayServicesAvailable: () => true,
+  nativeLog: () => {},
+}));
+mock.module("react-native", () => ({
+  Platform: { OS: "ios" },
+}));
+mock.module("react-native-fs-turbo", () => ({
+  default: {
+    CachesDirectoryPath: "/tmp",
+    DocumentDirectoryPath: "/tmp",
+  },
+}));
+mock.module("expo-device", () => ({
+  isDevice: true,
+}));
+
+const { isValidDestination, parseDestination } = await import("../../src/lib/sendUtils");
+
+// Fixture from LDK's BOLT12 parser tests. BOLT12 uses Bech32 encoding without a checksum.
+const BOLT12_OFFER =
+  "lno1pqps7sjqpgtyzm3qv4uxzmtsd3jjqer9wd3hy6tsw35k7msjzfpy7nz5yqcnygrfdej82um5wf5k2uckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg";
+
+describe("BOLT12 send destinations", () => {
+  test("accepts a bare BOLT12 offer", () => {
+    expect(isValidDestination(BOLT12_OFFER)).toBe(true);
+    expect(parseDestination(BOLT12_OFFER)).toEqual({
+      destinationType: "offer",
+      isAmountEditable: true,
+    });
+  });
+
+  test("accepts lightning-prefixed and uppercase offers", () => {
+    expect(parseDestination(`lightning:${BOLT12_OFFER}`)).toEqual({
+      destinationType: "offer",
+      isAmountEditable: true,
+    });
+    expect(parseDestination(BOLT12_OFFER.toUpperCase())).toEqual({
+      destinationType: "offer",
+      isAmountEditable: true,
+    });
+  });
+
+  test("accepts BOLT12 continuation markers", () => {
+    const continuedOffer = `${BOLT12_OFFER.slice(0, 40)}+ \n  ${BOLT12_OFFER.slice(40)}`;
+
+    expect(isValidDestination(continuedOffer)).toBe(true);
+    expect(parseDestination(continuedOffer)).toEqual({
+      destinationType: "offer",
+      isAmountEditable: true,
+    });
+  });
+
+  test("extracts a real offer from a BIP-321 URI", () => {
+    const uri = `bitcoin:?lno=${BOLT12_OFFER}`;
+
+    expect(isValidDestination(uri)).toBe(true);
+    expect(parseDestination(uri)).toEqual({
+      destinationType: "bip321",
+      isAmountEditable: true,
+      bip321: {
+        offer: BOLT12_OFFER,
+      },
+    });
+  });
+
+  test("rejects malformed offer encodings", () => {
+    const mixedCaseOffer = `${BOLT12_OFFER.slice(0, 10).toUpperCase()}${BOLT12_OFFER.slice(10)}`;
+
+    expect(isValidDestination("lno1")).toBe(false);
+    expect(isValidDestination("lno1not-an-offer")).toBe(false);
+    expect(isValidDestination(mixedCaseOffer)).toBe(false);
+    expect(isValidDestination("bitcoin:?lno=lno1not-an-offer")).toBe(false);
+    expect(parseDestination("bitcoin:?lno=lno1not-an-offer").destinationType).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- recognize standalone, lightning-prefixed, uppercase, continued, and BIP-321 BOLT12 offers
- keep Bark as the authoritative TLV and semantic validator before payment
- update send-screen guidance and add regression coverage using a real LDK offer fixture

## Root cause

The send destination gate only recognized BOLT11, Ark, on-chain, and Lightning Address inputs. The existing BIP-321 dependency also validates BOLT12 offers as checksummed Bech32, while real BOLT12 offers use checksum-less Bech32, so valid offers were discarded before reaching the existing native payment path.

## User impact

Users can paste or scan valid lno1 offers and proceed through amount entry and confirmation instead of receiving the invalid-destination popup.

## Validation

- just check
- ESLint
- 42 unit tests
- TypeScript typecheck