### PR TITLE
Update Nitro Ark to 0.0.133

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -63,7 +63,7 @@
         "react-native-gesture-handler": "~2.32.0",
         "react-native-keychain": "^10.0.0",
         "react-native-mmkv": "^4.3.1",
-        "react-native-nitro-ark": "0.0.132",
+        "react-native-nitro-ark": "0.0.133",
         "react-native-nitro-modules": "0.35.6",
         "react-native-qrcode-svg": "^6.3.21",
         "react-native-quick-base64": "^3.0.0",
@@ -1538,7 +1538,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@4.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg=="],
 
-    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.132", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-4X8drLfmNibIdnPUgV7/x+ahHj2xQH7ialX0jY9BpWFUI7CNnjIN0Iw11GngerjtDBfQ1eHHHjedDWoKiTSgRw=="],
+    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.133", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-PkHPEpQAdQ8BqEfTfbUsMJj/m2onLkBWGLxKxbGdDyrkAvIF8Kut5s6G3VCL4u7oGUBB3Vo4cE9znM50IsikMQ=="],
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.35.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g=="],
 

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -281,7 +281,7 @@ PODS:
     - ReactNativeDependencies
     - Yoga
   - MMKVCore (2.4.0)
-  - NitroArk (0.0.132):
+  - NitroArk (0.0.133):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -3264,7 +3264,7 @@ SPEC CHECKSUMS:
   hermes-engine: 82e1b37154a8c157253ac036eccbdd3f8dbdfa89
   MapLibreReactNative: 9f1f16d5f5f522309ad1f2afc483a34cfc56fe6e
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: 8d498c5a5d7e655e512369815b1a88090e3d8984
+  NitroArk: f29571846e9d3ec9e224c5b34f318815fdf4d6ea
   NitroMmkv: 4b4f95387a15161b346a6a93b9c7072c179e0e88
   NitroModules: c41b7b778d6557f1e517a80ec681a670321fa001
   NoahTools: 690d5d90593c5634d2a9ab514a6c243d8212ef20

--- a/client/nitromodules/noah-tools/android/src/main/java/com/margelo/nitro/noahtools/NoahPushService.kt
+++ b/client/nitromodules/noah-tools/android/src/main/java/com/margelo/nitro/noahtools/NoahPushService.kt
@@ -225,11 +225,11 @@ class NoahPushService : PushService() {
     ) {
         try {
             ensureWalletLoaded(clazz, instance, context)
-            clazz.getMethod("maintenanceWithOnchainDelegated").invoke(instance)
+            clazz.getMethod("maintenanceDelegated").invoke(instance)
             NoahToolsLogging.performNativeLog(
                 "info",
                 "NoahPushService",
-                "maintenanceWithOnchainDelegated() completed"
+                "maintenanceDelegated() completed"
             )
             if (server != null) {
                 reportJobStatus(clazz, instance, server, "maintenance", "success", null, k1)

--- a/client/package.json
+++ b/client/package.json
@@ -106,7 +106,7 @@
     "react-native-gesture-handler": "~2.32.0",
     "react-native-keychain": "^10.0.0",
     "react-native-mmkv": "^4.3.1",
-    "react-native-nitro-ark": "0.0.132",
+    "react-native-nitro-ark": "0.0.133",
     "react-native-nitro-modules": "0.35.6",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-quick-base64": "^3.0.0",

--- a/client/src/hooks/useWallet.ts
+++ b/client/src/hooks/useWallet.ts
@@ -10,7 +10,7 @@ import {
   loadWalletIfNeeded as loadWalletAction,
   sync as syncAction,
   onchainSync as onchainSyncAction,
-  maintenanceWithOnchainDelegated,
+  maintenanceDelegated,
   getVtxos,
   getExpiringVtxos,
   closeWalletIfLoaded,
@@ -199,7 +199,7 @@ export function useRefreshExpiringVtxos() {
 
   return useMutation({
     mutationFn: async () => {
-      const result = await maintenanceWithOnchainDelegated();
+      const result = await maintenanceDelegated();
       if (result.isErr()) {
         throw result.error;
       }

--- a/client/src/lib/exitTimeline.ts
+++ b/client/src/lib/exitTimeline.ts
@@ -14,6 +14,7 @@ export const EXIT_STATE_ORDER: ExitProgressState[] = [
   "ClaimInProgress",
   "Claimed",
   "VtxoAlreadySpent",
+  "Canceled",
 ];
 
 export const EXIT_STATE_LABELS: Record<ExitProgressState, string> = {
@@ -24,6 +25,7 @@ export const EXIT_STATE_LABELS: Record<ExitProgressState, string> = {
   ClaimInProgress: "Claiming",
   Claimed: "Claimed",
   VtxoAlreadySpent: "Already spent",
+  Canceled: "Canceled",
 };
 
 export type ExitDetailRow = {
@@ -197,6 +199,8 @@ export const getExitStatusText = ({
         : "Claim transaction confirmed";
     case "VtxoAlreadySpent":
       return "Exit VTXO was already spent";
+    case "Canceled":
+      return "Exit processing was canceled";
     case "Processing": {
       const txSummary = getProcessingTransactionSummary(details);
       return txSummary
@@ -245,6 +249,8 @@ const getTimelineDescription = ({
         : "Funds were recovered on-chain.";
     case "VtxoAlreadySpent":
       return "Exit tracking found that this VTXO was already spent.";
+    case "Canceled":
+      return "Exit processing was canceled before completion.";
   }
 };
 

--- a/client/src/lib/tasks.ts
+++ b/client/src/lib/tasks.ts
@@ -1,4 +1,4 @@
-import { loadWalletIfNeeded, maintenanceWithOnchainDelegated } from "./walletApi";
+import { loadWalletIfNeeded, maintenanceDelegated } from "./walletApi";
 import logger from "~/lib/log";
 import { bolt11Invoice, tryClaimAllLightningReceives } from "./paymentsApi";
 import { err, ok, Result } from "neverthrow";
@@ -16,7 +16,7 @@ export async function maintenanceTask(): Promise<Result<void, Error>> {
     return err(e);
   }
 
-  const maintenanceResult = await maintenanceWithOnchainDelegated();
+  const maintenanceResult = await maintenanceDelegated();
   if (maintenanceResult.isErr()) {
     log.e("Maintenance failed", [maintenanceResult.error]);
     return err(maintenanceResult.error);

--- a/client/src/lib/walletApi.ts
+++ b/client/src/lib/walletApi.ts
@@ -12,9 +12,7 @@ import {
   verifyMessage as verifyMessageNitro,
   maintenance as maintenanceNitro,
   maintenanceRefresh as maintenanceRefreshNitro,
-  maintenanceWithOnchain as maintenanceWithOnchainNitro,
   maintenanceDelegated as maintenanceDelegatedNitro,
-  maintenanceWithOnchainDelegated as maintenanceWithOnchainDelegatedNitro,
   refreshVtxosDelegated as refreshVtxosDelegatedNitro,
   estimateRefreshFee as estimateRefreshFeeNitro,
   refreshServer as refreshServerNitro,
@@ -26,6 +24,7 @@ import {
   decodeVtxoHex as decodeVtxoHexNitro,
   importVtxo as importVtxoNitro,
   dangerousDropVtxo as dangerousDropVtxoNitro,
+  unlockVtxos as unlockVtxosNitro,
   getExpiringVtxos as getExpiringVtxosNitro,
   type BarkArkInfo,
   type BarkFeeEstimate,
@@ -437,7 +436,7 @@ export const onchainSync = async (): Promise<Result<void, Error>> => {
   return ResultAsync.fromPromise(onchainSyncNitro(), (e) => e as Error);
 };
 
-export const maintanance = async (): Promise<Result<void, Error>> => {
+export const maintenance = async (): Promise<Result<void, Error>> => {
   return ResultAsync.fromPromise(maintenanceNitro(), (e) => e as Error);
 };
 
@@ -445,16 +444,8 @@ export const maintenanceRefresh = async (): Promise<Result<void, Error>> => {
   return ResultAsync.fromPromise(maintenanceRefreshNitro(), (e) => e as Error);
 };
 
-export const maintenanceWithOnchain = async (): Promise<Result<void, Error>> => {
-  return ResultAsync.fromPromise(maintenanceWithOnchainNitro(), (e) => e as Error);
-};
-
 export const maintenanceDelegated = async (): Promise<Result<void, Error>> => {
   return ResultAsync.fromPromise(maintenanceDelegatedNitro(), (e) => e as Error);
-};
-
-export const maintenanceWithOnchainDelegated = async (): Promise<Result<void, Error>> => {
-  return ResultAsync.fromPromise(maintenanceWithOnchainDelegatedNitro(), (e) => e as Error);
 };
 
 export const refreshVtxosDelegated = async (
@@ -532,6 +523,10 @@ export const importVtxo = async (vtxoHex: string): Promise<Result<BarkVtxo, Erro
 
 export const dropVtxo = async (vtxoId: string): Promise<Result<void, Error>> => {
   return ResultAsync.fromPromise(dangerousDropVtxoNitro(vtxoId), (e) => e as Error);
+};
+
+export const unlockVtxo = async (vtxoId: string): Promise<Result<void, Error>> => {
+  return ResultAsync.fromPromise(unlockVtxosNitro([vtxoId]), (e) => e as Error);
 };
 
 export const getExpiringVtxos = async () => {

--- a/client/src/screens/DebugScreen.tsx
+++ b/client/src/screens/DebugScreen.tsx
@@ -10,13 +10,13 @@ import { Input } from "~/components/ui/input";
 import {
   getArkInfo,
   refreshServer,
-  maintanance,
+  maintenance,
   maintenanceRefresh,
   maintenanceDelegated,
-  maintenanceWithOnchainDelegated,
   decodeVtxoHex,
   importVtxo,
   dropVtxo,
+  unlockVtxo,
 } from "~/lib/walletApi";
 import { offboardAllArk } from "~/lib/paymentsApi";
 import { registerForPushNotificationsAsync } from "~/lib/pushNotifications";
@@ -40,10 +40,10 @@ type DebugAction =
   | "maintenance"
   | "maintenanceRefresh"
   | "maintenanceDelegated"
-  | "maintenanceWithOnchainDelegated"
   | "decodeVtxoHex"
   | "importVtxo"
   | "dropVtxo"
+  | "unlockVtxo"
   | "offboardAll";
 
 interface ActionOption {
@@ -73,7 +73,7 @@ const DEBUG_ACTIONS: ActionOption[] = [
   {
     id: "maintenance",
     title: "Maintenance",
-    description: "Run maintenance to refresh expiring VTXOs",
+    description: "Run wallet maintenance, including on-chain sync and exit progression",
   },
   {
     id: "maintenanceRefresh",
@@ -83,12 +83,7 @@ const DEBUG_ACTIONS: ActionOption[] = [
   {
     id: "maintenanceDelegated",
     title: "Maintenance Delegated",
-    description: "Run delegated maintenance operation",
-  },
-  {
-    id: "maintenanceWithOnchainDelegated",
-    title: "Maintenance With Onchain Delegated",
-    description: "Run delegated maintenance with onchain operation",
+    description: "Run delegated wallet maintenance, including on-chain sync",
   },
   {
     id: "offboardAll",
@@ -115,6 +110,13 @@ const DEBUG_ACTIONS: ActionOption[] = [
     id: "dropVtxo",
     title: "Drop VTXO",
     description: "Dangerously remove a VTXO from the local wallet database",
+    requiresInput: true,
+    inputPlaceholder: "Enter VTXO ID",
+  },
+  {
+    id: "unlockVtxo",
+    title: "Unlock VTXO",
+    description: "Return a locked VTXO to the spendable state",
     requiresInput: true,
     inputPlaceholder: "Enter VTXO ID",
   },
@@ -194,7 +196,7 @@ const DebugScreen = () => {
       }
       case "maintenance": {
         log.d("Executing maintenance");
-        const result = await maintanance();
+        const result = await maintenance();
         if (result.isErr()) {
           return { success: false, error: result.error.message };
         }
@@ -215,17 +217,6 @@ const DebugScreen = () => {
           return { success: false, error: result.error.message };
         }
         return { success: true, message: "Maintenance delegated completed successfully" };
-      }
-      case "maintenanceWithOnchainDelegated": {
-        log.d("Executing maintenance with onchain delegated");
-        const result = await maintenanceWithOnchainDelegated();
-        if (result.isErr()) {
-          return { success: false, error: result.error.message };
-        }
-        return {
-          success: true,
-          message: "Maintenance with onchain delegated completed successfully",
-        };
       }
       case "offboardAll": {
         log.d("Executing offboard all to address:", [input]);
@@ -265,6 +256,15 @@ const DebugScreen = () => {
           return { success: false, error: result.error.message };
         }
         return { success: true, message: `Dropped VTXO ${vtxoId}` };
+      }
+      case "unlockVtxo": {
+        const vtxoId = input.trim();
+        log.d("Unlocking VTXO", [{ vtxoId }]);
+        const result = await unlockVtxo(vtxoId);
+        if (result.isErr()) {
+          return { success: false, error: result.error.message };
+        }
+        return { success: true, message: `Unlocked VTXO ${vtxoId}` };
       }
     }
   };

--- a/client/src/screens/ExitVtxoDetailScreen.tsx
+++ b/client/src/screens/ExitVtxoDetailScreen.tsx
@@ -44,6 +44,13 @@ const stateTone = (state: ExitProgressState) => {
         className: "text-muted-foreground",
         bgClassName: "bg-muted border-border",
       };
+    case "Canceled":
+      return {
+        icon: "close-circle-outline" as IconName,
+        color: "#dc2626",
+        className: "text-red-600 dark:text-red-300",
+        bgClassName: "bg-red-500/10 border-red-500/30",
+      };
     case "ClaimInProgress":
     case "AwaitingDelta":
       return {

--- a/client/src/screens/UnilateralExitScreen.tsx
+++ b/client/src/screens/UnilateralExitScreen.tsx
@@ -76,6 +76,13 @@ const stateTone = (state: ExitProgressState) => {
         className: "text-muted-foreground",
         bgClassName: "bg-muted border-border",
       };
+    case "Canceled":
+      return {
+        icon: "close-circle-outline" as IconName,
+        color: "#dc2626",
+        className: "text-red-600 dark:text-red-300",
+        bgClassName: "bg-red-500/10 border-red-500/30",
+      };
     case "ClaimInProgress":
     case "AwaitingDelta":
       return {
@@ -171,6 +178,7 @@ const PHASE_LABELS: Record<ExitProgressState, string> = {
   ClaimInProgress: "Claim",
   Claimed: "Done",
   VtxoAlreadySpent: "Spent",
+  Canceled: "Canceled",
 };
 
 const EXIT_MODE_OPTIONS = [
@@ -651,6 +659,7 @@ const UnilateralExitScreen = () => {
       ClaimInProgress: 0,
       Claimed: 0,
       VtxoAlreadySpent: 0,
+      Canceled: 0,
     },
   );
   const claimInProgressCount = stateCounts.ClaimInProgress;

--- a/client/tests/unit/exitTimeline.test.js
+++ b/client/tests/unit/exitTimeline.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, mock, test } from "bun:test";
+
+globalThis.__DEV__ = false;
+
+mock.module("noah-tools", () => ({
+  getAppVariant: () => "mainnet",
+  isGooglePlayServicesAvailable: () => true,
+  nativeLog: () => {},
+}));
+mock.module("react-native", () => ({
+  Platform: { OS: "ios" },
+}));
+mock.module("react-native-fs-turbo", () => ({
+  default: {
+    CachesDirectoryPath: "/tmp",
+    DocumentDirectoryPath: "/tmp",
+  },
+}));
+mock.module("expo-device", () => ({
+  isDevice: true,
+  manufacturer: "Apple",
+  modelName: "iPhone 12 Pro",
+  osName: "iOS",
+  osVersion: "26.5",
+}));
+
+const {
+  buildExitTimelineItems,
+  EXIT_STATE_LABELS,
+  EXIT_STATE_ORDER,
+  getExitStatusText,
+} = await import("../../src/lib/exitTimeline");
+
+describe("canceled exit timelines", () => {
+  test("exposes canceled as a terminal exit state", () => {
+    expect(EXIT_STATE_ORDER.at(-1)).toBe("Canceled");
+    expect(EXIT_STATE_LABELS.Canceled).toBe("Canceled");
+    expect(getExitStatusText({ state: "Canceled" })).toBe("Exit processing was canceled");
+  });
+
+  test("describes a canceled state in timeline history", () => {
+    const items = buildExitTimelineItems({
+      history: ["Start", "Canceled"],
+      historyDetails: [
+        { kind: "start", tip_height: 100 },
+        { kind: "canceled", tip_height: 101 },
+      ],
+      currentState: "Canceled",
+      currentDetails: { kind: "canceled", tip_height: 101 },
+      currentBlockHeight: 101,
+    });
+
+    expect(items.at(-1)).toMatchObject({
+      state: "Canceled",
+      label: "Canceled",
+      description: "Exit processing was canceled before completion.",
+      isCurrent: true,
+    });
+  });
+});

--- a/client/tests/unit/walletConfig.test.js
+++ b/client/tests/unit/walletConfig.test.js
@@ -8,6 +8,8 @@ mock.module("expo-constants", () => ({
 }));
 mock.module("noah-tools", () => ({
   getAppVariant: () => "signet",
+  isGooglePlayServicesAvailable: () => true,
+  nativeLog: () => {},
 }));
 mock.module("react-native", () => ({
   Platform: { OS: "android" },


### PR DESCRIPTION
## Summary

- update `react-native-nitro-ark` and the iOS pod lockfile to 0.0.133
- migrate callers from the removed with-onchain maintenance variants to the consolidated maintenance APIs
- support the new canceled unilateral-exit state in labels, timelines, counts, and visual treatments
- add a singular `unlockVtxo` wallet wrapper and debug-screen action backed by `unlockVtxos([vtxoId])`
- add focused canceled-exit timeline tests

## Why

Nitro Ark 0.0.133 removes the separate with-onchain maintenance exports because the remaining maintenance APIs now include on-chain synchronization. It also adds a canceled exit state and exposes the new batch VTXO unlock API. The client needed to adopt those contracts before it could typecheck against the new version.

## Impact

Background maintenance and manual refreshes retain their on-chain synchronization behavior through `maintenanceDelegated`. Canceled exits are now visible as terminal error states, and developers can unlock a single locked VTXO from the debug screen.

## Validation

- `nix develop -c just ios-prebuild`
- `just check`
- 50 unit tests passed
- TypeScript and ESLint passed
