### PR TITLE
Fix Lightning receive thresholds and refresh iOS metadata

### DIFF
--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -2835,17 +2835,17 @@ DEPENDENCIES:
   - ExpoClipboard (from `../../node_modules/expo-clipboard/ios`)
   - ExpoDevice (from `../../node_modules/expo-device/ios`)
   - "ExpoDomWebView (from `../../node_modules/@expo/dom-webview/ios`)"
-  - ExpoFileSystem (from `../../node_modules/expo-file-system/ios/ExpoFileSystem.podspec`)
-  - ExpoFont (from `../../node_modules/expo-font/ios/ExpoFont.podspec`)
+  - ExpoFileSystem (from `../../node_modules/expo-file-system/ios`)
+  - ExpoFont (from `../../node_modules/expo-font/ios`)
   - ExpoHaptics (from `../../node_modules/expo-haptics/ios`)
   - ExpoImagePicker (from `../../node_modules/expo-image-picker/ios`)
   - ExpoKeepAwake (from `../../node_modules/expo-keep-awake/ios`)
   - ExpoLocalAuthentication (from `../../node_modules/expo-local-authentication/ios`)
-  - ExpoLocation (from `../../node_modules/expo-location/ios/ExpoLocation.podspec`)
+  - ExpoLocation (from `../../node_modules/expo-location/ios`)
   - "ExpoLogBox (from `../../node_modules/@expo/log-box`)"
-  - ExpoModulesCore (from `../../node_modules/expo-modules-core/ExpoModulesCore.podspec`)
+  - ExpoModulesCore (from `../../node_modules/expo-modules-core`)
   - ExpoModulesJSI (from `../../node_modules/expo-modules-jsi/apple`)
-  - ExpoModulesWorklets (from `../../node_modules/expo-modules-core/ExpoModulesWorklets.podspec`)
+  - ExpoModulesWorklets (from `../../node_modules/expo-modules-core`)
   - ExpoModulesWorkletsAdapter (from `../../node_modules/expo-modules-core`)
   - ExpoNotifications (from `../../node_modules/expo-notifications/ios`)
   - ExpoSplashScreen (from `../../node_modules/expo-splash-screen/ios`)
@@ -2993,9 +2993,9 @@ EXTERNAL SOURCES:
   ExpoDomWebView:
     :path: "../../node_modules/@expo/dom-webview/ios"
   ExpoFileSystem:
-    :podspec: "../../node_modules/expo-file-system/ios/ExpoFileSystem.podspec"
+    :path: "../../node_modules/expo-file-system/ios"
   ExpoFont:
-    :podspec: "../../node_modules/expo-font/ios/ExpoFont.podspec"
+    :path: "../../node_modules/expo-font/ios"
   ExpoHaptics:
     :path: "../../node_modules/expo-haptics/ios"
   ExpoImagePicker:
@@ -3005,15 +3005,15 @@ EXTERNAL SOURCES:
   ExpoLocalAuthentication:
     :path: "../../node_modules/expo-local-authentication/ios"
   ExpoLocation:
-    :podspec: "../../node_modules/expo-location/ios/ExpoLocation.podspec"
+    :path: "../../node_modules/expo-location/ios"
   ExpoLogBox:
     :path: "../../node_modules/@expo/log-box"
   ExpoModulesCore:
-    :podspec: "../../node_modules/expo-modules-core/ExpoModulesCore.podspec"
+    :path: "../../node_modules/expo-modules-core"
   ExpoModulesJSI:
     :path: "../../node_modules/expo-modules-jsi/apple"
   ExpoModulesWorklets:
-    :podspec: "../../node_modules/expo-modules-core/ExpoModulesWorklets.podspec"
+    :path: "../../node_modules/expo-modules-core"
   ExpoModulesWorkletsAdapter:
     :path: "../../node_modules/expo-modules-core"
   ExpoNotifications:
@@ -3229,143 +3229,143 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EXApplication: 7283a281903a90230466ab545ab87a8c48cf4e12
-  EXConstants: d069b4a2dd469d5a3a4d3d7b09757e708fda8f64
+  EXApplication: 8d84036fc734ad0e4a9f778c28c6a7e3b3e42c3d
+  EXConstants: 850a80a96c7854acc6f65ef55f7eb0d2fe82c39f
   EXJSONUtils: 55eca2b6f8fc320cb36933cf45c4f2200a441589
-  EXManifests: 66a0e4af8cdb58c0983d462d886136b6d56eee38
-  Expo: cfb5f1189dfb9bd5ccc7701ceb2879d326c253e9
-  expo-dev-client: 3302134f3f8cce7d15f4ab921d2e47aaafd804cb
-  expo-dev-launcher: 3a5012ec6e2fe5488b3ab1c2a44fb2fcde74b02e
-  expo-dev-menu: ec44430d95774d757adc9524fc4a755b8bd8e6c1
+  EXManifests: b38a833a6b916a5d72b9c18eebd27f9d27bee963
+  Expo: a57eca9a47a1cd1c75d28be5d06a66e12dde1c8c
+  expo-dev-client: e54091877c32256df5ae782ac617733ade1f7dc4
+  expo-dev-launcher: 8e11bb2971d1aae9e5f094c03d260cb2d021db41
+  expo-dev-menu: d2b429a0b3be3616d784c7e51843d784b51b1723
   expo-dev-menu-interface: 7a59e803916fbfd1b96c75ff91ea8dddac7e722f
-  ExpoAsset: 586e89aeaab2e23bfa90b9dce4d7d5e36815c039
-  ExpoClipboard: 67d46a8be4a50ec610c7b2f4966c0475aec6d969
-  ExpoDevice: 090ee05e20e40ca981d39263e3e95c46ed850782
-  ExpoDomWebView: 73ba90107a5acc0017a09b06e66d8eb238e089b8
-  ExpoFileSystem: ffcd56066188802f263254b6b2e60f74b6a0bdae
-  ExpoFont: 35fd7ad72f697d3a9656545909972d8b9f60d5da
-  ExpoHaptics: c6d063c3bfda1c1d6d7fdf237ffb612c4fc09954
-  ExpoImagePicker: 27f4e9a5d797abc31c75237362f90ac012d1a8fe
-  ExpoKeepAwake: 8a96e2075b75641001f55393d7e6600a5b808f09
-  ExpoLocalAuthentication: 4f2c3ddae58a42e93564fcf2be4518c463fbdd71
-  ExpoLocation: f0127974a6e1edfb1ea255f55604addb51d020b5
-  ExpoLogBox: b39a76aab749833d58111c3be1264bb90f3b92d4
-  ExpoModulesCore: 8ef1f9b2ad9f431cd55ab38c67bbbc7afe14ac3d
-  ExpoModulesJSI: 0fad44a0464a4469b83a06e34e529c13043f2f69
-  ExpoModulesWorklets: f6b71b8ddeb8dceb2ce3504544ecfbd708ba79a2
-  ExpoModulesWorkletsAdapter: a99bb506851d32ff6f3a274698b931d18fcf48a6
-  ExpoNotifications: 02cd9efc076d8a4a64d36eee3297c9d84bb7e719
-  ExpoSplashScreen: ba6bd4b92a47f5da3cd70d82d33fcd8407be9d70
-  ExpoSystemUI: 4f343f83e81951d737b199ac9c0d9db0d577f942
-  ExpoTaskManager: 1314e194160dc3a2b5142342c7b30e92d1abcfa0
-  ExpoUI: 6dfd6c01cc124afb1f729548568f40fb00976f26
-  EXUpdatesInterface: 492cdb30f3889cc35d9e737a4b5fc3aec39d1131
+  ExpoAsset: fc429c61615141b81faabdb5b0c4f8f2861c7449
+  ExpoClipboard: d39b9a76fd198b8795d3f14640a8e589a240d60b
+  ExpoDevice: 40748abaa23876f888545d3534fb74bf3565525f
+  ExpoDomWebView: ae603aa2c151929ebb1ee68c4607e105b68b4ebc
+  ExpoFileSystem: bf907fa86da7cc9088331f1930a572f43353ed50
+  ExpoFont: 15dc02c38fcb621aa56c87c3ab840f281e92f6cf
+  ExpoHaptics: 3c3b578cf54486907b5e714335d08a62f24db9af
+  ExpoImagePicker: 028fde7f7f9a6d17db48f85dc15fd7046041ee3d
+  ExpoKeepAwake: c5a7e46e8f52c093370ea89457d73c060d0b2a2e
+  ExpoLocalAuthentication: 934b3cfab91473c0cf25114a119ac856eac122a5
+  ExpoLocation: a808bb82b56940bfe207730941c5d3518985960e
+  ExpoLogBox: 71393ad8a15193044673cee88f6f41cf014bccd7
+  ExpoModulesCore: 4a8b5444f63e5f45cc670a84a9dac5ad13f5b062
+  ExpoModulesJSI: ca1381e851de6269705442ba66bc54a3320a142b
+  ExpoModulesWorklets: 7ee538b64f31c28729cd5a6a693593b300452b4f
+  ExpoModulesWorkletsAdapter: 18f368bd566f644bab93f4e7704b62a49b06e8a7
+  ExpoNotifications: 24689e912a4f510fddf279dab65d114cb925413c
+  ExpoSplashScreen: 30410cb4714241e37bedee927e572335f591042f
+  ExpoSystemUI: 2805d71b08bbb83f80e67faa9f2e053309f5135c
+  ExpoTaskManager: 7ef510ea7b2b110bc4831d1c95a7c64f6ed6b834
+  ExpoUI: 4382121710efdc648b35e04b569f6b9988829d9c
+  EXUpdatesInterface: fb5f5bd7cc4cc5b598fe12386ad158db9aa8cbbb
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: 82e1b37154a8c157253ac036eccbdd3f8dbdfa89
-  MapLibreReactNative: 9f1f16d5f5f522309ad1f2afc483a34cfc56fe6e
+  hermes-engine: 10ad1fccd364c7e3d9c1de19a7edb1bdd632c6b4
+  MapLibreReactNative: 5df4460492c6c8af365fc6107f48f0e922d915ad
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: f29571846e9d3ec9e224c5b34f318815fdf4d6ea
-  NitroMmkv: 4b4f95387a15161b346a6a93b9c7072c179e0e88
-  NitroModules: c41b7b778d6557f1e517a80ec681a670321fa001
-  NoahTools: 690d5d90593c5634d2a9ab514a6c243d8212ef20
+  NitroArk: 0e482e534ffc9ca50b15dbf5af400f98a44caeb9
+  NitroMmkv: 1ff46eceb958298b1d7c013a6314432438b77a62
+  NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
+  NoahTools: efecfcff1688c6e63b9acb210286badaa3eaac36
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f
-  RCTSwiftUIWrapper: ab2ca548be15d63afa95103afc8685a7c3eab78b
+  RCTSwiftUIWrapper: 1feaf484029fd6294fe8bc401d28e1d803eca142
   RCTTypeSafety: 3eaed17dbddb0b989208b062ea14c44d412b9780
   React: 2574546f2d017abd14d0c9b48cf2b6a0547c2591
   React-callinvoker: 03cd4b931d1d583d87aae99b8f7b6fe26bf571ee
-  React-Core: 1c824d9c7dd8aa760b5f1b50d5a54c2a3f598f87
-  React-Core-prebuilt: 13924a267683b3d6fa4bde9c80380becf83a9c5c
-  React-CoreModules: 2f9ed75bca7f6dea2b70e8a1f4a5ca9b6be52d76
-  React-cxxreact: 7103d5ba69848c039e11079e74ceede05efe795e
+  React-Core: b0a0038e05720fb8148759404e9c354e3e60043c
+  React-Core-prebuilt: 7da85c26e5616d52f119b81ce5e3e6fc5c9bda49
+  React-CoreModules: a1121b3182200be11e078940159c67ff95ee98b4
+  React-cxxreact: 8f74977959064bee99af63bb0ad95b6c3dbec921
   React-debug: 8cc8d99ccc664ef9e873027f7fc3fb0a50496012
-  React-defaultsnativemodule: 603c108411d39d7bb5ccb8c270f1f50cb6207e10
-  React-domnativemodule: c49a502edc85f515a029c341fe5fba155fa6675c
-  React-Fabric: acc4915d719db793c5853e5c74b54ea5aa48e865
-  React-FabricComponents: aebebc98914a4a8fc962fa7b5b98ebaf250acb68
-  React-FabricImage: 42e99e48ff73c8b20cee229e622977d0b97b6247
-  React-featureflags: c6d8d8d52acf3a956485726076b73eeff7935340
-  React-featureflagsnativemodule: c992de92dcf30dcf09efdec17752abe4128ec55f
-  React-graphics: 239fd9b0512e539d3563f0825618f4e49795eefd
-  React-hermes: ae4685ca9fa5f47003bc594d3f146e29284136d1
-  React-idlecallbacksnativemodule: 10a5be842ab181953c772a3f28cdf94572833eb0
-  React-ImageManager: c36a56c3b13eba92e1d0d30da35d0a1ccf29cd6c
-  React-intersectionobservernativemodule: 71404bfa47d31e4143cc9db3e26178b5cfcd07e1
-  React-jserrorhandler: ca2eeb03c1a77bbfab1b5425b943e3e8d92295f2
-  React-jsi: c4b6daf8a31ac54f2db49cd6cce29720fec1f3a8
-  React-jsiexecutor: acdc1a217b7ea29bcf6315b770d01e6b1c2fca14
-  React-jsinspector: 95d6394efe9fb4a64ed33afc076b32a6384c8514
-  React-jsinspectorcdp: 6ce51378a552feaaaac1a7b0d995fa0c49fa4f8c
-  React-jsinspectornetwork: 0db435c9264f200635fdf294a3b643dd3946d4cf
-  React-jsinspectortracing: 2e4470e1f301ff597bd65299aa95da4bae6e5c4f
-  React-jsitooling: 796bc991cdce68e2cc059d0271a28e0d4f8b0891
-  React-jsitracing: f3008e7b5e1d9de8d9f2ca1b85824ed86b0cea00
-  React-logger: fff73f4ceecad968c97baafdc77dcf84befc38b6
-  React-Mapbuffer: ce449ccdf3b80384415b925606be8a4bdcfc65d3
-  React-microtasksnativemodule: 2eb3f49d0d8e77b5343455eccd057010b8d38b6b
-  React-mutationobservernativemodule: f0a0d5ae9b51caf7becbeabf836d716cfedb6bf2
-  react-native-bottom-tabs: e93dc04b1d64eb0932a099ca0d05a96f3f95fe61
-  react-native-quick-base64: 53393ee5ea472a7486e6652ad3d7a640ebf6ebda
-  react-native-safe-area-context: fb5c8ee9f6dd62ef710611b3d370c501f42a4ac0
-  react-native-vector-icons: fa90a3e51f7174137fa0836808ad5166efbf22dc
+  React-defaultsnativemodule: 7c8182addbb79ec576c589186b51e3fb405da7da
+  React-domnativemodule: 576bd1e6ad81477997dcb556e6db1f005134356b
+  React-Fabric: 4cbd22315ddb9e33441437f851117d314d1b4ad3
+  React-FabricComponents: efe374aecaf1bbc2fb9a195ece4b50fd9f66bfa0
+  React-FabricImage: cfeffc0b527de8bc2dc5a50618dad119361d0ec3
+  React-featureflags: 98931b22f5f4b861a3985b75bd79c5fcbe4618ab
+  React-featureflagsnativemodule: 518c2e279cdb3835604f7e8fb15f4c2691336b4c
+  React-graphics: ac9ff09da733d98c0e5eddb589dc7f9f082c9531
+  React-hermes: bd1a14a982e63ee75e9c9cb8d11d3d4b5f330196
+  React-idlecallbacksnativemodule: b6378d3bca83d8284e1abaa51251ee1ce570d85a
+  React-ImageManager: 4936349da191d1bc29ed2bbaf5a2dd74bfdf5ed8
+  React-intersectionobservernativemodule: d9a6451f2aa1f1c989d5d5e0d967db2c07d0c48c
+  React-jserrorhandler: 2455567e21fcc036f96015b2b8eb4eb13e0d8d05
+  React-jsi: bf5ec8e7a7b26bddc39ab7f821af5aad8bb94a33
+  React-jsiexecutor: cf6c957f578dd491ec8ae516a39aff2cf7369f1a
+  React-jsinspector: 63e9b9f9a5b6c51bf38deea2b379a63754c0ab0d
+  React-jsinspectorcdp: 327082854cdebb1f500a669c51146b9fd871058c
+  React-jsinspectornetwork: bbc5c2e881252075d63dc679f18cd856c2def94e
+  React-jsinspectortracing: ea6ec857ead0de4e6bbb2e12ee48ae4381938874
+  React-jsitooling: 52e278666b35e856414d613d7dc50d1f0d50d9a5
+  React-jsitracing: 642172314677a1d1780b81f4e2e4a3f4d3ccf238
+  React-logger: 35cda3ab8977c6c4546e3cf6dc8f91bacec25934
+  React-Mapbuffer: c058c051f571589e37a29bce18d0e9b730faa9d0
+  React-microtasksnativemodule: 03752e60738a797bb49f4d6cb0291dfa398099b8
+  React-mutationobservernativemodule: 2e568e13c98bd185fe83266795233fa7ad2cbc19
+  react-native-bottom-tabs: be329013de6620585cd5e6ca6ac020223e31be3e
+  react-native-quick-base64: f5840b9dd6ea8f5814fee7a11376d709d08cab3a
+  react-native-safe-area-context: c1eb308f4b36372a4de4b3bdaa8ed695ec3dd461
+  react-native-vector-icons: 96005b208c80c31220245b202468887afab1fddc
   react-native-vector-icons-ionicons: 7e633927db6ab96e0255b5920c053777cacca505
-  react-native-worklets-core: 89a42b9bbce25698c6fb3f36fa61181377655e6c
-  React-NativeModulesApple: a092d89b58f635ebfab88048b0eda9fb516819fd
-  React-networking: 968bbbe73590149feb1e72b2af4f6a68e4796ece
+  react-native-worklets-core: ac6ca44cc93388211aa7da8977227f9ef8bb1faf
+  React-NativeModulesApple: a4713821c9caae40ae33eef933a6e692a6f4a81d
+  React-networking: b344a1a41a4729ef859123b7a234f3092761cb25
   React-oscompat: 0b72a7e926954a0415ccd83e0748b6561fe45367
-  React-perflogger: 865984e492514aa6e5279fc3e663132cfa4d5022
-  React-performancecdpmetrics: 2efbf9bdb48c8d8446f4dd10e8bf0dc5d711772f
-  React-performancetimeline: 9d256484bff1513481be9f234baba694dc3b52e2
+  React-perflogger: a0d581c6cc174e847877107ddac3f4fc9b518dc7
+  React-performancecdpmetrics: 91d3d0dce2e3a239ea68cc2882e75b11a61cbf2e
+  React-performancetimeline: 4b9e04002c1ddba95167276a86424e5face65605
   React-RCTActionSheet: 902c79deec52f99cc48b1051b59bcbe86787d339
-  React-RCTAnimation: 09cf722039ae30ff5d64e2b011ff054ae651c3b6
-  React-RCTAppDelegate: a47de6fddb7eb0c028abba83138a5ce283bd7e77
-  React-RCTBlob: 38c418d067e0c61818223503063310122e44c588
-  React-RCTFabric: 480ca2a105730e1790cfd13291d086cb53725825
-  React-RCTFBReactNativeSpec: 63131378510a5191515a4adfc308e65b465106f4
-  React-RCTImage: 3ce36f82441b76b715818ee7ee95f6f5b34f9ee1
-  React-RCTLinking: 2f7b5ed4983122e5115732d25a4360960eab583c
-  React-RCTNetwork: dcd3b180f33da86f5dc5e928a816eb5464fa7f16
-  React-RCTRuntime: 6ef8e778fbab426b12eb5a9b5f7a0e86313c5a10
-  React-RCTSettings: b97727ec8c55c35bd284457a647c938c040b942b
-  React-RCTText: 4d1b88f6d3e1a43afe46706d956ec6664c87b984
-  React-RCTVibration: 415d14d6a1a64bf947fcef6b193915a494431168
+  React-RCTAnimation: f50eac1c9dbea36c4abc69cb24e2da4364374055
+  React-RCTAppDelegate: a5d746fec869d15a8f6eecce60510c18e52135d5
+  React-RCTBlob: e544dc72edc6f277c67e85493b0a405e1993c250
+  React-RCTFabric: 8003ea99830c294857d41469a888b033e5ad91a6
+  React-RCTFBReactNativeSpec: 8a3506041284fdc75da90e6fa40fb9b575414a39
+  React-RCTImage: fb85496986a53d9e11a835124a083b7c7c33f898
+  React-RCTLinking: b8eafcdedaebf981a18396db61d1190f5279ea81
+  React-RCTNetwork: 03573c4fcc73e28f48fea7aea69310b6955a749c
+  React-RCTRuntime: 08d58920b217b2d7715d5da595794e63520cd2d9
+  React-RCTSettings: f9b278b46e5de1ff8b843bb7aefaee721f06572d
+  React-RCTText: 7266943febf3382dac8adce9ba0de95b90c26e9e
+  React-RCTVibration: 27e1952701ec858922062f25a59b0c48e7153151
   React-rendererconsistency: ef8519bdd9931261c6561bfad6506356b8108387
-  React-renderercss: 1aa1bf99fa2ace143eb87d5190fd43609fc1e832
-  React-rendererdebug: 40a4fb3dea21a7ac1759ca0eb6c88a924aecb075
-  React-RuntimeApple: 84fadbb4fe8ca531e15e29a22af05911f17569c6
-  React-RuntimeCore: f4d9af5f16d37e63308cb03b36c89d01e7f68a06
-  React-runtimeexecutor: 4d59410f66af529d04c84c8b152ced07dabc471e
-  React-RuntimeHermes: fd719d8f4d9ce79636fe2e09e94b0ac31b7b263b
-  React-runtimescheduler: 784033620aa5515e2f45a60369eed4d32f9400b8
-  React-timing: a16df9ae98f950396d9ce3abf43cb0cb2f21194c
-  React-utils: b68ee619aef28d8f9b85532d98db0327f7bdf743
-  React-viewtransitionnativemodule: 11fe091101d381451b1542c37b2745900254f096
-  React-webperformancenativemodule: b5d249419f1546663845c82f24de4e18a3180997
-  ReactAppDependencyProvider: dcdd0e1b9559a6d8d8aea05286f4ed085091978e
-  ReactCodegen: 1973e629fe2614a7b2cf72919cb9935b6c34675f
-  ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
-  ReactNativeBottomSheet: 63aa348b5cc4cd101613c8ffa70163056043c0a5
+  React-renderercss: edc1b0a18b12d681f8edbc779039dc6db32cf7b2
+  React-rendererdebug: 074ec3420f3bab2bea498da65e5a17e9288c90d0
+  React-RuntimeApple: 180682587e82ae4fc525f7d6636ed5db39c1e78c
+  React-RuntimeCore: 991cdb27072f7885750fdad4a70c2b919533e4ef
+  React-runtimeexecutor: bfec6ca5e62c6b2460a4adf0fddce0c4db0a8748
+  React-RuntimeHermes: dcb07afe0f38c1cbaf48b7a1bf4904e867529726
+  React-runtimescheduler: fdf0b71e519e416ad38c76525df43eba8dd78db2
+  React-timing: 7b538f379678210bf30d8541eb4cf007c000c6f3
+  React-utils: a15da1da76aee3dd0ed9f51d62bf1c09be17c221
+  React-viewtransitionnativemodule: 8556c844dcd691ab3fe1b32bbf8f58c8c9a49c75
+  React-webperformancenativemodule: 4d1d0258107fe0cb8ef5c9ac17a6a099785f2995
+  ReactAppDependencyProvider: adf5403892170fbe996fce485a703f25df08db66
+  ReactCodegen: db8e2836b82f6f4c3ef1463cb6f6cd61a25b8cc8
+  ReactCommon: 4d01bfb533b93a2103329dfefc74db6a9e272888
+  ReactNativeBottomSheet: ad86e071a3993700fec5d394314cdaf5445f00c9
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
-  RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
-  RNFSTurbo: 2ba3f628bad433250a545a8c156529866f01d4da
-  RNGestureHandler: 92172e79df6e88e0e93b6341f9dcd8b5a02746ba
-  RNKeychain: 6778b35b5bd067c322f8479526ac09b1d61f31d0
-  RNReanimated: d44d84ef7c44f31180b818d69bc03579290a76f3
-  RNScreens: 991cc417cd396602a6cf59a42139e5a9d91462a9
-  RNSentry: c2b739c5dbdd77f439fbd197d1d45724b22a0437
-  RNShare: 7344a3a7d4e5df58c356ad0f79e4a3ef1325c635
-  RNSVG: 6cae8d4082913be2eb43eaec2a456222c42195ed
-  RNWorklets: bf2516ed0d2845e1947898c814a8d115015e34f3
+  RNCClipboard: c1cdf3cdd72df606520114f42e61c6898a488dd8
+  RNFSTurbo: d00626ccbeb66c229d14fa1ba33adc3d2f12caab
+  RNGestureHandler: a21ad1bb32b203570440c29b7e406a342a690842
+  RNKeychain: 1b055a0ec36d058cb0a075e965d8c9d335e0c828
+  RNReanimated: 1927878fa1a3c9b9cf583c30f2785dfc1dc65902
+  RNScreens: 032083414633a4d94cbcf08f8ab5019d72d1ba36
+  RNSentry: 859c1702fe09e25c24747a5feedecab1d5138074
+  RNShare: 43cee010ada075019148c7a6bac1ca71b074e1d7
+  RNSVG: ffe18ba0e8fbad864bf22d6f0060a4ee88ec9bf3
+  RNWorklets: 48a949da9ea166cbb2609c262f7faf4d1940321e
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageSVGCoder: 8e10c8f6cc879c7dfb317b284e13dd589379f01c
   Sentry: d587a8fe91ca13503ecd69a1905f3e8a0fcf61be
   SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
-  UMAppLoader: 6cb9f7f40f458bab7fbf7d8a4a4c95aa8016ce0b
-  VisionCamera: 0044a94f7489f19e19d5938e97dfc36f4784af3c
+  UMAppLoader: 871cc3dce7c702d48cc24848e8e9e2cb21dc9a59
+  VisionCamera: 47f10351a1b6a8d251b90986ae72ca5f52331954
   Yoga: fe50ab299e578f397fef753cf309c6703a4db29b
   ZIPFoundation: dfd3d681c4053ff7e2f7350bc4e53b5dba3f5351
 
-PODFILE CHECKSUM: 80eea33915f3bb1a0dfdcc59f7cfdc31ccaccbc3
+PODFILE CHECKSUM: c9c504df60b8b7a5b9dc8c814a85e0b70272af3e
 
 COCOAPODS: 1.16.2

--- a/client/ios/noah/PrivacyInfo.xcprivacy
+++ b/client/ios/noah/PrivacyInfo.xcprivacy
@@ -36,8 +36,8 @@
 			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>85F4.1</string>
 				<string>E174.1</string>
+				<string>85F4.1</string>
 			</array>
 		</dict>
 	</array>

--- a/client/src/lib/walletConfig.ts
+++ b/client/src/lib/walletConfig.ts
@@ -25,7 +25,7 @@ const WALLET_CONFIGS: Record<AppVariant, BaseWalletConfig> = {
     config: {
       esplora: "https://mempool.second.tech/api",
       ark: "https://ark.second.tech",
-      vtxo_refresh_expiry_threshold: 288,
+      vtxo_refresh_expiry_threshold: 144,
       fallback_fee_rate: 10000,
       htlc_recv_claim_delta: 18,
       vtxo_exit_margin: 12,
@@ -39,7 +39,7 @@ const WALLET_CONFIGS: Record<AppVariant, BaseWalletConfig> = {
     config: {
       esplora: "https://esplora.signet.2nd.dev",
       ark: "https://ark.signet.2nd.dev",
-      vtxo_refresh_expiry_threshold: 48,
+      vtxo_refresh_expiry_threshold: 12,
       fallback_fee_rate: 10000,
       htlc_recv_claim_delta: 18,
       vtxo_exit_margin: 12,

--- a/client/tests/unit/walletConfig.test.js
+++ b/client/tests/unit/walletConfig.test.js
@@ -43,7 +43,7 @@ describe("base wallet configuration", () => {
       config: {
         esplora: "https://mempool.second.tech/api",
         ark: "https://ark.second.tech",
-        vtxo_refresh_expiry_threshold: 288,
+        vtxo_refresh_expiry_threshold: 144,
         fallback_fee_rate: 10000,
         htlc_recv_claim_delta: 18,
         vtxo_exit_margin: 12,
@@ -60,7 +60,7 @@ describe("base wallet configuration", () => {
       config: {
         esplora: "https://esplora.signet.2nd.dev",
         ark: "https://ark.signet.2nd.dev",
-        vtxo_refresh_expiry_threshold: 48,
+        vtxo_refresh_expiry_threshold: 12,
         fallback_fee_rate: 10000,
         htlc_recv_claim_delta: 18,
         vtxo_exit_margin: 12,
@@ -124,6 +124,11 @@ describe("wallet configuration accessors", () => {
     });
     expect(getWalletRefreshExpiryThreshold("regtest")).toBe(24);
     expect(getWalletRpcAuth("regtest")).toEqual({ username: "second", password: "ark" });
+  });
+
+  test("keeps refresh thresholds below Lightning receive HTLC lifetimes", () => {
+    expect(getWalletRefreshExpiryThreshold("mainnet")).toBeLessThan(188);
+    expect(getWalletRefreshExpiryThreshold("signet")).toBeLessThan(50);
   });
 
   test("preserves the existing default block-height endpoints", () => {


### PR DESCRIPTION
## Summary

- lower the mainnet VTXO refresh expiry threshold from 288 blocks to Bark's 144-block default
- lower the signet threshold from 48 blocks to Bark's 12-block testnet default
- add regression coverage ensuring both thresholds stay below their Lightning receive HTLC lifetimes
- include the existing iOS pod lockfile refresh and privacy-manifest ordering update from the working tree

## Root cause

Bark 0.4.0 checks whether an HTLC-receive VTXO is near expiry before revealing the preimage. Mainnet HTLC-receive VTXOs live for roughly 188 blocks, but Noah configured `vtxo_refresh_expiry_threshold` to 288. Every newly granted HTLC was therefore considered near expiry immediately and abandoned, producing a canceled receive while refunding the sender.

The signet value of 48 was also only two blocks below its roughly 50-block HTLC lifetime, leaving almost no room for a delayed claim.

## Impact

The new values take effect the next time the wallet opens; no wallet migration is required. Lightning receives should proceed through the pre-claim expiry check instead of being canceled immediately.

## Validation

- `just check` (ESLint, 51 unit tests, and `tsc --noEmit`)
- focused wallet configuration tests: 9 passed
- `git diff --check`
- `plutil -lint client/ios/noah/PrivacyInfo.xcprivacy`
- parsed `client/ios/Podfile.lock` as YAML
