### PR TITLE
Improve BTC map nearby locations

### DIFF
--- a/client/src/lib/btcMapUtils.ts
+++ b/client/src/lib/btcMapUtils.ts
@@ -63,8 +63,11 @@ export const distanceKm = (
 
 export const formatDistance = (kilometers: number) =>
   kilometers < 1
-    ? `${Math.max(1, Math.round(kilometers * 1000))} m`
-    : `${kilometers.toFixed(1)} km`;
+    ? `${Math.max(1, Math.round(kilometers * 1000))} m (${Math.max(
+        1,
+        Math.round(kilometers * 1000 * 1.09361),
+      )} yd)`
+    : `${kilometers.toFixed(1)} km (${Math.round(kilometers * 0.621371)} mi)`;
 
 export const parseBtcMapViewport = (value: unknown): BtcMapViewport | undefined => {
   if (typeof value !== "object" || value === null || !("center" in value) || !("zoom" in value)) {

--- a/client/src/lib/btcMapUtils.ts
+++ b/client/src/lib/btcMapUtils.ts
@@ -67,7 +67,7 @@ export const formatDistance = (kilometers: number) =>
         1,
         Math.round(kilometers * 1000 * 1.09361),
       )} yd)`
-    : `${kilometers.toFixed(1)} km (${Math.round(kilometers * 0.621371)} mi)`;
+    : `${kilometers.toFixed(1)} km (${(kilometers * 0.621371).toFixed(1)} mi)`;
 
 export const parseBtcMapViewport = (value: unknown): BtcMapViewport | undefined => {
   if (typeof value !== "object" || value === null || !("center" in value) || !("zoom" in value)) {

--- a/client/src/screens/BtcMapScreen.tsx
+++ b/client/src/screens/BtcMapScreen.tsx
@@ -1045,7 +1045,7 @@ export default function BtcMapScreen() {
         <NearbyPlaces
           places={filteredPlaces}
           location={userLocation}
-          bottom={panelBottom}
+          bottom={Platform.OS === "android" ? 4 : tabBarHeight + 4}
           onSelect={selectPlace}
         />
       )}

--- a/client/tests/unit/btcMap.test.js
+++ b/client/tests/unit/btcMap.test.js
@@ -27,8 +27,12 @@ describe("BTC Map distance", () => {
 
     expect(distance).toBeGreaterThan(6);
     expect(distance).toBeLessThan(7);
-    expect(formatDistance(distance)).toBe(`${distance.toFixed(1)} km`);
-    expect(formatDistance(0.25)).toBe("250 m");
+    expect(formatDistance(distance)).toBe(
+      `${distance.toFixed(1)} km (${Math.round(distance * 0.621371)} mi)`,
+    );
+    expect(formatDistance(16)).toBe("16.0 km (10 mi)");
+    expect(formatDistance(0.25)).toBe("250 m (273 yd)");
+    expect(formatDistance(0)).toBe("1 m (1 yd)");
   });
 });
 

--- a/client/tests/unit/btcMap.test.js
+++ b/client/tests/unit/btcMap.test.js
@@ -28,9 +28,10 @@ describe("BTC Map distance", () => {
     expect(distance).toBeGreaterThan(6);
     expect(distance).toBeLessThan(7);
     expect(formatDistance(distance)).toBe(
-      `${distance.toFixed(1)} km (${Math.round(distance * 0.621371)} mi)`,
+      `${distance.toFixed(1)} km (${(distance * 0.621371).toFixed(1)} mi)`,
     );
-    expect(formatDistance(16)).toBe("16.0 km (10 mi)");
+    expect(formatDistance(1)).toBe("1.0 km (0.6 mi)");
+    expect(formatDistance(16)).toBe("16.0 km (9.9 mi)");
     expect(formatDistance(0.25)).toBe("250 m (273 yd)");
     expect(formatDistance(0)).toBe("1 m (1 yd)");
   });


### PR DESCRIPTION
- Improve alignment of nearby location on Android (closes https://github.com/smolcars/noah/issues/300)
- Add imperial distances (closes https://github.com/smolcars/noah/issues/279)

I lack ability to test how the carousel looks on iOS so if someone else could check that I'd appreciate it.

Screenshots from Android studio:

<img width="424" height="896" alt="Screenshot from 2026-07-26 12-45-26" src="https://github.com/user-attachments/assets/20f354aa-20f4-4efd-8ebb-e1c58f2e3795" />
<img width="421" height="938" alt="Screenshot from 2026-07-26 12-43-52" src="https://github.com/user-attachments/assets/c49677c0-ab73-40ca-a66a-e4c6380c20ed" />