### PR TITLE
Add unilateral exit cancellation flow

### DIFF
--- a/client/src/hooks/useUnilateralExit.ts
+++ b/client/src/hooks/useUnilateralExit.ts
@@ -5,6 +5,7 @@ import { useWalletStore } from "~/store/walletStore";
 import { getBlockHeight } from "~/hooks/useMarketData";
 import {
   allClaimableAtHeight,
+  cancelExit,
   claimExits,
   getExitStatus,
   getExitVtxos,
@@ -184,6 +185,32 @@ export function useStartVtxoExit() {
     onError: (error) => {
       log.e("Selected VTXO exit start mutation failed", [error]);
       showAlert({ title: "Failed to Start Exit", description: error.message });
+    },
+  });
+}
+
+export function useCancelExit() {
+  const { showAlert } = useAlert();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (vtxoId) => {
+      log.i("User requested exit cancellation", [{ vtxo_id: vtxoId }]);
+      readResult(await cancelExit(vtxoId));
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        invalidateExitQueries(),
+        queryClient.invalidateQueries({ queryKey: ["transactions"] }),
+      ]);
+      showAlert({
+        title: "Exit Canceled",
+        description: "The VTXO remains spendable and can be exited again later.",
+      });
+    },
+    onError: async (error) => {
+      log.e("Exit cancellation mutation failed", [error]);
+      showAlert({ title: "Failed to Cancel Exit", description: error.message });
+      await queryClient.invalidateQueries({ queryKey: ["exit-overview"] });
     },
   });
 }

--- a/client/src/lib/exitApi.ts
+++ b/client/src/lib/exitApi.ts
@@ -88,6 +88,18 @@ export const startExitForVtxos = async (vtxoIds: string[]): Promise<Result<void,
   return result;
 };
 
+export const cancelExit = async (vtxoId: string): Promise<Result<void, Error>> => {
+  log.i("Canceling exit", [{ vtxo_id: vtxoId }]);
+  const result = await ResultAsync.fromPromise(NitroArk.cancelExit(vtxoId), (e) => e as Error);
+
+  if (result.isErr()) {
+    log.e("Failed to cancel exit", [{ vtxo_id: vtxoId }, result.error]);
+  } else {
+    log.i("Canceled exit", [{ vtxo_id: vtxoId }]);
+  }
+  return result;
+};
+
 export const syncExit = async (): Promise<Result<void, Error>> => {
   log.d("Syncing exits with progress allowed");
   const result = await ResultAsync.fromPromise(NitroArk.syncExit(), (e) => e as Error);

--- a/client/src/lib/exitTimeline.ts
+++ b/client/src/lib/exitTimeline.ts
@@ -83,6 +83,24 @@ export const isClaimableExit = (exit: ExitVtxoResult, status?: ExitStatusResult)
   return exit.is_claimable || state === "Claimable" || kind === "claimable";
 };
 
+const CANCELABLE_EXIT_TX_STATUS_KINDS = new Set([
+  "verify-inputs",
+  "awaiting-input-confirmation",
+  "awaiting-cpfp-broadcast",
+]);
+
+export const isCancelableExit = (state: ExitProgressState, details?: ExitStateDetails) => {
+  if (state === "Start") {
+    return true;
+  }
+  if (state !== "Processing") {
+    return false;
+  }
+
+  const finalTransaction = details?.transactions?.at(-1);
+  return !finalTransaction || CANCELABLE_EXIT_TX_STATUS_KINDS.has(finalTransaction.status.kind);
+};
+
 export const getProcessingTransactionSummary = (details?: ExitStateDetails) => {
   const transactions = details?.transactions ?? [];
   if (transactions.length === 0) {

--- a/client/src/screens/UnilateralExitScreen.tsx
+++ b/client/src/screens/UnilateralExitScreen.tsx
@@ -24,6 +24,7 @@ import { NoahActivityIndicator } from "~/components/ui/NoahActivityIndicator";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import { ConfirmationDialog } from "~/components/ConfirmationDialog";
 import {
+  useCancelExit,
   useClaimExits,
   useExitOverview,
   useProgressExits,
@@ -40,6 +41,7 @@ import {
   formatBlocksRemaining,
   getExitBlockRows,
   getExitStatusText,
+  isCancelableExit,
   isClaimableExit,
   truncateMiddle,
 } from "~/lib/exitTimeline";
@@ -281,12 +283,18 @@ const ExitVtxoRow = ({
   history,
   currentBlockHeight,
   onPress,
+  onCancel,
+  isBusy,
+  isCanceling,
 }: {
   exit: ExitVtxoResult;
   status?: ExitStatusResult;
   history?: ExitProgressState[];
   currentBlockHeight?: number;
   onPress: () => void;
+  onCancel: () => void;
+  isBusy: boolean;
+  isCanceling: boolean;
 }) => {
   const formatBitcoinAmount = useBitcoinAmountFormatter();
   const state = status?.state ?? exit.state;
@@ -300,10 +308,11 @@ const ExitVtxoRow = ({
   const latestTxExplorerUrl = latestTxid ? getMempoolTxUrl(latestTxid) : null;
   const blockRows = getExitBlockRows({ state, details, currentBlockHeight });
   const statusText = getExitStatusText({ state, details, currentBlockHeight });
+  const canCancel = isCancelableExit(state, details);
 
   return (
-    <Pressable onPress={onPress} className="mb-3 rounded-lg border border-border bg-card p-4">
-      <View>
+    <View className="mb-3 overflow-hidden rounded-lg border border-border bg-card">
+      <Pressable onPress={onPress} className="p-4">
         <View className="flex-row items-center justify-between">
           <Text className="text-xl font-semibold text-foreground">
             {formatBitcoinAmount(exit.amount_sat)}
@@ -354,8 +363,20 @@ const ExitVtxoRow = ({
           currentDetails={details}
           currentBlockHeight={currentBlockHeight}
         />
-      </View>
-    </Pressable>
+      </Pressable>
+      {canCancel ? (
+        <View className="border-t border-border px-4 py-3">
+          <NativeNoahSecondaryButton
+            label={isCanceling ? "Canceling..." : "Cancel Exit"}
+            onPress={onCancel}
+            disabled={isBusy}
+            tone="destructive"
+            fullWidth
+            testID={`cancel-exit-${exit.vtxo_id}`}
+          />
+        </View>
+      ) : null}
+    </View>
   );
 };
 
@@ -379,7 +400,11 @@ const ExitCandidateVtxoRow = ({
       )}
     >
       <View className="mr-4">
-        <Icon name="cube-outline" size={22} color={isSelected ? COLORS.BITCOIN_ORANGE : "#22c55e"} />
+        <Icon
+          name="cube-outline"
+          size={22}
+          color={isSelected ? COLORS.BITCOIN_ORANGE : "#22c55e"}
+        />
       </View>
       <View className="flex-1">
         <Text className="text-base font-semibold text-foreground">
@@ -582,11 +607,7 @@ const StartAnotherExitCard = ({
   );
 };
 
-const EmptyExitState = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => (
+const EmptyExitState = ({ children }: { children: React.ReactNode }) => (
   <View className="gap-5">
     <View className="items-center rounded-lg border border-border bg-card px-4 py-8">
       <Icon name="shield-outline" size={40} color="#8e8e93" />
@@ -618,10 +639,12 @@ const UnilateralExitScreen = () => {
   const [showStartConfirm, setShowStartConfirm] = useState(false);
   const [showProgressConfirm, setShowProgressConfirm] = useState(false);
   const [showClaimConfirm, setShowClaimConfirm] = useState(false);
+  const [cancelExitVtxoId, setCancelExitVtxoId] = useState<string | null>(null);
 
   const overviewQuery = useExitOverview();
   const startWalletExit = useStartWalletExit();
   const startVtxoExit = useStartVtxoExit();
+  const cancelExit = useCancelExit();
   const progressExits = useProgressExits();
   const syncExits = useSyncExits();
   const claimExits = useClaimExits();
@@ -689,7 +712,8 @@ const UnilateralExitScreen = () => {
     startVtxoExit.isPending ||
     progressExits.isPending ||
     syncExits.isPending ||
-    claimExits.isPending;
+    claimExits.isPending ||
+    cancelExit.isPending;
   const canStartNewExit = spendableVtxos.length > 0;
 
   const startLabel = exitStartMode === "selected" ? "Start Selected Exit" : "Start Wallet Exit";
@@ -761,6 +785,15 @@ const UnilateralExitScreen = () => {
       destinationAddress: trimmedDestination,
     });
     setShowClaimConfirm(false);
+  };
+
+  const handleCancelExit = () => {
+    if (!cancelExitVtxoId) {
+      return;
+    }
+
+    cancelExit.mutate(cancelExitVtxoId);
+    setCancelExitVtxoId(null);
   };
 
   return (
@@ -936,6 +969,9 @@ const UnilateralExitScreen = () => {
                       onPress={() =>
                         navigation.navigate("ExitVtxoDetail", { vtxoId: exit.vtxo_id })
                       }
+                      onCancel={() => setCancelExitVtxoId(exit.vtxo_id)}
+                      isBusy={isBusy}
+                      isCanceling={cancelExit.isPending && cancelExit.variables === exit.vtxo_id}
                     />
                   ))}
                 </View>
@@ -1032,6 +1068,18 @@ const UnilateralExitScreen = () => {
               description={startDescription}
               confirmText={startLabel}
               onConfirm={handleStart}
+            />
+            <ConfirmationDialog
+              open={cancelExitVtxoId !== null}
+              onOpenChange={(open) => {
+                if (!open) {
+                  setCancelExitVtxoId(null);
+                }
+              }}
+              title="Cancel Emergency Exit"
+              description="Stop the emergency exit for this VTXO. Already-broadcast shared transactions are not reversed. The VTXO remains spendable and can be exited again. Cancellation only succeeds before the final exit transaction is broadcast."
+              confirmText="Cancel Exit"
+              onConfirm={handleCancelExit}
             />
             <ConfirmationDialog
               open={showProgressConfirm}

--- a/client/tests/unit/exitTimeline.test.js
+++ b/client/tests/unit/exitTimeline.test.js
@@ -29,7 +29,66 @@ const {
   EXIT_STATE_LABELS,
   EXIT_STATE_ORDER,
   getExitStatusText,
+  isCancelableExit,
 } = await import("../../src/lib/exitTimeline");
+
+describe("exit cancellation eligibility", () => {
+  test("allows a newly started exit", () => {
+    expect(isCancelableExit("Start", { kind: "start", tip_height: 100 })).toBe(true);
+  });
+
+  test("allows processing until the final exit transaction is broadcast", () => {
+    for (const kind of [
+      "verify-inputs",
+      "awaiting-input-confirmation",
+      "awaiting-cpfp-broadcast",
+    ]) {
+      expect(
+        isCancelableExit("Processing", {
+          kind: "processing",
+          tip_height: 100,
+          transactions: [{ txid: "final", status: { kind } }],
+        }),
+      ).toBe(true);
+    }
+
+    expect(
+      isCancelableExit("Processing", {
+        kind: "processing",
+        tip_height: 100,
+        transactions: [
+          { txid: "ancestor", status: { kind: "confirmed" } },
+          { txid: "final", status: { kind: "awaiting-cpfp-broadcast" } },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects processing after the final exit transaction is broadcast", () => {
+    for (const kind of ["awaiting-confirmation", "confirmed"]) {
+      expect(
+        isCancelableExit("Processing", {
+          kind: "processing",
+          tip_height: 100,
+          transactions: [{ txid: "final", status: { kind } }],
+        }),
+      ).toBe(false);
+    }
+  });
+
+  test("rejects states beyond the abortable window", () => {
+    for (const state of [
+      "AwaitingDelta",
+      "Claimable",
+      "ClaimInProgress",
+      "Claimed",
+      "VtxoAlreadySpent",
+      "Canceled",
+    ]) {
+      expect(isCancelableExit(state, { kind: "awaiting-delta", tip_height: 100 })).toBe(false);
+    }
+  });
+});
 
 describe("canceled exit timelines", () => {
   test("exposes canceled as a terminal exit state", () => {


### PR DESCRIPTION
Expose the Nitro cancellation API through wallet hooks and add cancel controls with eligibility coverage.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>