### PR TITLE
Render canceled payments as neutral activity

### DIFF
--- a/client/src/lib/transactionHistory.ts
+++ b/client/src/lib/transactionHistory.ts
@@ -113,13 +113,20 @@ export const mergeBoardingWithOnchainTransactions = (
   ];
 };
 
-export const getTransactionDisplayLabel = (transaction: Transaction): string => {
+export const isCanceledTransaction = (transaction: Transaction): boolean =>
+  transaction.movementStatus === "canceled";
+
+const getBaseTransactionDisplayLabel = (transaction: Transaction): string => {
   if (transaction.movementKind === "onboard") {
     return "Board";
   }
 
   if (transaction.movementKind === "offboard") {
     return "Offboard";
+  }
+
+  if (transaction.movementKind === "exit") {
+    return "Ark Exit";
   }
 
   if (transaction.type === "Bolt11" || transaction.type === "Lnurl") {
@@ -133,5 +140,31 @@ export const getTransactionDisplayLabel = (transaction: Transaction): string => 
   return transaction.type;
 };
 
+export const getTransactionDisplayLabel = (transaction: Transaction): string => {
+  const label = getBaseTransactionDisplayLabel(transaction);
+  return isCanceledTransaction(transaction) ? `Canceled ${label}` : label;
+};
+
 export const isInternalBoardingTransfer = (transaction: Transaction): boolean =>
   transaction.movementKind === "onboard";
+
+export type TransactionAccountingValues = {
+  direction: "Incoming" | "Outgoing" | "Transfer" | "None";
+  amount: number;
+};
+
+export const getTransactionAccountingValues = (
+  transaction: Transaction,
+): TransactionAccountingValues => {
+  if (isCanceledTransaction(transaction)) {
+    return { direction: "None", amount: 0 };
+  }
+
+  if (isInternalBoardingTransfer(transaction)) {
+    return { direction: "Transfer", amount: transaction.amount };
+  }
+
+  return transaction.direction === "outgoing"
+    ? { direction: "Outgoing", amount: -transaction.amount }
+    : { direction: "Incoming", amount: transaction.amount };
+};

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -7,7 +7,7 @@ import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert";
 import { AlertCircle, ChevronDown, Eye, EyeOff, PauseCircle } from "lucide-react-native";
 import { useCallback, useEffect, useState } from "react";
 import { COLORS } from "../lib/styleConstants";
-import { useIconColor } from "../hooks/useTheme";
+import { useThemeColors } from "../hooks/useTheme";
 import { NoahActivityIndicator } from "../components/ui/NoahActivityIndicator";
 import { useBalance, useLoadWallet, useWalletSync } from "../hooks/useWallet";
 import Icon from "@react-native-vector-icons/ionicons";
@@ -45,7 +45,11 @@ import { usePrivacyStore } from "~/store/privacyStore";
 import { useProfileStore } from "~/store/profileStore";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import { NativeHomeHeaderActions } from "~/components/ui/NativeHomeHeaderActions";
-import { getTransactionDisplayLabel, isInternalBoardingTransfer } from "~/lib/transactionHistory";
+import {
+  getTransactionDisplayLabel,
+  isCanceledTransaction,
+  isInternalBoardingTransfer,
+} from "~/lib/transactionHistory";
 
 const getTransactionIcon = (transaction: Transaction) => {
   if (transaction.movementKind === "onboard") {
@@ -71,7 +75,7 @@ const getTransactionIcon = (transaction: Transaction) => {
 
 const HomeScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
-  const iconColor = useIconColor();
+  const { foreground: iconColor, mutedForeground } = useThemeColors();
   const formatBitcoinAmount = useBitcoinAmountFormatter();
   const parentNavigation = navigation.getParent<NavigationProp<TabParamList>>();
   const { walletError, isWalletSuspended } = useWalletStore();
@@ -411,52 +415,61 @@ const HomeScreen = () => {
                       </Text>
                     </View>
                   ) : (
-                    recentTransactions.map((transaction, index) => (
-                      <Pressable
-                        key={transaction.id}
-                        onPress={() => openTransaction(transaction)}
-                        className={`flex-row items-center py-3 ${
-                          index < recentTransactions.length - 1 ? "border-b border-border/60" : ""
-                        }`}
-                      >
-                        <View className="mr-3 h-10 w-10 items-center justify-center rounded-full bg-background">
-                          <Icon
-                            name={getTransactionIcon(transaction)}
-                            size={20}
-                            color={
-                              isInternalBoardingTransfer(transaction)
-                                ? "#f97316"
-                                : transaction.direction === "outgoing"
-                                  ? "#ef4444"
-                                  : "#22c55e"
-                            }
-                          />
-                        </View>
-                        <View className="min-w-0 flex-1">
-                          <Text className="text-sm font-semibold text-foreground">
-                            {getTransactionDisplayLabel(transaction)}
-                          </Text>
-                          <Text className="mt-1 text-xs text-muted-foreground">
-                            {transaction.dateLabel ??
-                              new Date(transaction.date).toLocaleDateString(undefined, {
-                                month: "short",
-                                day: "numeric",
-                              })}
-                          </Text>
-                        </View>
-                        <Text
-                          className={`text-sm font-bold ${
-                            isInternalBoardingTransfer(transaction)
-                              ? "text-orange-500"
-                              : transaction.direction === "outgoing"
-                                ? "text-red-500"
-                                : "text-green-500"
+                    recentTransactions.map((transaction, index) => {
+                      const isCanceled = isCanceledTransaction(transaction);
+                      const isTransfer = isInternalBoardingTransfer(transaction);
+
+                      return (
+                        <Pressable
+                          key={transaction.id}
+                          onPress={() => openTransaction(transaction)}
+                          className={`flex-row items-center py-3 ${
+                            index < recentTransactions.length - 1 ? "border-b border-border/60" : ""
                           }`}
                         >
-                          {`${isInternalBoardingTransfer(transaction) ? "" : transaction.direction === "outgoing" ? "-" : "+"}${formatBitcoinAmount(transaction.amount)}`}
-                        </Text>
-                      </Pressable>
-                    ))
+                          <View className="mr-3 h-10 w-10 items-center justify-center rounded-full bg-background">
+                            <Icon
+                              name={getTransactionIcon(transaction)}
+                              size={20}
+                              color={
+                                isCanceled
+                                  ? mutedForeground
+                                  : isTransfer
+                                    ? "#f97316"
+                                    : transaction.direction === "outgoing"
+                                      ? "#ef4444"
+                                      : "#22c55e"
+                              }
+                            />
+                          </View>
+                          <View className="min-w-0 flex-1">
+                            <Text className="text-sm font-semibold text-foreground">
+                              {getTransactionDisplayLabel(transaction)}
+                            </Text>
+                            <Text className="mt-1 text-xs text-muted-foreground">
+                              {transaction.dateLabel ??
+                                new Date(transaction.date).toLocaleDateString(undefined, {
+                                  month: "short",
+                                  day: "numeric",
+                                })}
+                            </Text>
+                          </View>
+                          <Text
+                            className={`text-sm font-bold ${
+                              isCanceled
+                                ? "text-muted-foreground"
+                                : isTransfer
+                                  ? "text-orange-500"
+                                  : transaction.direction === "outgoing"
+                                    ? "text-red-500"
+                                    : "text-green-500"
+                            }`}
+                          >
+                            {`${isCanceled || isTransfer ? "" : transaction.direction === "outgoing" ? "-" : "+"}${formatBitcoinAmount(transaction.amount)}`}
+                          </Text>
+                        </Pressable>
+                      );
+                    })
                   )}
                 </View>
               </View>

--- a/client/src/screens/TransactionsScreen.tsx
+++ b/client/src/screens/TransactionsScreen.tsx
@@ -18,8 +18,14 @@ import { useProfileStore } from "~/store/profileStore";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import { NativeNoahIconButton } from "~/components/ui/NativeNoahIconButton";
 import { NativeNoahSegmentedControl } from "~/components/ui/NativeNoahSegmentedControl";
-import { getTransactionDisplayLabel, isInternalBoardingTransfer } from "~/lib/transactionHistory";
+import {
+  getTransactionAccountingValues,
+  getTransactionDisplayLabel,
+  isCanceledTransaction,
+  isInternalBoardingTransfer,
+} from "~/lib/transactionHistory";
 import { formatMovementStatusLabel } from "~/types/movement";
+import { useThemeColors } from "~/hooks/useTheme";
 
 const log = logger("TransactionsScreen");
 
@@ -34,6 +40,7 @@ const TRANSACTION_FILTER_OPTIONS = [
 
 const TransactionsScreen = () => {
   const formatBitcoinAmount = useBitcoinAmountFormatter();
+  const { mutedForeground } = useThemeColors();
   const { data: transactions = [], isLoading, isError, isRefetching, refetch } = useTransactions();
   const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
   const [filter, setFilter] = useState<TransactionFilter>("all");
@@ -64,17 +71,7 @@ const TransactionsScreen = () => {
           transaction.dateLabel ?? new Date(transaction.date).toISOString().split("T")[0];
         const type = getTransactionDisplayLabel(transaction);
         const status = formatMovementStatusLabel(transaction.movementStatus) ?? "";
-        const isTransfer = isInternalBoardingTransfer(transaction);
-        const direction = isTransfer
-          ? "Transfer"
-          : transaction.direction === "outgoing"
-            ? "Outgoing"
-            : "Incoming";
-        const amount = isTransfer
-          ? transaction.amount
-          : transaction.direction === "outgoing"
-            ? -transaction.amount
-            : transaction.amount;
+        const { direction, amount } = getTransactionAccountingValues(transaction);
         const id = transaction.id;
         const btcPrice = transaction.btcPrice;
         const txid = transaction.txid || "";
@@ -199,6 +196,7 @@ const TransactionsScreen = () => {
               data={filteredTransactions}
               renderItem={({ item }: { item: Transaction }) => {
                 const isTransfer = isInternalBoardingTransfer(item);
+                const isCanceled = isCanceledTransaction(item);
                 const movementStatus = formatMovementStatusLabel(item.movementStatus);
 
                 return (
@@ -215,7 +213,13 @@ const TransactionsScreen = () => {
                           name={getIconForTransaction(item)}
                           size={24}
                           color={
-                            isTransfer ? "#f97316" : item.direction === "outgoing" ? "red" : "green"
+                            isCanceled
+                              ? mutedForeground
+                              : isTransfer
+                                ? "#f97316"
+                                : item.direction === "outgoing"
+                                  ? "red"
+                                  : "green"
                           }
                         />
                       </View>
@@ -234,14 +238,16 @@ const TransactionsScreen = () => {
                         <View className="shrink-0 items-end">
                           <Text
                             className={`text-base font-bold ${
-                              isTransfer
-                                ? "text-orange-500"
-                                : item.direction === "outgoing"
-                                  ? "text-red-500"
-                                  : "text-green-500"
+                              isCanceled
+                                ? "text-muted-foreground"
+                                : isTransfer
+                                  ? "text-orange-500"
+                                  : item.direction === "outgoing"
+                                    ? "text-red-500"
+                                    : "text-green-500"
                             }`}
                           >
-                            {`${isTransfer ? "" : item.direction === "outgoing" ? "-" : "+"}${formatBitcoinAmount(item.amount)}`}
+                            {`${isCanceled || isTransfer ? "" : item.direction === "outgoing" ? "-" : "+"}${formatBitcoinAmount(item.amount)}`}
                           </Text>
                           {movementStatus ? (
                             <Text className="mt-1 text-xs text-muted-foreground">

--- a/client/tests/unit/transactionHistory.test.js
+++ b/client/tests/unit/transactionHistory.test.js
@@ -3,7 +3,9 @@ import { describe, expect, test } from "bun:test";
 import {
   getBoardingMovementAmount,
   getMovementTransactionId,
+  getTransactionAccountingValues,
   getTransactionDisplayLabel,
+  isCanceledTransaction,
   isInternalBoardingTransfer,
   mergeBoardingWithOnchainTransactions,
   parseMovementMetadata,
@@ -116,5 +118,47 @@ describe("unified transaction history", () => {
   test("treats boards as internal transfers but preserves offboards as outgoing sends", () => {
     expect(isInternalBoardingTransfer({ type: "Onchain", movementKind: "onboard" })).toBe(true);
     expect(isInternalBoardingTransfer({ type: "Onchain", movementKind: "offboard" })).toBe(false);
+  });
+
+  test("presents a canceled exit as neutral activity", () => {
+    const canceledExit = {
+      type: "Onchain",
+      movementKind: "exit",
+      movementStatus: "canceled",
+      direction: "outgoing",
+      amount: 92_590,
+    };
+
+    expect(isCanceledTransaction(canceledExit)).toBe(true);
+    expect(getTransactionDisplayLabel(canceledExit)).toBe("Canceled Ark Exit");
+    expect(getTransactionAccountingValues(canceledExit)).toEqual({
+      direction: "None",
+      amount: 0,
+    });
+    expect(
+      getTransactionDisplayLabel({
+        type: "Bolt11",
+        movementStatus: "canceled",
+      }),
+    ).toBe("Canceled Lightning");
+  });
+
+  test("preserves signed accounting values for completed activity", () => {
+    expect(
+      getTransactionAccountingValues({
+        type: "Arkoor",
+        direction: "outgoing",
+        amount: 21_000,
+      }),
+    ).toEqual({ direction: "Outgoing", amount: -21_000 });
+
+    expect(
+      getTransactionAccountingValues({
+        type: "Onchain",
+        movementKind: "onboard",
+        direction: "incoming",
+        amount: 50_000,
+      }),
+    ).toEqual({ direction: "Transfer", amount: 50_000 });
   });
 });


### PR DESCRIPTION
Use muted history styling and a zero CSV balance effect for every canceled movement type.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>