### PR TITLE
Add private Fly infrastructure for the barkd wallet

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,7 @@
 fly.toml
 .git/
+target/
+**/target/
+node_modules/
+**/node_modules/
+client/

--- a/docs/barkd_forwarding_invoices_todo.md
+++ b/docs/barkd_forwarding_invoices_todo.md
@@ -162,7 +162,7 @@ app = "noah-barkd-signet"
 primary_region = "iad"
 
 [build]
-  dockerfile = "fly/barkd.Dockerfile"
+  dockerfile = "barkd.Dockerfile"
 
 [deploy]
   strategy = "rolling"
@@ -208,7 +208,7 @@ Illustrative commands; verify them against the installed `flyctl` before executi
 ```sh
 fly apps create noah-barkd-signet
 fly volumes create bark_data --app noah-barkd-signet --region iad --size 1
-fly deploy --config fly/signet.barkd.fly.toml
+fly deploy --config fly/signet.barkd.fly.toml --remote-only --ha=false
 fly scale count 1 --app noah-barkd-signet
 fly ips list --app noah-barkd-signet
 ```

--- a/docs/barkd_forwarding_invoices_todo.md
+++ b/docs/barkd_forwarding_invoices_todo.md
@@ -125,7 +125,7 @@ These items block implementation or mainnet rollout.
 The normal process should be equivalent to:
 
 ```sh
-barkd --datadir /data --host :: --port 3000
+barkd --datadir /data/barkd --host :: --port 3000
 ```
 
 `barkd` currently parses `--host` as an IP address, so use the IPv6 wildcard `::`; do not pass the
@@ -147,7 +147,9 @@ Fly hostname `fly-local-6pn` as the flag value.
 - [ ] Add `fly/mainnet.barkd.fly.toml` only after signet passes the rollout gates.
 - [ ] Use `iad`, matching the Noah server's primary region.
 - [ ] Mount a volume named `bark_data` at `/data`.
-- [ ] Configure `BARKD_DATADIR=/data`, `BARKD_BIND_HOST=::`, and `BARKD_BIND_PORT=3000`.
+- [ ] Configure `BARKD_DATADIR=/data/barkd`, `BARKD_BIND_HOST=::`, and `BARKD_BIND_PORT=3000`.
+- [ ] Keep the datadir below the volume root so Fly's filesystem-owned `lost+found` directory does
+  not prevent wallet creation.
 - [ ] Use `strategy = "rolling"`; Fly blue/green and canary deployments are not supported for
   Machines with attached volumes.
 - [ ] Keep one Machine running with auto-stop disabled.
@@ -168,7 +170,7 @@ primary_region = "iad"
   strategy = "rolling"
 
 [env]
-  BARKD_DATADIR = "/data"
+  BARKD_DATADIR = "/data/barkd"
   BARKD_BIND_HOST = "::"
   BARKD_BIND_PORT = "3000"
 
@@ -219,7 +221,7 @@ fly ips list --app noah-barkd-signet
 
 - [ ] Start barkd with the empty mounted datadir. It should generate its REST auth token.
 - [ ] Retrieve the bearer token in a controlled operator session with
-  `barkd --datadir /data secret show`.
+  `barkd --datadir /data/barkd secret show`.
 - [ ] Store the token as `BARKD_AUTH_TOKEN` on the corresponding Noah app.
 - [ ] Store `BARKD_URL=http://noah-barkd-signet.internal:3000` on `noah-signet`.
 - [ ] Do not store the bearer token in Git, logs, Docker layers, or `fly.toml`.
@@ -423,7 +425,7 @@ negotiation fails.
   stuck paid receive.
 - [ ] Alert when the Fly volume is near capacity.
 - [ ] Document bearer-token rotation:
-  - Rotate with `barkd --datadir /data secret refresh` in a controlled session.
+  - Rotate with `barkd --datadir /data/barkd secret refresh` in a controlled session.
   - Update the corresponding Noah Fly secret.
   - Restart/roll Noah and verify authentication.
 - [ ] Document volume-host failure and restoration from continuous backup.

--- a/fly/barkd-entrypoint.sh
+++ b/fly/barkd-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+install --directory --owner barkd --group barkd --mode 0700 "${BARKD_DATADIR}"
+chown barkd:barkd "${BARKD_DATADIR}"
+chmod 0700 "${BARKD_DATADIR}"
+
+exec gosu barkd:barkd "$@"

--- a/fly/barkd-entrypoint.sh
+++ b/fly/barkd-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -eu
 
+# Fly mounts volumes as root:root on every boot. Reclaim the mount before
+# dropping privileges so barkd can initialize its nested datadir.
+chown barkd:barkd /data
+chmod 0700 /data
+
 install --directory --owner barkd --group barkd --mode 0700 "${BARKD_DATADIR}"
 chown barkd:barkd "${BARKD_DATADIR}"
 chmod 0700 "${BARKD_DATADIR}"

--- a/fly/barkd-setup.md
+++ b/fly/barkd-setup.md
@@ -41,7 +41,10 @@ fly volumes create bark_data \
   --size 1 \
   --snapshot-retention 30
 
-fly deploy --config fly/signet.barkd.fly.toml
+fly deploy \
+  --config fly/signet.barkd.fly.toml \
+  --remote-only \
+  --ha=false
 fly scale count 1 --app noah-barkd-signet
 ```
 

--- a/fly/barkd-setup.md
+++ b/fly/barkd-setup.md
@@ -1,7 +1,9 @@
 # Barkd Fly setup
 
 Noah uses one private barkd app and wallet per Bitcoin network. Barkd owns its SQLite wallet state
-on a Fly Volume; the Noah server remains stateless and calls barkd over Fly's private 6PN network.
+in `/data/barkd` on a Fly Volume; the Noah server remains stateless and calls barkd over Fly's
+private 6PN network. The subdirectory keeps the filesystem's `lost+found` directory outside Barkd's
+datadir, which must not contain unexpected files when the wallet is created.
 
 The barkd apps intentionally have no `http_service`, `services`, Flycast address, or public IP.
 They must remain in the same Fly organization/private network as their corresponding Noah apps.
@@ -67,7 +69,7 @@ Barkd generates an auth token in the datadir on first start. Display it in a con
 ```sh
 fly ssh console \
   --app noah-barkd-signet \
-  --command "barkd --datadir /data secret show"
+  --command "barkd --datadir /data/barkd secret show"
 ```
 
 Store the value on the Noah app, then discard it from the clipboard and terminal scrollback:
@@ -110,9 +112,16 @@ curl --fail-with-body \
 JSON
 ```
 
-Record the returned wallet fingerprint. Barkd generates the mnemonic inside `/data`; retrieve it in
-a controlled SSH session and store it in the approved offline recovery system. Do not enable the
-REST mnemonic endpoint in the normal deployment.
+Record the returned wallet fingerprint. Barkd generates the mnemonic inside `/data/barkd`; retrieve
+it in a controlled SSH session and store it in the approved offline recovery system:
+
+```sh
+fly ssh console \
+  --app noah-barkd-signet \
+  --command "cat /data/barkd/mnemonic"
+```
+
+Do not enable the REST mnemonic endpoint in the normal deployment.
 
 Check the Ark connection through the same tunnel:
 

--- a/fly/barkd-setup.md
+++ b/fly/barkd-setup.md
@@ -1,0 +1,180 @@
+# Barkd Fly setup
+
+Noah uses one private barkd app and wallet per Bitcoin network. Barkd owns its SQLite wallet state
+on a Fly Volume; the Noah server remains stateless and calls barkd over Fly's private 6PN network.
+
+The barkd apps intentionally have no `http_service`, `services`, Flycast address, or public IP.
+They must remain in the same Fly organization/private network as their corresponding Noah apps.
+
+## Files
+
+- `fly/barkd.Dockerfile`: pinned barkd runtime image
+- `fly/signet.barkd.fly.toml`: `noah-barkd-signet`
+- `fly/mainnet.barkd.fly.toml`: `noah-barkd-mainnet`
+
+## Build the image locally
+
+The published barkd binary is Linux x86-64, matching Fly's default Machine architecture.
+
+```sh
+docker build \
+  --platform linux/amd64 \
+  --file fly/barkd.Dockerfile \
+  --tag noah-barkd:0.6.1 \
+  .
+
+docker run --rm --platform linux/amd64 noah-barkd:0.6.1 barkd --version
+```
+
+The Dockerfile pins both the barkd version and the release binary SHA-256 checksum.
+
+## Provision signet
+
+Verify these commands against the installed `flyctl` before running them.
+
+```sh
+fly apps create noah-barkd-signet
+
+fly volumes create bark_data \
+  --app noah-barkd-signet \
+  --region iad \
+  --size 1 \
+  --snapshot-retention 30
+
+fly deploy --config fly/signet.barkd.fly.toml
+fly scale count 1 --app noah-barkd-signet
+```
+
+Verify that there is exactly one Machine and one attached volume, automatic snapshots are enabled,
+and no public IP was allocated:
+
+```sh
+fly machine list --app noah-barkd-signet
+fly volumes list --app noah-barkd-signet
+fly ips list --app noah-barkd-signet
+```
+
+Release any accidentally allocated public IP before continuing. Do not add an `http_service` or
+`services` section to make the API reachable.
+
+## Retrieve the REST token
+
+Barkd generates an auth token in the datadir on first start. Display it in a controlled terminal:
+
+```sh
+fly ssh console \
+  --app noah-barkd-signet \
+  --command "barkd --datadir /data secret show"
+```
+
+Store the value on the Noah app, then discard it from the clipboard and terminal scrollback:
+
+```sh
+fly secrets set --app noah-signet \
+  BARKD_AUTH_TOKEN=<token> \
+  BARKD_URL=http://noah-barkd-signet.internal:3000
+```
+
+Do not disable barkd authentication. The private network limits reachability; bearer authentication
+still limits which workloads on that network can control the wallet.
+
+## Create the signet wallet
+
+Open a local tunnel to the service-less Machine:
+
+```sh
+fly proxy 3001:3000 --app noah-barkd-signet
+```
+
+In a second controlled terminal, call the create endpoint once:
+
+```sh
+curl --fail-with-body \
+  --request POST \
+  --header "Authorization: Bearer <token>" \
+  --header "Content-Type: application/json" \
+  --data-binary @- \
+  http://127.0.0.1:3001/api/v1/wallet/create <<'JSON'
+{
+  "network": "signet",
+  "ark_server": "https://ark.signet.2nd.dev",
+  "chain_source": {
+    "esplora": {
+      "url": "https://esplora.signet.2nd.dev"
+    }
+  }
+}
+JSON
+```
+
+Record the returned wallet fingerprint. Barkd generates the mnemonic inside `/data`; retrieve it in
+a controlled SSH session and store it in the approved offline recovery system. Do not enable the
+REST mnemonic endpoint in the normal deployment.
+
+Check the Ark connection through the same tunnel:
+
+```sh
+curl --fail-with-body \
+  --header "Authorization: Bearer <token>" \
+  http://127.0.0.1:3001/api/v1/wallet/ark-info
+```
+
+## Provision mainnet
+
+Run the same procedure with these substitutions only after signet testing succeeds:
+
+| Setting | Mainnet value |
+| --- | --- |
+| Barkd app | `noah-barkd-mainnet` |
+| Noah app | `noah-mainnet` |
+| Fly config | `fly/mainnet.barkd.fly.toml` |
+| Network | `mainnet` |
+| Ark server | `https://ark.second.tech` |
+| Esplora | `https://mempool.second.tech/api` |
+| Noah URL | `http://noah-barkd-mainnet.internal:3000` |
+
+Never reuse the signet volume, mnemonic, REST token, or wallet fingerprint on mainnet.
+
+## Snapshots and restore
+
+Fly takes automatic daily snapshots. Both configs request 30-day retention. Create an on-demand
+snapshot before a barkd upgrade or risky operational change:
+
+```sh
+fly volumes list --app <barkd-app>
+fly volumes snapshots create <volume-id>
+fly volumes snapshots list <volume-id>
+```
+
+Restore a selected snapshot into a new volume of equal or greater size:
+
+```sh
+fly volumes create bark_data_restored \
+  --app <barkd-app> \
+  --region iad \
+  --size 1 \
+  --snapshot-id <snapshot-id> \
+  --snapshot-retention 30
+```
+
+Stop the original Machine before attaching and starting a replacement. Never run two barkd
+processes against copies intended to represent the same live wallet. After restoration, verify the
+recorded fingerprint and pending receive statuses before re-enabling invoice creation.
+
+Daily snapshots can miss changes made since the last snapshot. The independently stored mnemonic
+is the recovery backstop for wallet balance, but it does not restore recent history or every
+in-progress action.
+
+## Upgrade and rollback
+
+1. Disable new forwarded invoices in Noah.
+2. Leave barkd running until existing paid receives settle.
+3. Create and verify an on-demand volume snapshot.
+4. Update the pinned barkd version and checksum in `fly/barkd.Dockerfile`.
+5. Build and test the image on signet.
+6. Deploy with the barkd app's rolling strategy.
+7. Verify the wallet fingerprint, Ark connection, and a complete signet receive.
+8. Re-enable forwarded invoices.
+
+Do not blindly roll back the binary after an upgrade has migrated SQLite. Check Bark's release notes
+and restore the pre-upgrade snapshot when the old binary cannot read the migrated database.

--- a/fly/barkd.Dockerfile
+++ b/fly/barkd.Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
 COPY --from=downloader /barkd /usr/local/bin/barkd
 COPY fly/barkd-entrypoint.sh /usr/local/bin/barkd-entrypoint
 
-ENV BARKD_DATADIR=/data \
+ENV BARKD_DATADIR=/data/barkd \
     BARKD_BIND_HOST=:: \
     BARKD_BIND_PORT=3000
 

--- a/fly/barkd.Dockerfile
+++ b/fly/barkd.Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+FROM debian:bookworm-slim AS downloader
+
+ARG BARK_VERSION=0.6.1
+ARG BARKD_SHA256=41ca75ae2e474b3a3dbb33f51af95175926abb2286134fcb435fb47b995a1efd
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --fail --location --show-error \
+        "https://gitlab.com/ark-bitcoin/bark/-/releases/bark-${BARK_VERSION}/downloads/barkd-${BARK_VERSION}-linux-x86_64" \
+        --output /barkd \
+    && echo "${BARKD_SHA256}  /barkd" | sha256sum --check \
+    && chmod 0755 /barkd
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates gosu \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system barkd \
+    && useradd --system --gid barkd --home-dir /data --no-create-home barkd \
+    && install --directory --owner barkd --group barkd --mode 0700 /data
+
+COPY --from=downloader /barkd /usr/local/bin/barkd
+COPY fly/barkd-entrypoint.sh /usr/local/bin/barkd-entrypoint
+
+ENV BARKD_DATADIR=/data \
+    BARKD_BIND_HOST=:: \
+    BARKD_BIND_PORT=3000
+
+EXPOSE 3000
+
+ENTRYPOINT ["/usr/local/bin/barkd-entrypoint"]
+CMD ["barkd"]

--- a/fly/mainnet.barkd.fly.toml
+++ b/fly/mainnet.barkd.fly.toml
@@ -6,7 +6,7 @@ kill_signal = "SIGTERM"
 kill_timeout = "30s"
 
 [build]
-  dockerfile = "fly/barkd.Dockerfile"
+  dockerfile = "barkd.Dockerfile"
 
 [deploy]
   strategy = "rolling"

--- a/fly/mainnet.barkd.fly.toml
+++ b/fly/mainnet.barkd.fly.toml
@@ -1,0 +1,36 @@
+# Private singleton barkd wallet used by the Noah mainnet server.
+
+app = "noah-barkd-mainnet"
+primary_region = "iad"
+kill_signal = "SIGTERM"
+kill_timeout = "30s"
+
+[build]
+  dockerfile = "fly/barkd.Dockerfile"
+
+[deploy]
+  strategy = "rolling"
+  wait_timeout = "10m"
+
+[env]
+  BARKD_DATADIR = "/data"
+  BARKD_BIND_HOST = "::"
+  BARKD_BIND_PORT = "3000"
+
+[[mounts]]
+  source = "bark_data"
+  destination = "/data"
+  scheduled_snapshots = true
+  snapshot_retention = 30
+
+[checks.barkd_tcp]
+  type = "tcp"
+  port = 3000
+  interval = "30s"
+  timeout = "5s"
+  grace_period = "15s"
+
+[[vm]]
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/fly/mainnet.barkd.fly.toml
+++ b/fly/mainnet.barkd.fly.toml
@@ -16,7 +16,7 @@ kill_timeout = "30s"
   policy = "always"
 
 [env]
-  BARKD_DATADIR = "/data"
+  BARKD_DATADIR = "/data/barkd"
   BARKD_BIND_HOST = "::"
   BARKD_BIND_PORT = "3000"
 

--- a/fly/mainnet.barkd.fly.toml
+++ b/fly/mainnet.barkd.fly.toml
@@ -12,6 +12,9 @@ kill_timeout = "30s"
   strategy = "rolling"
   wait_timeout = "10m"
 
+[[restart]]
+  policy = "always"
+
 [env]
   BARKD_DATADIR = "/data"
   BARKD_BIND_HOST = "::"

--- a/fly/signet.barkd.fly.toml
+++ b/fly/signet.barkd.fly.toml
@@ -6,7 +6,7 @@ kill_signal = "SIGTERM"
 kill_timeout = "30s"
 
 [build]
-  dockerfile = "fly/barkd.Dockerfile"
+  dockerfile = "barkd.Dockerfile"
 
 [deploy]
   strategy = "rolling"

--- a/fly/signet.barkd.fly.toml
+++ b/fly/signet.barkd.fly.toml
@@ -16,7 +16,7 @@ kill_timeout = "30s"
   policy = "always"
 
 [env]
-  BARKD_DATADIR = "/data"
+  BARKD_DATADIR = "/data/barkd"
   BARKD_BIND_HOST = "::"
   BARKD_BIND_PORT = "3000"
 

--- a/fly/signet.barkd.fly.toml
+++ b/fly/signet.barkd.fly.toml
@@ -1,0 +1,36 @@
+# Private singleton barkd wallet used by the Noah signet server.
+
+app = "noah-barkd-signet"
+primary_region = "iad"
+kill_signal = "SIGTERM"
+kill_timeout = "30s"
+
+[build]
+  dockerfile = "fly/barkd.Dockerfile"
+
+[deploy]
+  strategy = "rolling"
+  wait_timeout = "10m"
+
+[env]
+  BARKD_DATADIR = "/data"
+  BARKD_BIND_HOST = "::"
+  BARKD_BIND_PORT = "3000"
+
+[[mounts]]
+  source = "bark_data"
+  destination = "/data"
+  scheduled_snapshots = true
+  snapshot_retention = 30
+
+[checks.barkd_tcp]
+  type = "tcp"
+  port = 3000
+  interval = "30s"
+  timeout = "5s"
+  grace_period = "15s"
+
+[[vm]]
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/fly/signet.barkd.fly.toml
+++ b/fly/signet.barkd.fly.toml
@@ -12,6 +12,9 @@ kill_timeout = "30s"
   strategy = "rolling"
   wait_timeout = "10m"
 
+[[restart]]
+  policy = "always"
+
 [env]
   BARKD_DATADIR = "/data"
   BARKD_BIND_HOST = "::"


### PR DESCRIPTION
## Summary

- Package the pinned barkd 0.6.1 Linux binary with checksum verification and a non-root runtime.
- Add private singleton signet and mainnet Fly apps with `/data` Fly Volumes and 30-day automatic snapshot retention.
- Document provisioning, token installation, wallet creation, snapshot restore, and safe upgrades.

## Verification

- Built the linux/amd64 image locally and verified `barkd --version`.
- Verified the runtime user and `/data` permissions.
- Parsed both Fly TOML configs locally. No Fly resources were created or changed.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>