### PR TITLE
Add manual Barkd image and Fly deployment workflows

### DIFF
--- a/.github/workflows/barkd-build-push.yml
+++ b/.github/workflows/barkd-build-push.yml
@@ -1,0 +1,97 @@
+name: Manual Barkd Image Build and Push
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  BARK_VERSION: "0.6.1"
+
+concurrency:
+  group: barkd-image-build
+  cancel-in-progress: false
+
+jobs:
+  barkd-build-and-push:
+    strategy:
+      matrix:
+        include:
+          - runner: blacksmith-4vcpu-ubuntu-2404
+            platform: linux/amd64
+            arch: amd64
+          - runner: blacksmith-4vcpu-ubuntu-2404-arm
+            platform: linux/arm64
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: 🏗 Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@v1
+
+      - name: 🔐 Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🔐 Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: 🚀 Build and push ${{ matrix.arch }}
+        uses: useblacksmith/build-push-action@v2
+        with:
+          context: .
+          file: fly/barkd.Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          build-args: |
+            BARK_VERSION=${{ env.BARK_VERSION }}
+          tags: |
+            ghcr.io/smolcars/noah-barkd:${{ env.BARK_VERSION }}-${{ matrix.arch }}
+            ghcr.io/smolcars/noah-barkd:latest-${{ matrix.arch }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/noah-barkd:${{ env.BARK_VERSION }}-${{ matrix.arch }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/noah-barkd:latest-${{ matrix.arch }}
+
+  create-manifest:
+    needs: barkd-build-and-push
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: 🔐 Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🔐 Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: 🎯 Create and push multi-arch manifests
+        run: |
+          docker buildx imagetools create -t ghcr.io/smolcars/noah-barkd:${BARK_VERSION} \
+            ghcr.io/smolcars/noah-barkd:${BARK_VERSION}-amd64 \
+            ghcr.io/smolcars/noah-barkd:${BARK_VERSION}-arm64
+
+          docker buildx imagetools create -t ghcr.io/smolcars/noah-barkd:latest \
+            ghcr.io/smolcars/noah-barkd:latest-amd64 \
+            ghcr.io/smolcars/noah-barkd:latest-arm64
+
+          docker buildx imagetools create -t ${{ secrets.DOCKERHUB_USERNAME }}/noah-barkd:${BARK_VERSION} \
+            ${{ secrets.DOCKERHUB_USERNAME }}/noah-barkd:${BARK_VERSION}-amd64 \
+            ${{ secrets.DOCKERHUB_USERNAME }}/noah-barkd:${BARK_VERSION}-arm64
+
+          docker buildx imagetools create -t ${{ secrets.DOCKERHUB_USERNAME }}/noah-barkd:latest \
+            ${{ secrets.DOCKERHUB_USERNAME }}/noah-barkd:latest-amd64 \
+            ${{ secrets.DOCKERHUB_USERNAME }}/noah-barkd:latest-arm64

--- a/.github/workflows/barkd-mainnet-deploy.yml
+++ b/.github/workflows/barkd-mainnet-deploy.yml
@@ -1,0 +1,30 @@
+name: Barkd Mainnet Fly Deploy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy mainnet Barkd
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: production
+    concurrency: fly-barkd-mainnet-deploy
+    steps:
+      - name: 🏗 Checkout code
+        uses: actions/checkout@v6
+
+      - name: 🛇 Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: 🔎 Validate Fly config
+        run: flyctl config validate --strict --config fly/mainnet.barkd.fly.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_BARKD_MAINNET_API_TOKEN }}
+
+      - name: 🚀 Deploy mainnet Barkd
+        run: flyctl deploy --config fly/mainnet.barkd.fly.toml --remote-only --ha=false
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_BARKD_MAINNET_API_TOKEN }}

--- a/.github/workflows/barkd-signet-deploy.yml
+++ b/.github/workflows/barkd-signet-deploy.yml
@@ -1,0 +1,29 @@
+name: Barkd Signet Fly Deploy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy signet Barkd
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    concurrency: fly-barkd-signet-deploy
+    steps:
+      - name: 🏗 Checkout code
+        uses: actions/checkout@v6
+
+      - name: 🛇 Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: 🔎 Validate Fly config
+        run: flyctl config validate --strict --config fly/signet.barkd.fly.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_BARKD_SIGNET_API_TOKEN }}
+
+      - name: 🚀 Deploy signet Barkd
+        run: flyctl deploy --config fly/signet.barkd.fly.toml --remote-only --ha=false
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_BARKD_SIGNET_API_TOKEN }}

--- a/.github/workflows/server-push.yml
+++ b/.github/workflows/server-push.yml
@@ -13,6 +13,10 @@ on:
       - "Cargo.lock"
       - "Dockerfile"
       - ".github/workflows/**"
+      - "!fly/barkd.Dockerfile"
+      - "!fly/barkd-entrypoint.sh"
+      - "!fly/*.barkd.fly.toml"
+      - "!.github/workflows/barkd-*.yml"
       - "!**/*.md"
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,8 +290,8 @@ checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
 name = "ark-lib"
-version = "0.4.0"
-source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.4.0#1538235d2e1fa166c7fc3c5d2d5531b9e09ba9de"
+version = "0.6.1"
+source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.6.1#8134aed9029e4bbd5dff922500affd8611edb511"
 dependencies = [
  "async-trait",
  "bark-bitcoin-ext",
@@ -947,8 +947,8 @@ dependencies = [
 
 [[package]]
 name = "bark-bitcoin-ext"
-version = "0.4.0"
-source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.4.0#1538235d2e1fa166c7fc3c5d2d5531b9e09ba9de"
+version = "0.6.1"
+source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.6.1#8134aed9029e4bbd5dff922500affd8611edb511"
 dependencies = [
  "bitcoin",
  "lazy_static",
@@ -959,8 +959,8 @@ dependencies = [
 
 [[package]]
 name = "bark-server-rpc"
-version = "0.3.0"
-source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.4.0#1538235d2e1fa166c7fc3c5d2d5531b9e09ba9de"
+version = "0.6.1"
+source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.6.1#8134aed9029e4bbd5dff922500affd8611edb511"
 dependencies = [
  "ark-lib",
  "bitcoin",
@@ -2755,7 +2755,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3998,7 +3998,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.42",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4037,7 +4037,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ For development and testing, you can run a complete local Ark stack using Docker
 - **bitcoind** - Bitcoin Core in regtest mode
 - **captaind** (aspd) - Ark Server Protocol Daemon
 - **bark** - Ark CLI client
+- **barkd** - Noah forwarding wallet daemon
 - **postgres** - Database for captaind
 - **dragonfly** - Redis-compatible cache backing LNURL auth (k1) storage
 - **cln** - Core Lightning node
@@ -147,14 +148,36 @@ just setup-everything
 
 This single command will:
 
-- Start all Docker services (bitcoind, captaind, postgres, dragonfly db, cln, lnd, bark, noah-server)
+- Start all Docker services (bitcoind, captaind, postgres, dragonfly db, cln, lnd, bark, barkd, noah-server)
 - Create and fund a Bitcoin Core wallet
 - Generate 150 blocks
 - Fund the Ark server with 1 BTC
 - Create a bark wallet
+- Create a barkd forwarding wallet
 - Funds the bark wallet with 0.1 BTC and boards into Ark with 0.01 BTC
 - Fund LND with 0.1 BTC
 - Open a Lightning channel between LND and CLN (1M sats, 900k pushed to CLN)
+
+**Barkd forwarding tests:**
+
+The default stack starts barkd, persists its wallet in a Docker volume, and enables server-side
+forwarding in Noah. `just setup-everything` initializes the wallet automatically. When starting a
+fresh stack manually, initialize barkd once after the services are up:
+
+```bash
+just up
+just create-barkd-wallet
+```
+
+The service uses the same versioned multi-architecture image as Fly, shares Noah's network
+namespace so the server reaches it at a loopback URL, and publishes the API only on
+`127.0.0.1:3001`. Authentication is disabled only in this local trusted environment. To test a
+locally built image before publication:
+
+```bash
+docker build --file fly/barkd.Dockerfile --tag noah-barkd:local .
+BARKD_IMAGE=noah-barkd:local just up
+```
 
 **Manual Setup (Step by Step):**
 
@@ -178,6 +201,9 @@ This single command will:
 
     # Create a bark wallet
     just create-bark-wallet
+
+    # Create a barkd forwarding wallet
+    just create-barkd-wallet
     ```
 
 3.  **Setup Lightning channels (optional)**
@@ -198,6 +224,7 @@ just down
 **Useful Commands:**
 
 - Interact with bark wallet: `just bark <command>`
+- Initialize the barkd forwarding wallet: `just create-barkd-wallet`
 - Interact with ASPD RPC: `just aspd <command>`
 - Use bitcoin-cli: `just bcli <command>`
 - Use lncli: `just lncli <command>`
@@ -211,6 +238,7 @@ just down
 - Ark Server (captaind): `http://localhost:3535`
 - Noah Server: `http://localhost:3000`
 - Noah Server Health: `http://localhost:3099/health`
+- Barkd API: `http://127.0.0.1:3001`
 - PostgreSQL: `localhost:5432`
 - LND RPC: `localhost:10009` (P2P: `localhost:9735`)
 - CLN RPC: `localhost:9988` (P2P: `localhost:9736`)

--- a/fly/barkd-setup.md
+++ b/fly/barkd-setup.md
@@ -13,22 +13,35 @@ They must remain in the same Fly organization/private network as their correspon
 - `fly/barkd.Dockerfile`: pinned barkd runtime image
 - `fly/signet.barkd.fly.toml`: `noah-barkd-signet`
 - `fly/mainnet.barkd.fly.toml`: `noah-barkd-mainnet`
+- `.github/workflows/barkd-build-push.yml`: manual multi-architecture image publication
+- `.github/workflows/barkd-signet-deploy.yml`: manual signet deployment
+- `.github/workflows/barkd-mainnet-deploy.yml`: manual production-approved mainnet deployment
 
 ## Build the image locally
 
-The published barkd binary is Linux x86-64, matching Fly's default Machine architecture.
+Second publishes barkd binaries for Linux x86-64 and ARM64. The Dockerfile selects the matching
+asset through BuildKit's `TARGETARCH` and verifies a pinned SHA-256 for each architecture.
 
 ```sh
 docker build \
-  --platform linux/amd64 \
   --file fly/barkd.Dockerfile \
   --tag noah-barkd:0.6.1 \
   .
 
-docker run --rm --platform linux/amd64 noah-barkd:0.6.1 barkd --version
+docker run --rm noah-barkd:0.6.1 barkd --version
 ```
 
-The Dockerfile pins both the barkd version and the release binary SHA-256 checksum.
+The manual build workflow builds natively on amd64 and arm64 runners, then publishes shared
+`0.6.1` and `latest` manifests to `niteshbalusu/noah-barkd` on Docker Hub and
+`ghcr.io/smolcars/noah-barkd` on GHCR:
+
+```sh
+gh workflow run barkd-build-push.yml --ref master
+```
+
+The workflow uses the existing `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets.
+The Fly configs deliberately use the immutable `0.6.1` tag rather than `latest`, so signet and
+mainnet promote the same image version.
 
 ## Provision signet
 
@@ -43,12 +56,11 @@ fly volumes create bark_data \
   --size 1 \
   --snapshot-retention 30
 
-fly deploy \
-  --config fly/signet.barkd.fly.toml \
-  --remote-only \
-  --ha=false
-fly scale count 1 --app noah-barkd-signet
+gh workflow run barkd-signet-deploy.yml --ref master
 ```
+
+The workflow requires a `FLY_BARKD_SIGNET_API_TOKEN` repository secret with access to only the
+signet barkd app. The app and volume are one-time prerequisites; deployment never recreates them.
 
 Verify that there is exactly one Machine and one attached volume, automatic snapshots are enabled,
 and no public IP was allocated:
@@ -155,6 +167,15 @@ Run the same procedure with these substitutions only after signet testing succee
 
 Never reuse the signet volume, mnemonic, REST token, or wallet fingerprint on mainnet.
 
+Deploy mainnet manually after publishing and testing the pinned image on signet:
+
+```sh
+gh workflow run barkd-mainnet-deploy.yml --ref master
+```
+
+The workflow uses the GitHub `production` environment for approval and requires a
+`FLY_BARKD_MAINNET_API_TOKEN` secret with access to only the mainnet barkd app.
+
 ## Snapshots and restore
 
 Fly takes automatic daily snapshots. Both configs request 30-day retention. Create an on-demand
@@ -190,9 +211,10 @@ in-progress action.
 1. Disable new forwarded invoices in Noah.
 2. Leave barkd running until existing paid receives settle.
 3. Create and verify an on-demand volume snapshot.
-4. Update the pinned barkd version and checksum in `fly/barkd.Dockerfile`.
-5. Build and test the image on signet.
-6. Deploy with the barkd app's rolling strategy.
+4. Update the pinned barkd version and both architecture checksums in `fly/barkd.Dockerfile`, the
+   image tags in the Fly and Compose configs, and `BARK_VERSION` in the build workflow.
+5. Dispatch the image build workflow and deploy the versioned image to signet.
+6. Test signet, then dispatch the production-approved mainnet deployment.
 7. Verify the wallet fingerprint, Ark connection, and a complete signet receive.
 8. Re-enable forwarded invoices.
 

--- a/fly/barkd.Dockerfile
+++ b/fly/barkd.Dockerfile
@@ -3,15 +3,22 @@
 FROM debian:bookworm-slim AS downloader
 
 ARG BARK_VERSION=0.6.1
-ARG BARKD_SHA256=41ca75ae2e474b3a3dbb33f51af95175926abb2286134fcb435fb47b995a1efd
+ARG TARGETARCH
+ARG BARKD_SHA256_AMD64=41ca75ae2e474b3a3dbb33f51af95175926abb2286134fcb435fb47b995a1efd
+ARG BARKD_SHA256_ARM64=a078495b095aab9826ccebc921dfad3cc1ae822e1610b94894f9833569552482
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/* \
+    && case "${TARGETARCH}" in \
+        amd64) release_arch="x86_64"; checksum="${BARKD_SHA256_AMD64}" ;; \
+        arm64) release_arch="arm64"; checksum="${BARKD_SHA256_ARM64}" ;; \
+        *) echo "Unsupported Barkd architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
     && curl --fail --location --show-error \
-        "https://gitlab.com/ark-bitcoin/bark/-/releases/bark-${BARK_VERSION}/downloads/barkd-${BARK_VERSION}-linux-x86_64" \
+        "https://gitlab.com/ark-bitcoin/bark/-/releases/bark-${BARK_VERSION}/downloads/barkd-${BARK_VERSION}-linux-${release_arch}" \
         --output /barkd \
-    && echo "${BARKD_SHA256}  /barkd" | sha256sum --check \
+    && echo "${checksum}  /barkd" | sha256sum --check \
     && chmod 0755 /barkd
 
 FROM debian:bookworm-slim

--- a/fly/mainnet.barkd.fly.toml
+++ b/fly/mainnet.barkd.fly.toml
@@ -6,7 +6,7 @@ kill_signal = "SIGTERM"
 kill_timeout = "30s"
 
 [build]
-  dockerfile = "barkd.Dockerfile"
+  image = "niteshbalusu/noah-barkd:0.6.1"
 
 [deploy]
   strategy = "rolling"

--- a/fly/signet.barkd.fly.toml
+++ b/fly/signet.barkd.fly.toml
@@ -6,7 +6,7 @@ kill_signal = "SIGTERM"
 kill_timeout = "30s"
 
 [build]
-  dockerfile = "barkd.Dockerfile"
+  image = "niteshbalusu/noah-barkd:0.6.1"
 
 [deploy]
   strategy = "rolling"

--- a/justfile
+++ b/justfile
@@ -165,6 +165,9 @@ create-wallet:
 create-bark-wallet:
     ./scripts/ark-dev.sh create-bark-wallet
 
+create-barkd-wallet:
+    ./scripts/ark-dev.sh create-barkd-wallet
+
 generate blocks="101":
     ./scripts/ark-dev.sh generate {{ blocks }}
 

--- a/scripts/ark-dev.sh
+++ b/scripts/ark-dev.sh
@@ -13,6 +13,7 @@ COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
 BITCOIND_SERVICE="bitcoind"
 ASPD_SERVICE="captaind"
 BARK_SERVICE="bark"
+BARKD_SERVICE="barkd"
 CLN_SERVICE="cln"
 LND_SERVICE="lnd"
 NOAH_SERVER_SERVICE="noah-server"
@@ -25,7 +26,7 @@ BITCOIN_CLI_OPTS="-regtest -rpcuser=second -rpcpassword=ark -rpcwallet=$WALLET_N
 # --- End Configuration ---
     echo "SETUP:"
     echo "  setup                      Clone the bark repo and checkout the correct version."
-    echo "  setup-everything           Run complete setup: setup, up, create-wallet, generate 150, fund-aspd 1, create-bark-wallet, start noah-server."
+    echo "  setup-everything           Run complete setup: start services, fund wallets, and initialize bark and barkd."
 
 
 # Helper function to avoid repeating the long docker-compose command
@@ -43,7 +44,7 @@ usage() {
     echo ""
     echo "SETUP:"
     echo "  setup                      Clone the bark repo and checkout the correct version."
-    echo "  setup-everything           Run complete setup: setup, up, create-wallet, generate 150, fund-aspd 1, create-bark-wallet, start noah-server."
+    echo "  setup-everything           Run complete setup: start services, fund wallets, and initialize bark and barkd."
     echo ""
     echo "LIFECYCLE COMMANDS (run after 'setup'):"
     echo "  up                         Start all services in the background (docker-compose up -d)."
@@ -53,6 +54,7 @@ usage() {
     echo "MANAGEMENT COMMANDS (run while services are 'up'):"
     echo "  create-wallet              Create and load a new wallet in bitcoind named '$WALLET_NAME'."
     echo "  create-bark-wallet         Create a new bark wallet with pre-configured dev settings."
+    echo "  create-barkd-wallet        Create the barkd forwarding wallet."
     echo "  generate <num_blocks>      Mine blocks on bitcoind. Creates wallet if it doesn't exist."
     echo "  fund-aspd <amount>         Send <amount> of BTC from bitcoind to the ASPD wallet."
     echo "  send-to <addr> <amt>       Send <amt> BTC from bitcoind to <addr> and mine 1 block."
@@ -98,6 +100,63 @@ create_bark_wallet() {
         --bitcoind-pass ark \
         --force
     echo "✅ Bark wallet created. You can now use './ark-dev.sh bark <command>'."
+}
+
+# Creates the barkd wallet used for server-side forwarding tests.
+create_barkd_wallet() {
+    if ! command -v jq &> /dev/null; then
+        echo "Error: 'jq' is not installed. Please install it to continue." >&2
+        exit 1
+    fi
+
+    echo "Waiting for the local barkd API..."
+    local wallet_response=""
+    local barkd_ready=false
+    local attempt
+    for attempt in $(seq 1 20); do
+        if wallet_response=$(curl --silent --fail http://127.0.0.1:3001/api/v1/wallet); then
+            barkd_ready=true
+            break
+        fi
+        sleep 1
+    done
+
+    if [[ "$barkd_ready" != true ]]; then
+        echo "Error: $BARKD_SERVICE is not reachable. Run 'just up' first." >&2
+        exit 1
+    fi
+
+    local fingerprint
+    fingerprint=$(printf '%s' "$wallet_response" | jq -r '.fingerprint // empty')
+    if [[ -n "$fingerprint" ]]; then
+        echo "Barkd wallet already exists with fingerprint: $fingerprint"
+        return
+    fi
+
+    local create_response
+    create_response=$(curl --fail-with-body \
+        --request POST \
+        --header "Content-Type: application/json" \
+        --data-binary @- \
+        http://127.0.0.1:3001/api/v1/wallet/create <<'JSON'
+{
+  "network": "regtest",
+  "ark_server": "http://captaind:3535",
+  "chain_source": {
+    "esplora": {
+      "url": "http://electrs:3002"
+    }
+  }
+}
+JSON
+    )
+
+    fingerprint=$(printf '%s' "$create_response" | jq -r '.fingerprint // empty')
+    if [[ -z "$fingerprint" ]]; then
+        echo "Error: barkd did not return a wallet fingerprint." >&2
+        exit 1
+    fi
+    echo "Barkd wallet created with fingerprint: $fingerprint"
 }
 
 # Generates blocks using the bitcoind container
@@ -251,6 +310,9 @@ setup_everything() {
     create_bark_wallet
 
     echo ""
+    create_barkd_wallet
+
+    echo ""
     echo "🔍 Getting bark onchain address..."
     local bark_address
     bark_address=$(dcr run --rm "$BARK_SERVICE" bark onchain address | jq -r '.address')
@@ -280,6 +342,7 @@ setup_everything() {
     echo "  - ASPD (Ark Server): http://localhost:3535"
     echo "  - Noah Server: http://localhost:3000"
     echo "  - Noah Server Health: http://localhost:3099/health"
+    echo "  - Barkd API: http://127.0.0.1:3001"
     echo "  - LND (Lightning): RPC at localhost:10009, P2P at localhost:9735"
     echo "  - CLN (Core Lightning): RPC at localhost:9988, P2P at localhost:9736"
     echo "  - Lightning Channel: LND <-> CLN (1M sats with 900k pushed to CLN)"
@@ -328,6 +391,10 @@ case "$COMMAND" in
 
     create-bark-wallet)
         create_bark_wallet
+        ;;
+
+    create-barkd-wallet)
+        create_barkd_wallet
         ;;
 
     generate)

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -152,13 +152,37 @@ services:
       dockerfile: Dockerfile
     env_file:
       - .env.regtest
+    environment:
+      BARKD_FORWARDED_INVOICES_ENABLED: "true"
+      BARKD_URL: http://127.0.0.1:3001
+      BARKD_AUTH_TOKEN: regtest-no-auth
     ports:
       - "3000:3000"
       - "3099:3099"
+      - "127.0.0.1:3001:3001"
     depends_on:
       captaind:
         condition: service_started
       dragonfly:
+        condition: service_started
+
+  barkd:
+    image: ${BARKD_IMAGE:-niteshbalusu/noah-barkd:0.6.1}
+    restart: on-failure
+    network_mode: "service:noah-server"
+    environment:
+      BARKD_BIND_HOST: 0.0.0.0
+      BARKD_BIND_PORT: "3001"
+      BARKD_DATADIR: /data/barkd
+      BARKD_NO_AUTH: "true"
+    volumes:
+      - barkd:/data
+    depends_on:
+      noah-server:
+        condition: service_started
+      captaind:
+        condition: service_started
+      electrs:
         condition: service_started
 
 volumes:
@@ -169,6 +193,7 @@ volumes:
   bitcoind:
   postgres:
   lnd:
+  barkd:
 
 networks:
   bark:

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,8 +26,8 @@ tokio-cron-scheduler = { version = "0.15.1", features = ["english"] }
 serde_json = "1.0.150"
 random_word = { version = "0.5.2", features = ["en"] }
 futures-util = "0.3.32"
-bark-server-rpc = { git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.4.0" }
-ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.4.0" }
+bark-server-rpc = { git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.6.1" }
+ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.6.1" }
 deadpool-redis = { version = "0.23.0", features = ["serde", "rt_tokio_1"] }
 redis = { version = "1.4.0", features = ["aio", "tokio-comp"] }
 
@@ -62,7 +62,7 @@ jsonwebtoken = { version = "10.4.0", features = ["aws_lc_rs"] }
 tower = { version = "0.5.3", features = ["full"] }
 tracing-test = "0.2.6"
 once_cell = "1.21.4"
-ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.4.0", features = [
+ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.6.1", features = [
   "test-util",
 ] }
 


### PR DESCRIPTION
## Summary

- align Noah's Ark protocol crates with Barkd/signet by upgrading `ark-lib`, `bark-server-rpc`, and `bark-bitcoin-ext` to Second's `server-0.6.1` tag
- publish Barkd 0.6.1 as a checksum-pinned multi-architecture image for amd64 and arm64 on Docker Hub and GHCR
- add manual workflow dispatches for the signet and production-approved mainnet Fly deployments
- deploy Fly from the immutable `niteshbalusu/noah-barkd:0.6.1` image while preserving the existing volume-backed singleton topology
- run Barkd in the default local Docker Compose stack with a persistent volume and Noah forwarding enabled
- initialize the local Barkd wallet automatically in `just setup-everything`, while retaining an idempotent `just create-barkd-wallet` helper for manual setup
- document image publication, one-time Fly provisioning, wallet initialization, snapshots, upgrades, and local testing

## Signet diagnosis

Signet receives the Arkoor mailbox message but repeatedly retries the same checkpoint before reaching push dispatch. Noah was decoding those VTXOs with `server-0.4.0`, while Barkd 0.6.1 and current signet use the 0.6.1 protocol structures. This upgrade resolves all three Ark crates to commit `8134aed9`, matching Barkd 0.6.1.

## Validation

- built and ran the official Barkd binary on both `linux/amd64` and `linux/arm64`
- validated signet and mainnet Fly configs with `flyctl config validate --strict`
- validated the default Compose configuration with Barkd included
- validated workflow syntax and expressions with Actionlint (custom Blacksmith labels ignored)
- `cargo check -p server`
- all 10 mailbox worker tests pass against the 0.6.1 Ark test vectors
- full server run passed 358 tests; one unrelated Postgres pool timeout passed immediately when rerun in isolation
- repository commit hooks passed client lint, 59 unit tests, and TypeScript checks

## Rollout

1. Ensure `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` exist.
2. Add `FLY_BARKD_SIGNET_API_TOKEN` and `FLY_BARKD_MAINNET_API_TOKEN` (the latter on the protected `production` environment when possible).
3. Dispatch **Manual Barkd Image Build and Push**.
4. Merge to deploy the protocol-aligned Noah server to signet.
5. Dispatch **Barkd Signet Fly Deploy** and complete Arkoor and forwarded-Lightning receive tests.
6. Dispatch **Barkd Mainnet Fly Deploy** only after signet promotion is accepted.

The Fly apps and volumes remain one-time prerequisites; deployment workflows do not create them.