### PR TITLE
Add repeat payments from transaction history

### DIFF
--- a/client/src/Navigators.tsx
+++ b/client/src/Navigators.tsx
@@ -63,12 +63,17 @@ import {
 } from "~/lib/pushNotifications";
 import { PermissionStatus } from "expo-notifications";
 import logger from "~/lib/log";
+import type { RepeatPaymentDetails } from "~/types/repeatPayment";
 
 // Param list types
 export type TabParamList = {
   Home: NavigatorScreenParams<HomeStackParamList> | undefined;
   Receive: undefined;
-  Send: { destination?: string; requestId?: number };
+  Send: {
+    destination?: string;
+    repeatPayment?: RepeatPaymentDetails;
+    requestId?: number;
+  };
   History: NavigatorScreenParams<TransactionsStackParamList> | undefined;
 };
 

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -30,6 +30,8 @@ import {
   estimateStandardOnchainTxFee,
   validateArkoorPaymentAddress,
   type StandardOnchainWalletFeeEstimate,
+  history,
+  updateHistoryMetadata,
 } from "../lib/paymentsApi";
 import { queryClient } from "~/queryClient";
 import { DestinationTypes } from "~/lib/sendUtils";
@@ -37,6 +39,12 @@ import { getArkInfo } from "~/lib/walletApi";
 import logger from "~/lib/log";
 import ky from "ky";
 import { Result } from "neverthrow";
+import {
+  buildRepeatPaymentMetadataPatch,
+  findNewArkoorMovementId,
+  shouldUseArkDirectLightningAddressRoute,
+} from "~/lib/repeatPayment";
+import type { RepeatPaymentDetails } from "~/types/repeatPayment";
 
 const log = logger("usePayments");
 
@@ -247,9 +255,11 @@ type SendVariables = {
   onchainSource?: OnchainSendSource;
   lightningAddressPaymentRoute?: LightningAddressPaymentRoute;
   btcPrice?: number;
+  repeatPayment?: RepeatPaymentDetails;
 };
 
-type SendResult = ArkoorPaymentResult | LightningPayment | NoahOnchainPaymentResult;
+type ArkoorPaymentWithMovement = ArkoorPaymentResult & { movement_id?: number };
+type SendResult = ArkoorPaymentWithMovement | LightningPayment | NoahOnchainPaymentResult;
 
 export type SendFeeEstimateParams =
   | {
@@ -449,19 +459,52 @@ const sendLightningAddressPayment = async (
   destination: string,
   amountSat: number,
   comment: string | null,
-): Promise<ArkoorPaymentResult | LightningPayment> => {
+): Promise<ArkoorPaymentWithMovement | LightningPayment> => {
   const amountMsat = amountSat * 1000;
   if (amountMsat < route.minSendableMsat || amountMsat > route.maxSendableMsat) {
     throw new Error("Payment amount is outside the supported range for this lightning address");
   }
 
-  if (route.method === "ark") {
+  if (
+    route.method === "ark" &&
+    shouldUseArkDirectLightningAddressRoute(route.method, comment)
+  ) {
     log.d("Paying lightning address via Ark direct payment");
+    const historyBeforeResult = await history();
+    const existingMovementIds = historyBeforeResult.isOk()
+      ? new Set(historyBeforeResult.value.map((movement) => movement.id))
+      : undefined;
+    if (historyBeforeResult.isErr()) {
+      log.w("Unable to snapshot history before Ark-routed lightning address payment", [
+        historyBeforeResult.error,
+      ]);
+    }
+
     const result = await sendArkoorPayment(route.destination, amountSat);
     if (result.isErr()) {
       throw result.error;
     }
-    return result.value;
+
+    if (!existingMovementIds) {
+      return result.value;
+    }
+
+    const historyAfterResult = await history();
+    if (historyAfterResult.isErr()) {
+      log.w("Unable to load history after Ark-routed lightning address payment", [
+        historyAfterResult.error,
+      ]);
+      return result.value;
+    }
+
+    const movementId = findNewArkoorMovementId({
+      existingMovementIds,
+      movements: historyAfterResult.value,
+      destination: route.destination,
+      amountSat,
+    });
+
+    return movementId === undefined ? result.value : { ...result.value, movement_id: movementId };
   }
 
   log.d("Paying via standard Lightning Address flow");
@@ -479,6 +522,7 @@ export function useSend(destinationType: DestinationTypes) {
         comment,
         onchainSource,
         lightningAddressPaymentRoute,
+        repeatPayment,
       } = variables;
       if (!isMaxAmount && amountSat === undefined && destinationType !== "lightning") {
         throw new Error("Amount is required");
@@ -534,24 +578,47 @@ export function useSend(destinationType: DestinationTypes) {
             throw new Error("Amount is required for LNURL payments");
           }
 
+          let paymentResult: ArkoorPaymentWithMovement | LightningPayment;
           if (lightningAddressPaymentRoute) {
-            return sendLightningAddressPayment(
+            paymentResult = await sendLightningAddressPayment(
               lightningAddressPaymentRoute,
               destination,
               amountSat,
               comment,
             );
+          } else {
+            let route: LightningAddressPaymentRoute | undefined;
+            try {
+              route = await resolveLightningAddressPaymentRoute(destination);
+            } catch (routeError) {
+              log.w("Failed to resolve lightning address payment route, using standard LNURL", [
+                routeError,
+              ]);
+            }
+
+            paymentResult = route
+              ? await sendLightningAddressPayment(route, destination, amountSat, comment)
+              : await readLightningPayment(
+                  payLightningAddress(destination, amountSat, comment || ""),
+                );
           }
 
-          try {
-            const route = await resolveLightningAddressPaymentRoute(destination);
-            return sendLightningAddressPayment(route, destination, amountSat, comment);
-          } catch (routeError) {
-            log.w("Failed to resolve lightning address payment route, using standard LNURL", [
-              routeError,
-            ]);
-            return readLightningPayment(payLightningAddress(destination, amountSat, comment || ""));
+          const movementId = paymentResult.movement_id;
+          if (repeatPayment && movementId !== undefined) {
+            const updateResult = await updateHistoryMetadata(
+              movementId,
+              buildRepeatPaymentMetadataPatch(repeatPayment),
+            );
+            if (updateResult.isErr()) {
+              log.w("Payment succeeded but repeat-payment metadata could not be saved", [
+                updateResult.error,
+              ]);
+            }
+          } else if (repeatPayment) {
+            log.w("Payment succeeded without a movement ID; repeat-payment metadata was not saved");
           }
+
+          return paymentResult;
         }
         case "offer":
           return readLightningPayment(payLightningOffer(destination, amountSat));

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -28,9 +28,14 @@ import { useBalance } from "./useWallet";
 import { useLightningAddressSuggestions } from "./useLightningAddressSuggestions";
 import { formatBitcoinAmount } from "~/lib/bitcoinAmount";
 import { fiatToSats, satsToFiat } from "~/lib/fiatCurrency";
+import {
+  getRepeatPaymentPrefill,
+  shouldUseArkDirectLightningAddressRoute,
+} from "~/lib/repeatPayment";
 import { getMaxSendBalanceSat } from "~/lib/onchainSend";
 import { useProfileStore } from "~/store/profileStore";
 import logger from "~/lib/log";
+import type { TabParamList } from "~/Navigators";
 
 const log = logger("useSendScreen");
 
@@ -43,10 +48,7 @@ type DisplayResult = {
   type: string;
 };
 
-type SendScreenRouteProp = RouteProp<
-  { params: { destination?: string; requestId?: number } },
-  "params"
->;
+type SendScreenRouteProp = RouteProp<TabParamList, "Send">;
 
 const formatFeeRate = (feeRateSatVb: number) => {
   if (Number.isInteger(feeRateSatVb)) {
@@ -165,17 +167,23 @@ export const useSendScreen = () => {
   } = useSend(finalDestinationType);
 
   useEffect(() => {
-    if (!route.params?.destination) {
+    const repeatPayment = route.params?.repeatPayment;
+    const requestedDestination = repeatPayment?.destination ?? route.params?.destination;
+    if (!requestedDestination) {
       return;
     }
 
+    const repeatPaymentPrefill = repeatPayment
+      ? getRepeatPaymentPrefill(repeatPayment, fiatCurrency)
+      : undefined;
+
     reset();
-    setAmount("");
+    setAmount(repeatPaymentPrefill?.amountInput ?? "");
     setIsAmountEditable(true);
-    setComment("");
+    setComment(repeatPayment?.comment ?? "");
     setParsedResult(null);
     setDestinationType(null);
-    setCurrency("SATS");
+    setCurrency(repeatPaymentPrefill?.amountMode ?? "SATS");
     setParsedAmount(null);
     setBip321Data(null);
     setSelectedPaymentMethod("onchain");
@@ -184,9 +192,9 @@ export const useSendScreen = () => {
     setShowConfirmation(false);
     setShowSuccess(false);
     setIsDestinationFocused(false);
-    setDestination(normalizeLightningAddressDestination(route.params.destination));
+    setDestination(normalizeLightningAddressDestination(requestedDestination));
     setDestinationRequestRevision((revision) => revision + 1);
-  }, [reset, route.params]);
+  }, [fiatCurrency, reset, route.params]);
 
   const { suggestions: lightningAddressSuggestions } = useLightningAddressSuggestions({
     destination,
@@ -301,10 +309,17 @@ export const useSendScreen = () => {
       case "lightning":
       case "offer":
         return { method: "lightning", amountSat };
-      case "lnurl":
-        return lightningAddressPaymentRouteQuery.data
-          ? { method: lightningAddressPaymentRouteQuery.data.method, amountSat }
+      case "lnurl": {
+        const route = lightningAddressPaymentRouteQuery.data;
+        return route
+          ? {
+              method: shouldUseArkDirectLightningAddressRoute(route.method, comment || null)
+                ? "ark"
+                : "lightning",
+              amountSat,
+            }
           : null;
+      }
       case "onchain":
         if (isMaxSend && resolvedOnchainSource === "onchain") {
           return null;
@@ -329,6 +344,7 @@ export const useSendScreen = () => {
     amountSat,
     bip321Data,
     cleanedDestination,
+    comment,
     destinationType,
     finalDestinationType,
     isMaxSend,
@@ -679,6 +695,17 @@ export const useSendScreen = () => {
             ? lightningAddressPaymentRouteQuery.data
             : undefined,
         btcPrice,
+        repeatPayment:
+          finalDestinationType === "lnurl"
+            ? {
+                destination: destinationToSend,
+                comment,
+                amountMode: currency,
+                amountInput: amount,
+                amountSat,
+                ...(currency === "FIAT" ? { fiatCurrency } : {}),
+              }
+            : undefined,
       });
     }
   };

--- a/client/src/hooks/useTransactions.ts
+++ b/client/src/hooks/useTransactions.ts
@@ -29,6 +29,7 @@ import {
   mergeBoardingWithOnchainTransactions,
   parseMovementMetadata,
 } from "~/lib/transactionHistory";
+import { resolveRepeatPaymentDetails } from "~/lib/repeatPayment";
 
 const log = logger("useTransactions");
 const UNKNOWN_ONCHAIN_DATE_ISO = new Date(0).toISOString();
@@ -218,18 +219,29 @@ const transformMovementToTransaction = async (
     : getMovementAmount(movement, isOutgoing);
   const metadata = parseMovementMetadata(movement.metadata_json);
   const txid = getMovementTransactionId(movement, metadata, isOutgoing);
-  const transactionType = determineTransactionType(movement, movementKind, isOutgoing);
+  const destinationEntry = isOutgoing ? movement.sent_to?.[0] : movement.received_on?.[0];
+  const movementDestination = getMovementDestinationValue(destinationEntry);
+  const repeatPayment =
+    isOutgoing && movement.sent_to.length === 1
+      ? resolveRepeatPaymentDetails({
+          metadata: metadata.repeatPayment,
+          destination: movementDestination,
+          paymentMethod: destinationEntry?.payment_method,
+          amountSat: amount,
+        })
+      : undefined;
+  const isLightningAddressPayment = Boolean(
+    metadata.repeatPayment || destinationEntry?.payment_method === "lightning-address",
+  );
+  const transactionType = isLightningAddressPayment
+    ? "Lnurl"
+    : determineTransactionType(movement, movementKind, isOutgoing);
 
   let btcPrice: number | undefined;
   const btcPriceResult = await getHistoricalBtcToFiatRate(dateIso, currency);
   if (btcPriceResult.isOk()) {
     btcPrice = btcPriceResult.value;
   }
-
-  const destinationEntry = isOutgoing
-    ? movement.sent_to?.[0]?.destination
-    : movement.received_on?.[0]?.destination;
-  const destination = getMovementDestinationValue({ destination: destinationEntry });
 
   return {
     id: `movement-${movement.id}`,
@@ -242,7 +254,7 @@ const transformMovementToTransaction = async (
     source: "ark",
     btcPrice,
     description: "",
-    destination: destination ?? "",
+    destination: repeatPayment?.destination ?? movementDestination ?? "",
     movementId: movement.id,
     movementStatus: movement.status as MovementStatus,
     movementKind,
@@ -257,14 +269,17 @@ const transformMovementToTransaction = async (
     sentTo: movement.sent_to.map((destination) => ({
       destination: getMovementDestinationValue(destination) ?? "",
       amount_sat: destination.amount_sat,
+      paymentMethod: destination.payment_method,
     })),
     receivedOn: movement.received_on.map((destination) => ({
       destination: getMovementDestinationValue(destination) ?? "",
       amount_sat: destination.amount_sat,
+      paymentMethod: destination.payment_method,
     })),
     inputVtxos: movement.input_vtxos,
     outputVtxos: movement.output_vtxos,
     exitedVtxos: movement.exited_vtxos,
+    repeatPayment,
   };
 };
 

--- a/client/src/lib/paymentsApi.ts
+++ b/client/src/lib/paymentsApi.ts
@@ -29,6 +29,7 @@ import {
   estimateSendOnchain as estimateSendOnchainNitro,
   estimateOffboardAll as estimateOffboardAllNitro,
   history as historyNitro,
+  updateHistoryMetadata as updateHistoryMetadataNitro,
   tryClaimAllLightningReceives as tryClaimAllLightningReceivesNitro,
   tryClaimLightningReceive as tryClaimLightningReceiveNitro,
   peekAddress as peekAddressNitro,
@@ -484,6 +485,19 @@ export const history = async (): Promise<Result<BarkMovement[], Error>> => {
     );
 
     return e;
+  });
+};
+
+export const updateHistoryMetadata = async (
+  movementId: number,
+  patchJson: string,
+): Promise<Result<void, Error>> => {
+  return ResultAsync.fromPromise(updateHistoryMetadataNitro(movementId, patchJson), (error) => {
+    return new Error(
+      `Failed to update movement metadata: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
   });
 };
 

--- a/client/src/lib/repeatPayment.ts
+++ b/client/src/lib/repeatPayment.ts
@@ -1,0 +1,181 @@
+import type { BarkMovement } from "react-native-nitro-ark";
+
+import { getMovementDestinationValue } from "~/lib/barkMovement";
+import { isFiatCurrencyCode } from "~/lib/fiatCurrency";
+import type {
+  PaymentAmountMode,
+  RepeatPaymentDetails,
+  RepeatPaymentMetadata,
+} from "~/types/repeatPayment";
+
+const REPEAT_PAYMENT_METADATA_VERSION = 1;
+
+const normalizeLightningAddress = (value: string): string | undefined => {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/^lightning:/, "");
+  const parts = normalized.split("@");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return undefined;
+  }
+
+  return normalized;
+};
+
+const parseAmountMode = (value: unknown): PaymentAmountMode | undefined => {
+  if (value === "fiat") {
+    return "FIAT";
+  }
+  if (value === "sats") {
+    return "SATS";
+  }
+  return undefined;
+};
+
+export const buildRepeatPaymentMetadataPatch = (details: RepeatPaymentDetails): string =>
+  JSON.stringify({
+    noah: {
+      repeat_payment: {
+        version: REPEAT_PAYMENT_METADATA_VERSION,
+        destination: details.destination,
+        comment: details.comment,
+        amount_mode: details.amountMode.toLowerCase(),
+        amount_value: details.amountInput,
+        ...(details.amountMode === "FIAT" && details.fiatCurrency
+          ? { fiat_currency: details.fiatCurrency }
+          : {}),
+      },
+    },
+  });
+
+export const parseRepeatPaymentMetadata = (value: unknown): RepeatPaymentMetadata | undefined => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const metadata = value as Record<string, unknown>;
+  if (metadata.version !== REPEAT_PAYMENT_METADATA_VERSION) {
+    return undefined;
+  }
+
+  const destination =
+    typeof metadata.destination === "string"
+      ? normalizeLightningAddress(metadata.destination)
+      : undefined;
+  const amountMode = parseAmountMode(metadata.amount_mode);
+  const numericAmount =
+    typeof metadata.amount_value === "string" ? Number(metadata.amount_value) : Number.NaN;
+  const amountInput =
+    typeof metadata.amount_value === "string" && Number.isFinite(numericAmount) && numericAmount > 0
+      ? metadata.amount_value
+      : undefined;
+  const comment = typeof metadata.comment === "string" ? metadata.comment : "";
+
+  if (!destination || !amountMode || !amountInput) {
+    return undefined;
+  }
+
+  if (amountMode === "FIAT") {
+    if (!isFiatCurrencyCode(metadata.fiat_currency)) {
+      return undefined;
+    }
+    return {
+      destination,
+      comment,
+      amountMode,
+      amountInput,
+      fiatCurrency: metadata.fiat_currency,
+    };
+  }
+
+  return { destination, comment, amountMode, amountInput };
+};
+
+export const resolveRepeatPaymentDetails = ({
+  metadata,
+  destination,
+  paymentMethod,
+  amountSat,
+}: {
+  metadata?: RepeatPaymentMetadata;
+  destination?: string;
+  paymentMethod?: string;
+  amountSat: number;
+}): RepeatPaymentDetails | undefined => {
+  if (!Number.isFinite(amountSat) || amountSat <= 0) {
+    return undefined;
+  }
+
+  if (metadata) {
+    return { ...metadata, amountSat };
+  }
+
+  const arkDestination = paymentMethod === "ark" ? destination?.trim() : undefined;
+  const repeatDestination =
+    paymentMethod === "lightning-address" && destination
+      ? normalizeLightningAddress(destination)
+      : arkDestination || undefined;
+  if (!repeatDestination) {
+    return undefined;
+  }
+
+  return {
+    destination: repeatDestination,
+    comment: "",
+    amountMode: "SATS",
+    amountInput: amountSat.toString(),
+    amountSat,
+  };
+};
+
+export const canRepeatPayment = (transaction: {
+  direction: "incoming" | "outgoing";
+  movementStatus?: string;
+  repeatPayment?: RepeatPaymentDetails;
+}): boolean =>
+  transaction.direction === "outgoing" &&
+  transaction.movementStatus === "successful" &&
+  transaction.repeatPayment !== undefined;
+
+export const getRepeatPaymentPrefill = (
+  details: RepeatPaymentDetails,
+  preferredFiatCurrency: RepeatPaymentDetails["fiatCurrency"],
+): { amountInput: string; amountMode: PaymentAmountMode } => {
+  const canRestoreFiat =
+    details.amountMode === "FIAT" && details.fiatCurrency === preferredFiatCurrency;
+
+  return canRestoreFiat
+    ? { amountInput: details.amountInput, amountMode: "FIAT" }
+    : { amountInput: details.amountSat.toString(), amountMode: "SATS" };
+};
+
+export const shouldUseArkDirectLightningAddressRoute = (
+  routeMethod: "ark" | "lightning",
+  comment: string | null,
+): boolean => routeMethod === "ark" && !comment;
+
+export const findNewArkoorMovementId = ({
+  existingMovementIds,
+  movements,
+  destination,
+  amountSat,
+}: {
+  existingMovementIds: ReadonlySet<number>;
+  movements: BarkMovement[];
+  destination: string;
+  amountSat: number;
+}): number | undefined =>
+  movements
+    .filter(
+      (movement) =>
+        !existingMovementIds.has(movement.id) &&
+        movement.status === "successful" &&
+        movement.subsystem?.name?.toLowerCase() === "bark.arkoor" &&
+        movement.subsystem?.kind?.toLowerCase() === "send" &&
+        movement.sent_to.some(
+          (sentTo) =>
+            getMovementDestinationValue(sentTo) === destination && sentTo.amount_sat === amountSat,
+        ),
+    )
+    .sort((a, b) => b.id - a.id)[0]?.id;

--- a/client/src/lib/transactionHistory.ts
+++ b/client/src/lib/transactionHistory.ts
@@ -1,11 +1,14 @@
 import type { BarkMovement } from "react-native-nitro-ark";
 
+import { parseRepeatPaymentMetadata } from "~/lib/repeatPayment";
 import type { Transaction } from "~/types/transaction";
+import type { RepeatPaymentMetadata } from "~/types/repeatPayment";
 
 export type MovementMetadata = {
   offboardTxid?: string;
   onchainFeeSat?: number;
   chainAnchor?: string;
+  repeatPayment?: RepeatPaymentMetadata;
 };
 
 export const parseMovementMetadata = (metadataJson: string): MovementMetadata => {
@@ -20,11 +23,18 @@ export const parseMovementMetadata = (metadataJson: string): MovementMetadata =>
     }
 
     const metadata = parsed as Record<string, unknown>;
+    const noahMetadata =
+      metadata.noah && typeof metadata.noah === "object" && !Array.isArray(metadata.noah)
+        ? (metadata.noah as Record<string, unknown>)
+        : undefined;
+    const repeatPayment = parseRepeatPaymentMetadata(noahMetadata?.repeat_payment);
+
     return {
       offboardTxid: typeof metadata.offboard_txid === "string" ? metadata.offboard_txid : undefined,
       onchainFeeSat:
         typeof metadata.onchain_fee_sat === "number" ? metadata.onchain_fee_sat : undefined,
       chainAnchor: typeof metadata.chain_anchor === "string" ? metadata.chain_anchor : undefined,
+      ...(repeatPayment ? { repeatPayment } : {}),
     };
   } catch {
     return {};

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -50,6 +50,7 @@ import {
   isCanceledTransaction,
   isInternalBoardingTransfer,
 } from "~/lib/transactionHistory";
+import type { RepeatPaymentDetails } from "~/types/repeatPayment";
 
 const getTransactionIcon = (transaction: Transaction) => {
   if (transaction.movementKind === "onboard") {
@@ -130,6 +131,11 @@ const HomeScreen = () => {
   const openTransaction = (transaction: Transaction) => {
     setSelectedTransaction(transaction);
     setIsTransactionSheetOpen(true);
+  };
+
+  const repeatPayment = (details: RepeatPaymentDetails) => {
+    setIsTransactionSheetOpen(false);
+    parentNavigation?.navigate("Send", { repeatPayment: details, requestId: Date.now() });
   };
 
   const isLoading = isBalanceLoading || isSyncPending || isRateLoading;
@@ -490,6 +496,7 @@ const HomeScreen = () => {
             transaction={selectedTransaction}
             fiatCurrency={fiatCurrency}
             onClose={() => setIsTransactionSheetOpen(false)}
+            onRepeatPayment={repeatPayment}
             closeIconName="close-outline"
           />
         </AppBottomSheet>

--- a/client/src/screens/TransactionDetailScreen.tsx
+++ b/client/src/screens/TransactionDetailScreen.tsx
@@ -6,7 +6,7 @@ import Icon from "@react-native-vector-icons/ionicons";
 import { useIconColor } from "../hooks/useTheme";
 import { copyToClipboard } from "../lib/clipboardUtils";
 import { type Transaction } from "../types/transaction";
-import { type ComponentProps, useState } from "react";
+import { type ComponentProps, type ReactNode, useState } from "react";
 import { COLORS } from "~/lib/styleConstants";
 import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
@@ -15,6 +15,76 @@ import { getMempoolTxUrl } from "~/constants";
 import { useProfileStore } from "~/store/profileStore";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import { getTransactionDisplayLabel } from "~/lib/transactionHistory";
+import { canRepeatPayment } from "~/lib/repeatPayment";
+import type { RepeatPaymentDetails } from "~/types/repeatPayment";
+import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
+
+const getTransactionIcon = (transaction: Transaction): ComponentProps<typeof Icon>["name"] => {
+  if (transaction.movementKind === "onboard") {
+    return "log-in-outline";
+  }
+
+  if (transaction.movementKind === "offboard") {
+    return "log-out-outline";
+  }
+
+  switch (transaction.type) {
+    case "Bolt11":
+    case "Lnurl":
+      return "flash-outline";
+    case "Arkoor":
+      return "boat-outline";
+    case "Onchain":
+      return "cube-outline";
+    default:
+      return "cash-outline";
+  }
+};
+
+const DetailSection = ({ title, children }: { title: string; children: ReactNode }) => (
+  <View className="mt-8">
+    <Text className="mb-1 text-xs font-semibold uppercase tracking-[2px] text-muted-foreground">
+      {title}
+    </Text>
+    <View className="border-t border-border/40">{children}</View>
+  </View>
+);
+
+const PaymentDestination = ({ value }: { value: string }) => {
+  const [copied, setCopied] = useState(false);
+  const iconColor = useIconColor();
+
+  const onCopy = async () => {
+    await copyToClipboard(value, {
+      onCopy: () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1000);
+      },
+    });
+  };
+
+  return (
+    <Pressable
+      accessibilityLabel={`Copy destination ${value}`}
+      accessibilityRole="button"
+      className="mt-2 max-w-[320px] flex-row items-center justify-center gap-2 px-4"
+      onPress={onCopy}
+    >
+      <Text
+        className="min-w-0 text-center text-base font-medium leading-6 text-foreground"
+        ellipsizeMode="middle"
+        numberOfLines={2}
+      >
+        {value}
+      </Text>
+      <Icon
+        name={copied ? "checkmark-circle-outline" : "copy-outline"}
+        size={17}
+        color={copied ? COLORS.SUCCESS : iconColor}
+      />
+    </Pressable>
+  );
+};
 
 const TransactionDetailRow = ({
   label,
@@ -40,17 +110,21 @@ const TransactionDetailRow = ({
   };
 
   return (
-    <View className="flex-row justify-between items-center py-3 border-b border-border/10 last:border-b-0">
-      <Text className="text-muted-foreground text-sm">{label}</Text>
+    <View className="flex-row items-start justify-between gap-4 border-b border-border/20 py-3.5 last:border-b-0">
+      <Text className="w-[112px] text-sm text-muted-foreground">{label}</Text>
       {copyable || explorerUrl ? (
-        <View className="flex-row items-center gap-x-3 flex-shrink-0">
+        <View className="min-w-0 flex-1 flex-row items-center justify-end gap-x-2">
           {copyable ? (
-            <Pressable onPress={onCopy} className="flex-row items-center gap-x-2 flex-shrink-0">
+            <Pressable
+              accessibilityLabel={`Copy ${label}`}
+              accessibilityRole="button"
+              onPress={onCopy}
+              className="min-w-0 flex-1 flex-row items-center justify-end gap-x-2"
+            >
               <Text
-                className="text-foreground text-sm text-right"
+                className="min-w-0 flex-shrink text-right text-sm text-foreground"
                 ellipsizeMode="middle"
                 numberOfLines={1}
-                style={{ maxWidth: 150 }}
               >
                 {value}
               </Text>
@@ -73,10 +147,9 @@ const TransactionDetailRow = ({
         </View>
       ) : (
         <Text
-          className="text-foreground text-sm text-right"
+          className="min-w-0 flex-1 text-right text-sm leading-5 text-foreground"
           ellipsizeMode="tail"
-          numberOfLines={2}
-          style={{ maxWidth: 200 }}
+          numberOfLines={3}
         >
           {value}
         </Text>
@@ -95,14 +168,16 @@ const MovementDestinationList = ({
   const formatBitcoinAmount = useBitcoinAmountFormatter();
 
   return (
-    <View className="bg-card p-4 rounded-lg mb-4">
-      <Text className="text-sm font-semibold text-foreground mb-3">{title}</Text>
+    <View className="mt-5 border-t border-border/30 pt-4">
+      <Text className="text-xs font-semibold uppercase tracking-[1.6px] text-muted-foreground">
+        {title}
+      </Text>
       {destinations.map((dest, index) => (
         <View
           key={`${dest.destination}-${index}`}
-          className="py-2 border-b border-border/10 last:border-b-0"
+          className="border-b border-border/20 py-3 last:border-b-0"
         >
-          <Text className="text-foreground text-sm mb-1" numberOfLines={2}>
+          <Text className="mb-1 text-sm leading-5 text-foreground" numberOfLines={2}>
             {dest.destination}
           </Text>
           <Text className="text-muted-foreground text-xs">
@@ -118,21 +193,21 @@ export const TransactionDetailContent = ({
   transaction,
   fiatCurrency,
   onClose,
+  onRepeatPayment,
   closeIconName = "arrow-back-outline",
 }: {
   transaction: Transaction;
   fiatCurrency: FiatCurrencyCode;
   onClose?: () => void;
+  onRepeatPayment?: (details: RepeatPaymentDetails) => void;
   closeIconName?: ComponentProps<typeof Icon>["name"];
 }) => {
+  const [showTechnicalDetails, setShowTechnicalDetails] = useState(false);
   const iconColor = useIconColor();
   const formatBitcoinAmount = useBitcoinAmountFormatter();
 
   const fiatAmount = transaction.btcPrice
     ? satsToFiat(transaction.amount, transaction.btcPrice, fiatCurrency)
-    : "N/A";
-  const bitcoinPrice = transaction.btcPrice
-    ? formatFiatAmount(transaction.btcPrice, fiatCurrency)
     : "N/A";
   const formattedFiatAmount =
     fiatAmount === "N/A" ? fiatAmount : formatFiatAmount(fiatAmount, fiatCurrency);
@@ -157,177 +232,250 @@ export const TransactionDetailContent = ({
     !hasOnchainWalletDetails && transaction.type === "Onchain" && transaction.txid
       ? getMempoolTxUrl(transaction.txid)
       : null;
+  const repeatPaymentDetails = transaction.repeatPayment;
+  const isRepeatable = Boolean(
+    onRepeatPayment && canRepeatPayment(transaction) && repeatPaymentDetails,
+  );
+  const isCompleted =
+    transaction.movementStatus === "successful" ||
+    (hasOnchainWalletDetails && transaction.hasConfirmation === true);
+  const isFailed =
+    transaction.movementStatus === "failed" || transaction.movementStatus === "canceled";
+  const statusLabel = isCompleted
+    ? "Completed"
+    : movementStatusLabel ||
+      (hasOnchainWalletDetails
+        ? transaction.hasConfirmation
+          ? "Confirmed"
+          : "Unconfirmed"
+        : "Recorded");
+  const statusColor = isCompleted ? COLORS.SUCCESS : isFailed ? "#ef4444" : COLORS.BITCOIN_ORANGE;
+  const paymentRoute =
+    transaction.type === "Lnurl" ? "Lightning address" : getTransactionDisplayLabel(transaction);
+  const enteredAmount =
+    repeatPaymentDetails?.amountMode === "FIAT" && repeatPaymentDetails.fiatCurrency
+      ? formatFiatAmount(repeatPaymentDetails.amountInput, repeatPaymentDetails.fiatCurrency)
+      : null;
+  const paymentFeeSat =
+    typeof transaction.offchainFeeSat === "number"
+      ? transaction.offchainFeeSat
+      : transaction.hasOnchainFee && typeof transaction.onchainFeeSat === "number"
+        ? transaction.onchainFeeSat
+        : undefined;
 
   return (
     <ScrollView
       className="flex-1"
-      contentContainerStyle={{ padding: 16, paddingBottom: 48 }}
+      contentContainerStyle={{ padding: 16, paddingBottom: 40 }}
       showsVerticalScrollIndicator={false}
     >
-      <View className="flex-row items-center mb-8">
+      <View className="relative flex-row items-center justify-between">
         {onClose ? (
-          <Pressable onPress={onClose} className="mr-4">
-            <Icon name={closeIconName} size={24} color={iconColor} />
+          <Pressable
+            accessibilityLabel="Close payment details"
+            accessibilityRole="button"
+            onPress={onClose}
+            className="z-10 h-10 w-10 items-center justify-center rounded-full bg-muted/60"
+          >
+            <Icon name={closeIconName} size={20} color={iconColor} />
           </Pressable>
-        ) : null}
-        <Text className="text-2xl font-bold text-foreground">
-          {getTransactionDisplayLabel(transaction)}
+        ) : (
+          <View className="h-10 w-10" />
+        )}
+        <Text className="absolute left-0 right-0 text-center text-base font-semibold text-foreground">
+          Payment details
         </Text>
+        <View
+          className="z-10 rounded-full px-3 py-1.5"
+          style={{ backgroundColor: `${statusColor}18` }}
+        >
+          <Text className="text-xs font-semibold" style={{ color: statusColor }}>
+            {statusLabel}
+          </Text>
+        </View>
       </View>
 
-      <View className="items-center my-8">
-        <Text className="text-4xl font-bold text-foreground">
+      <View className="items-center pb-2 pt-8">
+        <View
+          className="h-14 w-14 items-center justify-center rounded-full"
+          style={{ backgroundColor: `${COLORS.BITCOIN_ORANGE}18` }}
+        >
+          <Icon name={getTransactionIcon(transaction)} size={26} color={COLORS.BITCOIN_ORANGE} />
+        </View>
+        <Text className="mt-4 text-xs font-semibold uppercase tracking-[2px] text-muted-foreground">
+          {transaction.direction === "outgoing" ? "Sent" : "Received"}
+        </Text>
+        <Text className="mt-1 text-4xl font-bold tracking-tight text-foreground">
           {formatBitcoinAmount(transaction.amount)}
         </Text>
-        <Text className="text-xl text-muted-foreground">{formattedFiatAmount}</Text>
+        {formattedFiatAmount !== "N/A" ? (
+          <Text className="mt-1 text-base text-muted-foreground">≈ {formattedFiatAmount}</Text>
+        ) : null}
+        {transaction.destination ? (
+          <>
+            <Text className="mt-6 text-xs font-medium uppercase tracking-[1.8px] text-muted-foreground">
+              {transaction.direction === "outgoing" ? "Paid to" : "Received on"}
+            </Text>
+            <PaymentDestination value={transaction.destination} />
+            {isRepeatable && repeatPaymentDetails ? (
+              <NativeNoahButton
+                className="mt-4"
+                label="Pay again"
+                onPress={() => onRepeatPayment?.(repeatPaymentDetails)}
+                size="sm"
+                testID="repeat-payment-button"
+                width={148}
+              />
+            ) : null}
+          </>
+        ) : null}
       </View>
 
-      <View className="bg-card p-4 rounded-lg mb-4">
-        <TransactionDetailRow label={`Bitcoin Price (${fiatCurrency})`} value={bitcoinPrice} />
+      <DetailSection title="Overview">
         <TransactionDetailRow
-          label="Amount"
-          value={`${formatBitcoinAmount(transaction.amount)} (${formattedFiatAmount})`}
+          label={transaction.dateLabel ? "Confirmation" : "Date & time"}
+          value={transactionDateLabel}
         />
-      </View>
+        <TransactionDetailRow label="Route" value={paymentRoute} />
+        {enteredAmount ? <TransactionDetailRow label="Entered as" value={enteredAmount} /> : null}
+        {paymentFeeSat !== undefined ? (
+          <TransactionDetailRow
+            label="Fee"
+            value={paymentFeeSat === 0 ? "No fee" : formatBitcoinAmount(paymentFeeSat)}
+          />
+        ) : null}
+        {transaction.description ? (
+          <TransactionDetailRow label="Note" value={transaction.description} />
+        ) : null}
+        {repeatPaymentDetails?.comment ? (
+          <TransactionDetailRow label="Message" value={repeatPaymentDetails.comment} />
+        ) : null}
+      </DetailSection>
 
-      {hasOnchainWalletDetails ? (
-        <View className="bg-card p-4 rounded-lg mb-4">
-          <Text className="text-lg font-semibold text-foreground mb-3">
-            Onchain Wallet Transaction
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ expanded: showTechnicalDetails }}
+        className="mt-7 flex-row items-center justify-between border-y border-border/40 py-4"
+        onPress={() => setShowTechnicalDetails((isVisible) => !isVisible)}
+        testID="technical-details-toggle"
+      >
+        <View>
+          <Text className="text-sm font-semibold text-foreground">More details</Text>
+          <Text className="mt-0.5 text-xs text-muted-foreground">
+            IDs, routing, and movement data
           </Text>
+        </View>
+        <Icon
+          name={showTechnicalDetails ? "chevron-up-outline" : "chevron-down-outline"}
+          size={18}
+          color={iconColor}
+        />
+      </Pressable>
+
+      {showTechnicalDetails ? (
+        <View className="border-b border-border/40 pb-4">
+          <TransactionDetailRow label="Payment ID" value={transaction.id} copyable />
           {transaction.txid ? (
             <TransactionDetailRow
               label="Transaction ID"
               value={transaction.txid}
               copyable
-              explorerUrl={onchainExplorerUrl}
+              explorerUrl={hasOnchainWalletDetails ? onchainExplorerUrl : arkSendOnchainExplorerUrl}
             />
           ) : null}
-          <TransactionDetailRow
-            label="Status"
-            value={transaction.hasConfirmation ? "Confirmed" : "Unconfirmed"}
-          />
-          {typeof transaction.balanceChangeSat === "number" ? (
-            <TransactionDetailRow
-              label="Balance Δ"
-              value={formatBitcoinAmount(transaction.balanceChangeSat)}
-            />
+          {transaction.preimage ? (
+            <TransactionDetailRow label="Preimage" value={transaction.preimage} copyable />
           ) : null}
-          {transaction.hasOnchainFee && typeof transaction.onchainFeeSat === "number" ? (
+          {transaction.receivedOn?.length === 1 && transaction.receivedOn[0]?.destination ? (
             <TransactionDetailRow
-              label="Onchain Fee"
-              value={formatBitcoinAmount(transaction.onchainFeeSat)}
-            />
-          ) : null}
-          {typeof transaction.confirmationHeight === "number" ? (
-            <TransactionDetailRow
-              label="Confirmation Height"
-              value={transaction.confirmationHeight.toString()}
-            />
-          ) : null}
-          {transaction.confirmationHash ? (
-            <TransactionDetailRow
-              label="Block Hash"
-              value={transaction.confirmationHash}
+              label="Invoice"
+              value={transaction.receivedOn[0].destination}
               copyable
             />
           ) : null}
-          {transaction.txHex ? (
-            <TransactionDetailRow label="Raw Transaction" value={transaction.txHex} copyable />
+
+          {hasOnchainWalletDetails ? (
+            <>
+              <TransactionDetailRow
+                label="Chain status"
+                value={transaction.hasConfirmation ? "Confirmed" : "Unconfirmed"}
+              />
+              {typeof transaction.balanceChangeSat === "number" ? (
+                <TransactionDetailRow
+                  label="Balance change"
+                  value={formatBitcoinAmount(transaction.balanceChangeSat)}
+                />
+              ) : null}
+              {typeof transaction.confirmationHeight === "number" ? (
+                <TransactionDetailRow
+                  label="Block height"
+                  value={transaction.confirmationHeight.toString()}
+                />
+              ) : null}
+              {transaction.confirmationHash ? (
+                <TransactionDetailRow
+                  label="Block hash"
+                  value={transaction.confirmationHash}
+                  copyable
+                />
+              ) : null}
+              {transaction.txHex ? (
+                <TransactionDetailRow label="Raw transaction" value={transaction.txHex} copyable />
+              ) : null}
+            </>
+          ) : null}
+
+          {hasMovementDetails ? (
+            <>
+              {movementKindLabel ? (
+                <TransactionDetailRow label="Movement type" value={movementKindLabel} />
+              ) : null}
+              {transaction.movementId !== undefined ? (
+                <TransactionDetailRow
+                  label="Movement ID"
+                  value={transaction.movementId.toString()}
+                  copyable
+                />
+              ) : null}
+              {transaction.subsystemName ? (
+                <TransactionDetailRow
+                  label="Subsystem"
+                  value={
+                    transaction.subsystemKind
+                      ? `${transaction.subsystemName} (${transaction.subsystemKind})`
+                      : transaction.subsystemName
+                  }
+                />
+              ) : null}
+              {transaction.chainAnchor && transaction.chainAnchor !== transaction.txid ? (
+                <TransactionDetailRow
+                  label="Chain anchor"
+                  value={transaction.chainAnchor}
+                  copyable
+                />
+              ) : null}
+              {typeof transaction.intendedBalanceSat === "number" ? (
+                <TransactionDetailRow
+                  label="Intended change"
+                  value={formatBitcoinAmount(transaction.intendedBalanceSat)}
+                />
+              ) : null}
+              {typeof transaction.effectiveBalanceSat === "number" ? (
+                <TransactionDetailRow
+                  label="Effective change"
+                  value={formatBitcoinAmount(transaction.effectiveBalanceSat)}
+                />
+              ) : null}
+            </>
+          ) : null}
+
+          {transaction.sentTo && transaction.sentTo.length > 0 ? (
+            <MovementDestinationList title="Sent to" destinations={transaction.sentTo} />
+          ) : null}
+          {transaction.receivedOn && transaction.receivedOn.length > 0 ? (
+            <MovementDestinationList title="Received on" destinations={transaction.receivedOn} />
           ) : null}
         </View>
-      ) : null}
-
-      {hasMovementDetails ? (
-        <View className="bg-card p-4 rounded-lg mb-4">
-          <Text className="text-lg font-semibold text-foreground mb-3">Ark Movement</Text>
-          {movementKindLabel ? (
-            <TransactionDetailRow label="Type" value={movementKindLabel} />
-          ) : null}
-          {movementStatusLabel ? (
-            <TransactionDetailRow label="Status" value={movementStatusLabel} />
-          ) : null}
-          {transaction.movementId !== undefined ? (
-            <TransactionDetailRow
-              label="Movement ID"
-              value={transaction.movementId.toString()}
-              copyable
-            />
-          ) : null}
-          {transaction.subsystemName ? (
-            <TransactionDetailRow
-              label="Subsystem"
-              value={
-                transaction.subsystemKind
-                  ? `${transaction.subsystemName} (${transaction.subsystemKind})`
-                  : transaction.subsystemName
-              }
-            />
-          ) : null}
-          {transaction.chainAnchor && transaction.chainAnchor !== transaction.txid ? (
-            <TransactionDetailRow label="Chain Anchor" value={transaction.chainAnchor} copyable />
-          ) : null}
-          {typeof transaction.intendedBalanceSat === "number" ? (
-            <TransactionDetailRow
-              label="Intended Δ"
-              value={formatBitcoinAmount(transaction.intendedBalanceSat)}
-            />
-          ) : null}
-          {typeof transaction.effectiveBalanceSat === "number" ? (
-            <TransactionDetailRow
-              label="Effective Δ"
-              value={formatBitcoinAmount(transaction.effectiveBalanceSat)}
-            />
-          ) : null}
-          {typeof transaction.offchainFeeSat === "number" ? (
-            <TransactionDetailRow
-              label="Offchain Fee"
-              value={formatBitcoinAmount(transaction.offchainFeeSat)}
-            />
-          ) : null}
-        </View>
-      ) : null}
-
-      <View className="bg-card p-4 rounded-lg">
-        {transaction.description ? (
-          <TransactionDetailRow label="Note" value={transaction.description} />
-        ) : null}
-        <TransactionDetailRow
-          label={transaction.dateLabel ? "Confirmation" : "Date & time"}
-          value={transactionDateLabel}
-        />
-        <TransactionDetailRow label="Payment ID" value={transaction.id} copyable />
-        {transaction.txid && !hasOnchainWalletDetails ? (
-          <TransactionDetailRow
-            label="Transaction ID"
-            value={transaction.txid}
-            copyable
-            explorerUrl={arkSendOnchainExplorerUrl}
-          />
-        ) : null}
-        {transaction.preimage ? (
-          <TransactionDetailRow label="Preimage" value={transaction.preimage} copyable />
-        ) : null}
-        {transaction.destination ? (
-          <TransactionDetailRow label="Destination" value={transaction.destination} copyable />
-        ) : null}
-        {transaction.receivedOn &&
-        transaction.receivedOn.length === 1 &&
-        transaction.receivedOn[0]?.destination ? (
-          <TransactionDetailRow
-            label="Invoice"
-            value={transaction.receivedOn[0].destination}
-            copyable
-          />
-        ) : null}
-      </View>
-
-      {transaction.sentTo && transaction.sentTo.length > 0 ? (
-        <MovementDestinationList title="Sent To" destinations={transaction.sentTo} />
-      ) : null}
-
-      {transaction.receivedOn && transaction.receivedOn.length > 0 ? (
-        <MovementDestinationList title="Received On" destinations={transaction.receivedOn} />
       ) : null}
     </ScrollView>
   );

--- a/client/src/screens/TransactionDetailScreen.tsx
+++ b/client/src/screens/TransactionDetailScreen.tsx
@@ -14,7 +14,10 @@ import { formatMovementKindLabel, formatMovementStatusLabel } from "~/types/move
 import { getMempoolTxUrl } from "~/constants";
 import { useProfileStore } from "~/store/profileStore";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
-import { getTransactionDisplayLabel } from "~/lib/transactionHistory";
+import {
+  getTransactionAccountingValues,
+  getTransactionDisplayLabel,
+} from "~/lib/transactionHistory";
 import { canRepeatPayment } from "~/lib/repeatPayment";
 import type { RepeatPaymentDetails } from "~/types/repeatPayment";
 import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
@@ -250,18 +253,27 @@ export const TransactionDetailContent = ({
           : "Unconfirmed"
         : "Recorded");
   const statusColor = isCompleted ? COLORS.SUCCESS : isFailed ? "#ef4444" : COLORS.BITCOIN_ORANGE;
+  const accountingDirection = getTransactionAccountingValues(transaction).direction;
+  const receiptActionLabel =
+    accountingDirection === "Transfer"
+      ? "Transferred"
+      : accountingDirection === "None"
+        ? "Canceled"
+        : accountingDirection === "Outgoing"
+          ? "Sent"
+          : "Received";
   const paymentRoute =
     transaction.type === "Lnurl" ? "Lightning address" : getTransactionDisplayLabel(transaction);
   const enteredAmount =
     repeatPaymentDetails?.amountMode === "FIAT" && repeatPaymentDetails.fiatCurrency
       ? formatFiatAmount(repeatPaymentDetails.amountInput, repeatPaymentDetails.fiatCurrency)
       : null;
-  const paymentFeeSat =
-    typeof transaction.offchainFeeSat === "number"
-      ? transaction.offchainFeeSat
-      : transaction.hasOnchainFee && typeof transaction.onchainFeeSat === "number"
-        ? transaction.onchainFeeSat
-        : undefined;
+  const offchainFeeSat =
+    typeof transaction.offchainFeeSat === "number" ? transaction.offchainFeeSat : undefined;
+  const onchainFeeSat =
+    transaction.hasOnchainFee && typeof transaction.onchainFeeSat === "number"
+      ? transaction.onchainFeeSat
+      : undefined;
 
   return (
     <ScrollView
@@ -303,7 +315,7 @@ export const TransactionDetailContent = ({
           <Icon name={getTransactionIcon(transaction)} size={26} color={COLORS.BITCOIN_ORANGE} />
         </View>
         <Text className="mt-4 text-xs font-semibold uppercase tracking-[2px] text-muted-foreground">
-          {transaction.direction === "outgoing" ? "Sent" : "Received"}
+          {receiptActionLabel}
         </Text>
         <Text className="mt-1 text-4xl font-bold tracking-tight text-foreground">
           {formatBitcoinAmount(transaction.amount)}
@@ -338,10 +350,16 @@ export const TransactionDetailContent = ({
         />
         <TransactionDetailRow label="Route" value={paymentRoute} />
         {enteredAmount ? <TransactionDetailRow label="Entered as" value={enteredAmount} /> : null}
-        {paymentFeeSat !== undefined ? (
+        {offchainFeeSat !== undefined ? (
           <TransactionDetailRow
-            label="Fee"
-            value={paymentFeeSat === 0 ? "No fee" : formatBitcoinAmount(paymentFeeSat)}
+            label={onchainFeeSat !== undefined ? "Offchain fee" : "Fee"}
+            value={offchainFeeSat === 0 ? "No fee" : formatBitcoinAmount(offchainFeeSat)}
+          />
+        ) : null}
+        {onchainFeeSat !== undefined ? (
+          <TransactionDetailRow
+            label={offchainFeeSat !== undefined ? "Onchain fee" : "Fee"}
+            value={onchainFeeSat === 0 ? "No fee" : formatBitcoinAmount(onchainFeeSat)}
           />
         ) : null}
         {transaction.description ? (

--- a/client/src/screens/TransactionsScreen.tsx
+++ b/client/src/screens/TransactionsScreen.tsx
@@ -1,4 +1,6 @@
 import { View, Pressable, ActivityIndicator } from "react-native";
+import { type NavigationProp, useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import Share from "react-native-share";
 import { useState } from "react";
@@ -26,6 +28,8 @@ import {
 } from "~/lib/transactionHistory";
 import { formatMovementStatusLabel } from "~/types/movement";
 import { useThemeColors } from "~/hooks/useTheme";
+import type { TabParamList, TransactionsStackParamList } from "~/Navigators";
+import type { RepeatPaymentDetails } from "~/types/repeatPayment";
 
 const log = logger("TransactionsScreen");
 
@@ -39,6 +43,8 @@ const TRANSACTION_FILTER_OPTIONS = [
 ] as const;
 
 const TransactionsScreen = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<TransactionsStackParamList>>();
+  const tabNavigation = navigation.getParent<NavigationProp<TabParamList>>();
   const formatBitcoinAmount = useBitcoinAmountFormatter();
   const { mutedForeground } = useThemeColors();
   const { data: transactions = [], isLoading, isError, isRefetching, refetch } = useTransactions();
@@ -61,6 +67,11 @@ const TransactionsScreen = () => {
   const openTransaction = (transaction: Transaction) => {
     setSelectedTransaction(transaction);
     setIsTransactionSheetOpen(true);
+  };
+
+  const repeatPayment = (details: RepeatPaymentDetails) => {
+    setIsTransactionSheetOpen(false);
+    tabNavigation?.navigate("Send", { repeatPayment: details, requestId: Date.now() });
   };
 
   const exportToCSV = async () => {
@@ -276,6 +287,7 @@ const TransactionsScreen = () => {
               transaction={selectedTransaction}
               fiatCurrency={fiatCurrency}
               onClose={() => setIsTransactionSheetOpen(false)}
+              onRepeatPayment={repeatPayment}
               closeIconName="close-outline"
             />
           </AppBottomSheet>

--- a/client/src/types/repeatPayment.ts
+++ b/client/src/types/repeatPayment.ts
@@ -1,0 +1,14 @@
+import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
+
+export type PaymentAmountMode = "FIAT" | "SATS";
+
+export type RepeatPaymentDetails = {
+  destination: string;
+  comment: string;
+  amountMode: PaymentAmountMode;
+  amountInput: string;
+  amountSat: number;
+  fiatCurrency?: FiatCurrencyCode;
+};
+
+export type RepeatPaymentMetadata = Omit<RepeatPaymentDetails, "amountSat">;

--- a/client/src/types/transaction.ts
+++ b/client/src/types/transaction.ts
@@ -1,5 +1,6 @@
 import type { MovementStatus } from "react-native-nitro-ark";
 import type { BarkSubsystemKind, BarkSubsystemName } from "~/lib/barkMovement";
+import type { RepeatPaymentDetails } from "~/types/repeatPayment";
 
 export type PaymentTypes = "Bolt11" | "Bolt12" | "Lnurl" | "Arkoor" | "Onchain";
 import type { MovementKind } from "./movement";
@@ -41,9 +42,11 @@ export type Transaction = {
   hasConfirmation?: boolean;
   confirmationHeight?: number;
   confirmationHash?: string;
+  repeatPayment?: RepeatPaymentDetails;
 };
 
 export type MovementDestination = {
   destination: string;
   amount_sat: number;
+  paymentMethod?: string;
 };

--- a/client/tests/unit/transactionHistory.test.js
+++ b/client/tests/unit/transactionHistory.test.js
@@ -10,6 +10,14 @@ import {
   mergeBoardingWithOnchainTransactions,
   parseMovementMetadata,
 } from "../../src/lib/transactionHistory";
+import {
+  buildRepeatPaymentMetadataPatch,
+  canRepeatPayment,
+  findNewArkoorMovementId,
+  getRepeatPaymentPrefill,
+  resolveRepeatPaymentDetails,
+  shouldUseArkDirectLightningAddressRoute,
+} from "../../src/lib/repeatPayment";
 
 describe("boarding transaction metadata", () => {
   test("extracts the chain transaction and fees", () => {
@@ -52,6 +60,138 @@ describe("boarding transaction metadata", () => {
         received_on: [],
       }),
     ).toBe(50_000);
+  });
+});
+
+describe("repeat payment metadata", () => {
+  test("round trips a fiat lightning-address payment", () => {
+    const details = {
+      destination: "merchant@example.com",
+      comment: "Order 307",
+      amountMode: "FIAT",
+      amountInput: "12.50",
+      amountSat: 10_000,
+      fiatCurrency: "USD",
+    };
+
+    const metadata = parseMovementMetadata(buildRepeatPaymentMetadataPatch(details));
+
+    expect(metadata.repeatPayment).toEqual({
+      destination: "merchant@example.com",
+      comment: "Order 307",
+      amountMode: "FIAT",
+      amountInput: "12.50",
+      fiatCurrency: "USD",
+    });
+    expect(
+      resolveRepeatPaymentDetails({ metadata: metadata.repeatPayment, amountSat: 10_000 }),
+    ).toEqual(details);
+  });
+
+  test("derives a sats repeat action for legacy lightning-address history", () => {
+    expect(
+      resolveRepeatPaymentDetails({
+        destination: "LEGACY@EXAMPLE.COM",
+        paymentMethod: "lightning-address",
+        amountSat: 2_100,
+      }),
+    ).toEqual({
+      destination: "legacy@example.com",
+      comment: "",
+      amountMode: "SATS",
+      amountInput: "2100",
+      amountSat: 2_100,
+    });
+  });
+
+  test("derives a sats repeat action for an Ark payment", () => {
+    expect(
+      resolveRepeatPaymentDetails({
+        destination: "  tark1recipient  ",
+        paymentMethod: "ark",
+        amountSat: 5_000,
+      }),
+    ).toEqual({
+      destination: "tark1recipient",
+      comment: "",
+      amountMode: "SATS",
+      amountInput: "5000",
+      amountSat: 5_000,
+    });
+  });
+
+  test("only enables repeat for successful outgoing payments", () => {
+    const repeatPayment = {
+      destination: "merchant@example.com",
+      comment: "",
+      amountMode: "SATS",
+      amountInput: "2100",
+      amountSat: 2_100,
+    };
+
+    expect(
+      canRepeatPayment({ direction: "outgoing", movementStatus: "successful", repeatPayment }),
+    ).toBe(true);
+    expect(
+      canRepeatPayment({ direction: "incoming", movementStatus: "successful", repeatPayment }),
+    ).toBe(false);
+    expect(
+      canRepeatPayment({ direction: "outgoing", movementStatus: "failed", repeatPayment }),
+    ).toBe(false);
+  });
+
+  test("restores fiat only when the preferred currency still matches", () => {
+    const repeatPayment = {
+      destination: "merchant@example.com",
+      comment: "",
+      amountMode: "FIAT",
+      amountInput: "12.50",
+      amountSat: 10_000,
+      fiatCurrency: "USD",
+    };
+
+    expect(getRepeatPaymentPrefill(repeatPayment, "USD")).toEqual({
+      amountInput: "12.50",
+      amountMode: "FIAT",
+    });
+    expect(getRepeatPaymentPrefill(repeatPayment, "EUR")).toEqual({
+      amountInput: "10000",
+      amountMode: "SATS",
+    });
+  });
+
+  test("uses standard LNURL when a comment must be delivered", () => {
+    expect(shouldUseArkDirectLightningAddressRoute("ark", null)).toBe(true);
+    expect(shouldUseArkDirectLightningAddressRoute("ark", "Order 307")).toBe(false);
+    expect(shouldUseArkDirectLightningAddressRoute("lightning", null)).toBe(false);
+  });
+
+  test("finds the new matching Ark-routed movement", () => {
+    const movement = {
+      id: 9,
+      status: "successful",
+      subsystem: { name: "bark.arkoor", kind: "send" },
+      sent_to: [
+        { destination: "tark-destination", payment_method: "ark", amount_sat: 3_000 },
+      ],
+    };
+
+    expect(
+      findNewArkoorMovementId({
+        existingMovementIds: new Set([8]),
+        movements: [movement],
+        destination: "tark-destination",
+        amountSat: 3_000,
+      }),
+    ).toBe(9);
+    expect(
+      findNewArkoorMovementId({
+        existingMovementIds: new Set([9]),
+        movements: [movement],
+        destination: "tark-destination",
+        amountSat: 3_000,
+      }),
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- persist Lightning-address destination, message, and original fiat or sats amount mode in Ark movement metadata
- add Pay again actions for successful outgoing Lightning-address and Ark payments, prefilling Send for review
- preserve LNURL comments by using standard Lightning routing when an Ark-capable address has a message
- replace the raw movement dump with a receipt-style transaction detail view and a collapsible More details section
- label incoming receive endpoints accurately as Received on

## Testing

- bun --cwd client check
- verified Lightning-address and Ark prefills in the iOS regtest Simulator without submitting the repeated payment

Closes #307